### PR TITLE
Allow certain furniture to replace other furniture - ie. Doors into Walls

### DIFF
--- a/Assets/Scripts/Controllers/BuildModeController.cs
+++ b/Assets/Scripts/Controllers/BuildModeController.cs
@@ -80,6 +80,13 @@ public class BuildModeController : MonoBehaviour {
 				t.pendingFurnitureJob == null
 			) {
 				// This tile position is valid for this furniture
+
+				// Check if there is existing furniture in this tile. If so delete it.
+				// TODO Possibly return resources. Will the Deconstruct() method handle that? If so what will happen if resources drop ontop of new non-passable structure.
+				if (t.furniture != null) {
+					t.furniture.Deconstruct ();
+				}
+
 				// Create a job for it to be build
 
 				Job j;

--- a/Assets/Scripts/Controllers/MouseController.cs
+++ b/Assets/Scripts/Controllers/MouseController.cs
@@ -61,7 +61,7 @@ public class MouseController : MonoBehaviour {
 		currFramePosition = Camera.main.ScreenToWorldPoint( Input.mousePosition );
 		currFramePosition.z = 0;
 
-		if( Input.GetKeyUp(KeyCode.Escape) ) {
+		if( Input.GetKeyUp(KeyCode.Escape)  || Input.GetMouseButtonUp(1) ) {
 			if(currentMode == MouseMode.BUILD) {
 				currentMode = MouseMode.SELECT;
 			}

--- a/Assets/Scripts/Models/Furniture.cs
+++ b/Assets/Scripts/Models/Furniture.cs
@@ -35,6 +35,7 @@ public class Furniture : IXmlSerializable, ISelectableInterface {
 	//public Func<Furniture, ENTERABILITY> IsEnterable;
 	protected string isEnterableAction;
 
+	protected List<string> replaceableFurniture = new List<string>();
 
 	List<Job> jobs;
 
@@ -89,6 +90,12 @@ public class Furniture : IXmlSerializable, ISelectableInterface {
 		}
 		set {
 			_Name = value;
+		}
+	}
+
+	public List<string> ReplaceableFurniture {
+		get {
+			return replaceableFurniture;
 		}
 	}
 
@@ -265,13 +272,26 @@ public class Furniture : IXmlSerializable, ISelectableInterface {
 			for (int y_off = t.Y; y_off < (t.Y + Height); y_off++) {
 				Tile t2 = World.current.GetTileAt(x_off, y_off);
 
+
+				// Check to see if there is furniture which is replaceable
+				bool isReplaceable = false;
+
+				if (t2.furniture != null) {
+					for (int i = 0; i < ReplaceableFurniture.Count; i++) {
+						if(t2.furniture.Name == ReplaceableFurniture[i]) {
+							isReplaceable = true;
+						}
+
+					}
+				}
+
 				// Make sure tile is FLOOR
 				if( t2.Type != TileType.Floor ) {
 					return false;
 				}
 
 				// Make sure tile doesn't already have furniture
-				if( t2.furniture != null ) {
+				if( t2.furniture != null && isReplaceable == false) {
 					return false;
 				}
 
@@ -335,22 +355,27 @@ public class Furniture : IXmlSerializable, ISelectableInterface {
 					reader.Read();
 					roomEnclosure = reader.ReadContentAsBoolean();
 					break;
-				case "BuildingJob":
-					float jobTime = float.Parse( reader.GetAttribute("jobTime") );
+			case "CanReplaceFurniture":
+				replaceableFurniture.Add (reader.GetAttribute ("objectName").ToString ());
+				break;
+			case "BuildingJob":
+				float jobTime = float.Parse (reader.GetAttribute ("jobTime"));
+
+
 
 					List<Inventory> invs = new List<Inventory>();
 
 					XmlReader invs_reader = reader.ReadSubtree();
 
 					while(invs_reader.Read()) {
-						if(invs_reader.Name == "Inventory") {
+						if (invs_reader.Name == "Inventory") {
 							// Found an inventory requirement, so add it to the list!
-							invs.Add(new Inventory( 
-								invs_reader.GetAttribute("objectType"),
-								int.Parse( invs_reader.GetAttribute("amount") ),
+							invs.Add (new Inventory (
+								invs_reader.GetAttribute ("objectType"),
+								int.Parse (invs_reader.GetAttribute ("amount")),
 								0
 							));
-						}
+						} 
 					}
 
 					Job j = new Job( null, 

--- a/Assets/StreamingAssets/Data/Furniture.xml
+++ b/Assets/StreamingAssets/Data/Furniture.xml
@@ -27,6 +27,7 @@
         <Height>1</Height>
         <LinksToNeighbours>false</LinksToNeighbours>
         <EnclosesRooms>true</EnclosesRooms>
+        <CanReplaceFurniture objectName="Basic Wall" />
 
 
         <Params>

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ code or various creative assets, feel free to follow the standard Github workflo
 6. Make a "Pull Request" from your branch here on Github.
 
 For a video tutorial, please see:
+<https://www.youtube.com/watch?v=-N4Cghw0l2Q>
 
 
 ## Contact


### PR DESCRIPTION
I added the ability to inset furniture in place of other furniture. Details below for a `Door` into `Wall`example

For example, a `Door` needs to be able to replace a `Wall` so in the XML on the Door furniture, I'll add this line.

ie. `<CanReplaceFurniture objectName="Basic Wall" />`

Now validation will allow me to replace a wall block with a door.

**Note**: I apologise for all the unnecessary file changes. My MonoDevelop added auto-formatting to some of the methods.