### PR TITLE
Ensure that git sets text files to OS-native EOL

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# https://help.github.com/articles/dealing-with-line-endings/
+# Declare files that will always have LF line endings on checkout.
+*.cs text eol=lf
+*.xml text eol=lf
+*.lua text eol=lf


### PR DESCRIPTION
Without this everyone who contributed could push his own line-endings to repository leading to destroying of the universe... Or some annoying Unity warnings.