### PR TITLE
Update graphics on furniture deconstruction

### DIFF
--- a/Assets/Scripts/Models/Furniture.cs
+++ b/Assets/Scripts/Models/Furniture.cs
@@ -617,6 +617,32 @@ public class Furniture : IXmlSerializable, ISelectable
 
         World.current.InvalidateTileGraph();
 
+        if(linksToNeighbour == true) {
+            //Notify all neighbors that this furniture no longer exists so they can update correctly.
+            Tile t;
+            int x = tile.X;
+            int y = tile.Y;
+
+            t = World.current.GetTileAt(x, y + 1);
+            if (t != null && t.furniture != null && t.furniture.cbOnChanged != null && t.furniture.objectType == this.objectType) {
+                // We have a Northern Neighbour with the same object type as us, so
+                // tell it that it has changed by firing is callback.
+                t.furniture.cbOnChanged(t.furniture);
+            }
+            t = World.current.GetTileAt(x + 1, y);
+            if (t != null && t.furniture != null && t.furniture.cbOnChanged != null && t.furniture.objectType == this.objectType) {
+                t.furniture.cbOnChanged(t.furniture);
+            }
+            t = World.current.GetTileAt(x, y - 1);
+            if (t != null && t.furniture != null && t.furniture.cbOnChanged != null && t.furniture.objectType == this.objectType) {
+                t.furniture.cbOnChanged(t.furniture);
+            }
+            t = World.current.GetTileAt(x - 1, y);
+            if (t != null && t.furniture != null && t.furniture.cbOnChanged != null && t.furniture.objectType == this.objectType) {
+                t.furniture.cbOnChanged(t.furniture);
+            }
+        }
+
         // At this point, no DATA structures should be pointing to us, so we
         // should get garbage-collected.
 


### PR DESCRIPTION
Graphics haven't been being updated when furniture gets deconstructed. I've made it so when a piece of furniture gets deconstructed it looks it if links to neighbors and if so call the OnChangedCallback for all its neighbors.