### PR TITLE
BuildingJobs for every furniture.

### DIFF
--- a/Assets/StreamingAssets/Data/Furniture.xml
+++ b/Assets/StreamingAssets/Data/Furniture.xml
@@ -57,6 +57,9 @@
         <MovementCost>1</MovementCost>
         <LinksToNeighbours>true</LinksToNeighbours>
 
+        <BuildingJob jobTime="0">
+        </BuildingJob>
+
         <OnUpdate FunctionName="Stockpile_UpdateAction" />
 	</Furniture>
 
@@ -65,6 +68,9 @@
         <MovementCost>10</MovementCost>
         <Width>2</Width>
         <Height>2</Height>
+
+        <BuildingJob jobTime="0">
+        </BuildingJob>
 
         <OnUpdate FunctionName="OnUpdate_GasGenerator" />
 
@@ -82,6 +88,9 @@
         <MovementCost>1</MovementCost>
         <Width>3</Width>
         <Height>3</Height>
+
+        <BuildingJob jobTime="0">
+        </BuildingJob>
 
         <JobSpotOffset X="1" Y="0" />
         <JobSpawnSpotOffset X="0" Y="0" />


### PR DESCRIPTION
**BuildingJobs for every furniture so their furniture job prototypes get initialized.**

I noticed that every time I place any other furniture than Door or Wall I get an error like:
`There is no furniture job prototype for 'Mining Drone Station'.`

Reason for that was missing BuildingJob tags for other furniture.

So I added the BuildingJob tags with jobTime 0 in those furniture and now the error is gone.