### PR TITLE
Fixing doors part 1: Update surrounding furniture when create and removing furniture

### DIFF
--- a/Assets/Scripts/Controllers/FurnitureSpriteController.cs
+++ b/Assets/Scripts/Controllers/FurnitureSpriteController.cs
@@ -111,6 +111,23 @@ public class FurnitureSpriteController : MonoBehaviour
         //Debug.Log(furn_go);
         //Debug.Log(furn_go.GetComponent<SpriteRenderer>());
 
+        // FIXME: This hardcoding is not ideal!
+        if (furn.objectType == "Door")
+        {
+            // By default, the door graphic is meant for walls to the east & west
+            // Check to see if we actually have a wall north/south, and if so
+            // then rotate this GO by 90 degrees
+
+            Tile northTile = world.GetTileAt(furn.tile.X, furn.tile.Y + 1);
+            Tile southTile = world.GetTileAt(furn.tile.X, furn.tile.Y - 1);
+
+            if (northTile != null && southTile != null && northTile.furniture != null && southTile.furniture != null &&
+            northTile.furniture.objectType.Contains("Wall") && southTile.furniture.objectType.Contains("Wall"))
+            {
+                furn_go.transform.rotation = Quaternion.Euler(0, 0, 90);
+            }
+        }
+
         furn_go.GetComponent<SpriteRenderer>().sprite = GetSpriteForFurniture(furn);
         furn_go.GetComponent<SpriteRenderer>().color = furn.tint;
 

--- a/Assets/Scripts/Models/Furniture.cs
+++ b/Assets/Scripts/Models/Furniture.cs
@@ -244,7 +244,7 @@ public class Furniture : IXmlSerializable, ISelectable
         {
             for (int ypos = y - 1; ypos < (y + proto.Height + 1); ypos++)
             {
-                t = World.current.GetTileAt(xpos, ypos + 1);
+                t = World.current.GetTileAt(xpos, ypos);
                 if (t != null && t.furniture != null && t.furniture.cbOnChanged != null)
                 {
                     t.furniture.cbOnChanged(t.furniture);
@@ -612,7 +612,7 @@ public class Furniture : IXmlSerializable, ISelectable
         {
             for (int ypos = y - 1; ypos < (y + fheight + 1); ypos++)
             {
-                Tile t = World.current.GetTileAt(xpos, ypos + 1);
+                Tile t = World.current.GetTileAt(xpos, ypos);
                 if (t != null && t.furniture != null && t.furniture.cbOnChanged != null)
                 {
                     t.furniture.cbOnChanged(t.furniture);

--- a/Assets/Scripts/Models/Furniture.cs
+++ b/Assets/Scripts/Models/Furniture.cs
@@ -233,40 +233,26 @@ public class Furniture : IXmlSerializable, ISelectable
             return null;
         }
 
-        if (obj.linksToNeighbour)
+        // We should inform our neighbours that they have a new
+        // neighbour regardless of LinksToNeighbours and objectType.  
+        // Just trigger their OnChangedCallback.        
+        Tile t;
+        int x = tile.X;
+        int y = tile.Y;
+
+        for (int xpos = x - 1; xpos < (x + proto.Width + 1); xpos++)
         {
-            // This type of furniture links itself to its neighbours,
-            // so we should inform our neighbours that they have a new
-            // buddy.  Just trigger their OnChangedCallback.
-
-            Tile t;
-            int x = tile.X;
-            int y = tile.Y;
-
-            t = World.current.GetTileAt(x, y + 1);
-            if (t != null && t.furniture != null && t.furniture.cbOnChanged != null && t.furniture.objectType == obj.objectType)
+            for (int ypos = y - 1; ypos < (y + proto.Height + 1); ypos++)
             {
-                // We have a Northern Neighbour with the same object type as us, so
-                // tell it that it has changed by firing is callback.
-                t.furniture.cbOnChanged(t.furniture);
+                t = World.current.GetTileAt(xpos, ypos + 1);
+                if (t != null && t.furniture != null && t.furniture.cbOnChanged != null)
+                {
+                    t.furniture.cbOnChanged(t.furniture);
+                }
             }
-            t = World.current.GetTileAt(x + 1, y);
-            if (t != null && t.furniture != null && t.furniture.cbOnChanged != null && t.furniture.objectType == obj.objectType)
-            {
-                t.furniture.cbOnChanged(t.furniture);
-            }
-            t = World.current.GetTileAt(x, y - 1);
-            if (t != null && t.furniture != null && t.furniture.cbOnChanged != null && t.furniture.objectType == obj.objectType)
-            {
-                t.furniture.cbOnChanged(t.furniture);
-            }
-            t = World.current.GetTileAt(x - 1, y);
-            if (t != null && t.furniture != null && t.furniture.cbOnChanged != null && t.furniture.objectType == obj.objectType)
-            {
-                t.furniture.cbOnChanged(t.furniture);
-            }
-
         }
+
+
 
         return obj;
     }
@@ -426,12 +412,12 @@ public class Furniture : IXmlSerializable, ISelectable
                                     int.Parse(invs_reader.GetAttribute("amount")),
                                     0
                                 ));
-                        } 
+                        }
                     }
 
-                    Job j = new Job(null, 
-                        objectType, 
-                        FurnitureActions.JobComplete_FurnitureBuilding, jobTime, 
+                    Job j = new Job(null,
+                        objectType,
+                        FurnitureActions.JobComplete_FurnitureBuilding, jobTime,
                         invs.ToArray()
                     );
 
@@ -603,6 +589,10 @@ public class Furniture : IXmlSerializable, ISelectable
     public void Deconstruct()
     {
         Debug.Log("Deconstruct");
+        int x = tile.X;
+        int y = tile.Y;
+        int fwidth = tile.furniture.Width;
+        int fheight = tile.furniture.Height;
 
         tile.UnplaceFurniture();
 
@@ -613,6 +603,21 @@ public class Furniture : IXmlSerializable, ISelectable
         if (roomEnclosure)
         {
             Room.DoRoomFloodFill(this.tile);
+        }
+
+        // We should inform our neighbours that they have just lost a
+        // neighbour regardless of LinksToNeighbours and objectType.  
+        // Just trigger their OnChangedCallback.        
+        for (int xpos = x - 1; xpos < (x + fwidth + 1); xpos++)
+        {
+            for (int ypos = y - 1; ypos < (y + fheight + 1); ypos++)
+            {
+                Tile t = World.current.GetTileAt(xpos, ypos + 1);
+                if (t != null && t.furniture != null && t.furniture.cbOnChanged != null)
+                {
+                    t.furniture.cbOnChanged(t.furniture);
+                }
+            }
         }
 
         World.current.InvalidateTileGraph();


### PR DESCRIPTION
When placing or removing furniture, all surrounding furniture gets
updated. Regardless if they are same type or connects to neighbours.
This is first step in fixing doors not connecting correctly to walls if door is placed before walls.