### PR TITLE
Fixing doors: Update surrounding furniture when create and removing furniture

### DIFF
--- a/Assets/Scripts/Controllers/FurnitureSpriteController.cs
+++ b/Assets/Scripts/Controllers/FurnitureSpriteController.cs
@@ -120,11 +120,18 @@ public class FurnitureSpriteController : MonoBehaviour
 
             Tile northTile = world.GetTileAt(furn.tile.X, furn.tile.Y + 1);
             Tile southTile = world.GetTileAt(furn.tile.X, furn.tile.Y - 1);
+            Tile eastTile = world.GetTileAt(furn.tile.X+1, furn.tile.Y);
+            Tile westTile = world.GetTileAt(furn.tile.X-1, furn.tile.Y);
 
             if (northTile != null && southTile != null && northTile.furniture != null && southTile.furniture != null &&
             northTile.furniture.objectType.Contains("Wall") && southTile.furniture.objectType.Contains("Wall"))
             {
                 furn_go.transform.rotation = Quaternion.Euler(0, 0, 90);
+            }
+            else if (eastTile != null && westTile != null && eastTile.furniture != null && westTile.furniture != null &&
+            eastTile.furniture.objectType.Contains("Wall") && westTile.furniture.objectType.Contains("Wall"))
+            {
+                furn_go.transform.rotation = Quaternion.Euler(0, 0, 0);
             }
         }
 

--- a/Assets/Scripts/Controllers/FurnitureSpriteController.cs
+++ b/Assets/Scripts/Controllers/FurnitureSpriteController.cs
@@ -111,6 +111,23 @@ public class FurnitureSpriteController : MonoBehaviour
         //Debug.Log(furn_go);
         //Debug.Log(furn_go.GetComponent<SpriteRenderer>());
 
+        // FIXME: This hardcoding is not ideal!
+        if (furn.objectType == "Door")
+        {
+            // By default, the door graphic is meant for walls to the east & west
+            // Check to see if we actually have a wall north/south, and if so
+            // then rotate this GO by 90 degrees
+
+            Tile northTile = world.GetTileAt(furn.tile.X, furn.tile.Y + 1);
+            Tile southTile = world.GetTileAt(furn.tile.X, furn.tile.Y - 1);
+
+            if (northTile != null && southTile != null && northTile.furniture != null && southTile.furniture != null &&
+            northTile.furniture.objectType.Contains("Wall") && southTile.furniture.objectType.Contains("Wall"))
+            {
+                furn_go.transform.rotation = Quaternion.Euler(0, 0, 90);
+            }
+        }
+
         furn_go.GetComponent<SpriteRenderer>().sprite = GetSpriteForFurniture(furn);
         furn_go.GetComponent<SpriteRenderer>().color = furn.tint;
 

--- a/Assets/Scripts/Models/Furniture.cs
+++ b/Assets/Scripts/Models/Furniture.cs
@@ -234,24 +234,26 @@ public class Furniture : IXmlSerializable, ISelectable
         }
 
         // We should inform our neighbours that they have a new
-        // neighbour regardless of LinksToNeighbours and objectType.  
-        // Just trigger their OnChangedCallback.        
-        Tile t;
-        int x = tile.X;
-        int y = tile.Y;
-
-        for (int xpos = x - 1; xpos < (x + proto.Width + 1); xpos++)
+        // neighbour regardless of objectType.  
+        // Just trigger their OnChangedCallback. 
+        if (obj.linksToNeighbour == true)
         {
-            for (int ypos = y - 1; ypos < (y + proto.Height + 1); ypos++)
+            Tile t;
+            int x = tile.X;
+            int y = tile.Y;
+
+            for (int xpos = x - 1; xpos < (x + proto.Width + 1); xpos++)
             {
-                t = World.current.GetTileAt(xpos, ypos);
-                if (t != null && t.furniture != null && t.furniture.cbOnChanged != null)
+                for (int ypos = y - 1; ypos < (y + proto.Height + 1); ypos++)
                 {
-                    t.furniture.cbOnChanged(t.furniture);
+                    t = World.current.GetTileAt(xpos, ypos);
+                    if (t != null && t.furniture != null && t.furniture.cbOnChanged != null)
+                    {
+                        t.furniture.cbOnChanged(t.furniture);
+                    }
                 }
             }
         }
-
 
 
         return obj;
@@ -451,7 +453,7 @@ public class Furniture : IXmlSerializable, ISelectable
 
                     break;
                 case "Params":
-                    ReadXmlParams(reader);	// Read in the Param tag
+                    ReadXmlParams(reader);  // Read in the Param tag
                     break;
             }
         }
@@ -591,13 +593,16 @@ public class Furniture : IXmlSerializable, ISelectable
         Debug.Log("Deconstruct");
         int x = tile.X;
         int y = tile.Y;
-        int fwidth = 1; 
-        int fheight = 1; 
+        int fwidth = 1;
+        int fheight = 1;
+        bool linksToNeighbour = false;
         if (tile.furniture != null)
         {
-            fwidth = tile.furniture.Width;
-            fheight = tile.furniture.Height;
-            tile.furniture.CancelJobs();
+            Furniture f = tile.furniture;
+            fwidth = f.Width;
+            fheight = f.Height;
+            linksToNeighbour = f.linksToNeighbour;
+            f.CancelJobs();
         }
         tile.UnplaceFurniture();
 
@@ -611,16 +616,19 @@ public class Furniture : IXmlSerializable, ISelectable
         }
 
         // We should inform our neighbours that they have just lost a
-        // neighbour regardless of LinksToNeighbours and objectType.  
-        // Just trigger their OnChangedCallback.        
-        for (int xpos = x - 1; xpos < (x + fwidth + 1); xpos++)
+        // neighbour regardless of objectType.  
+        // Just trigger their OnChangedCallback. 
+        if (linksToNeighbour == true)
         {
-            for (int ypos = y - 1; ypos < (y + fheight + 1); ypos++)
+            for (int xpos = x - 1; xpos < (x + fwidth + 1); xpos++)
             {
-                Tile t = World.current.GetTileAt(xpos, ypos);
-                if (t != null && t.furniture != null && t.furniture.cbOnChanged != null)
+                for (int ypos = y - 1; ypos < (y + fheight + 1); ypos++)
                 {
-                    t.furniture.cbOnChanged(t.furniture);
+                    Tile t = World.current.GetTileAt(xpos, ypos);
+                    if (t != null && t.furniture != null && t.furniture.cbOnChanged != null)
+                    {
+                        t.furniture.cbOnChanged(t.furniture);
+                    }
                 }
             }
         }
@@ -656,7 +664,7 @@ public class Furniture : IXmlSerializable, ISelectable
 
     public string GetHitPointString()
     {
-        return "18/18";	// TODO: Add a hitpoint system to...well...everything
+        return "18/18"; // TODO: Add a hitpoint system to...well...everything
     }
 
     #endregion

--- a/Assets/Scripts/Models/Furniture.cs
+++ b/Assets/Scripts/Models/Furniture.cs
@@ -244,7 +244,7 @@ public class Furniture : IXmlSerializable, ISelectable
         {
             for (int ypos = y - 1; ypos < (y + proto.Height + 1); ypos++)
             {
-                t = World.current.GetTileAt(xpos, ypos + 1);
+                t = World.current.GetTileAt(xpos, ypos);
                 if (t != null && t.furniture != null && t.furniture.cbOnChanged != null)
                 {
                     t.furniture.cbOnChanged(t.furniture);
@@ -612,7 +612,7 @@ public class Furniture : IXmlSerializable, ISelectable
         {
             for (int ypos = y - 1; ypos < (y + fheight + 1); ypos++)
             {
-                Tile t = World.current.GetTileAt(xpos, ypos + 1);
+                Tile t = World.current.GetTileAt(xpos, ypos);
                 if (t != null && t.furniture != null && t.furniture.cbOnChanged != null)
                 {
                     t.furniture.cbOnChanged(t.furniture);

--- a/Assets/Scripts/Models/Furniture.cs
+++ b/Assets/Scripts/Models/Furniture.cs
@@ -591,9 +591,14 @@ public class Furniture : IXmlSerializable, ISelectable
         Debug.Log("Deconstruct");
         int x = tile.X;
         int y = tile.Y;
-        int fwidth = tile.furniture.Width;
-        int fheight = tile.furniture.Height;
-
+        int fwidth = 1; 
+        int fheight = 1; 
+        if (tile.furniture != null)
+        {
+            fwidth = tile.furniture.Width;
+            fheight = tile.furniture.Height;
+            tile.furniture.CancelJobs();
+        }
         tile.UnplaceFurniture();
 
         if (cbOnRemoved != null)

--- a/Assets/Scripts/Models/Furniture.cs
+++ b/Assets/Scripts/Models/Furniture.cs
@@ -233,40 +233,26 @@ public class Furniture : IXmlSerializable, ISelectable
             return null;
         }
 
-        if (obj.linksToNeighbour)
+        // We should inform our neighbours that they have a new
+        // neighbour regardless of LinksToNeighbours and objectType.  
+        // Just trigger their OnChangedCallback.        
+        Tile t;
+        int x = tile.X;
+        int y = tile.Y;
+
+        for (int xpos = x - 1; xpos < (x + proto.Width + 1); xpos++)
         {
-            // This type of furniture links itself to its neighbours,
-            // so we should inform our neighbours that they have a new
-            // buddy.  Just trigger their OnChangedCallback.
-
-            Tile t;
-            int x = tile.X;
-            int y = tile.Y;
-
-            t = World.current.GetTileAt(x, y + 1);
-            if (t != null && t.furniture != null && t.furniture.cbOnChanged != null && t.furniture.objectType == obj.objectType)
+            for (int ypos = y - 1; ypos < (y + proto.Height + 1); ypos++)
             {
-                // We have a Northern Neighbour with the same object type as us, so
-                // tell it that it has changed by firing is callback.
-                t.furniture.cbOnChanged(t.furniture);
+                t = World.current.GetTileAt(xpos, ypos + 1);
+                if (t != null && t.furniture != null && t.furniture.cbOnChanged != null)
+                {
+                    t.furniture.cbOnChanged(t.furniture);
+                }
             }
-            t = World.current.GetTileAt(x + 1, y);
-            if (t != null && t.furniture != null && t.furniture.cbOnChanged != null && t.furniture.objectType == obj.objectType)
-            {
-                t.furniture.cbOnChanged(t.furniture);
-            }
-            t = World.current.GetTileAt(x, y - 1);
-            if (t != null && t.furniture != null && t.furniture.cbOnChanged != null && t.furniture.objectType == obj.objectType)
-            {
-                t.furniture.cbOnChanged(t.furniture);
-            }
-            t = World.current.GetTileAt(x - 1, y);
-            if (t != null && t.furniture != null && t.furniture.cbOnChanged != null && t.furniture.objectType == obj.objectType)
-            {
-                t.furniture.cbOnChanged(t.furniture);
-            }
-
         }
+
+
 
         return obj;
     }
@@ -426,12 +412,12 @@ public class Furniture : IXmlSerializable, ISelectable
                                     int.Parse(invs_reader.GetAttribute("amount")),
                                     0
                                 ));
-                        } 
+                        }
                     }
 
-                    Job j = new Job(null, 
-                        objectType, 
-                        FurnitureActions.JobComplete_FurnitureBuilding, jobTime, 
+                    Job j = new Job(null,
+                        objectType,
+                        FurnitureActions.JobComplete_FurnitureBuilding, jobTime,
                         invs.ToArray()
                     );
 
@@ -603,6 +589,10 @@ public class Furniture : IXmlSerializable, ISelectable
     public void Deconstruct()
     {
         Debug.Log("Deconstruct");
+        int x = tile.X;
+        int y = tile.Y;
+        int fwidth = tile.furniture.Width;
+        int fheight = tile.furniture.Height;
 
         tile.UnplaceFurniture();
 
@@ -613,6 +603,21 @@ public class Furniture : IXmlSerializable, ISelectable
         if (roomEnclosure)
         {
             Room.DoRoomFloodFill(this.tile);
+        }
+
+        // We should inform our neighbours that they have just lost a
+        // neighbour regardless of LinksToNeighbours and objectType.  
+        // Just trigger their OnChangedCallback.        
+        for (int xpos = x - 1; xpos < (x + fwidth + 1); xpos++)
+        {
+            for (int ypos = y - 1; ypos < (y + fheight + 1); ypos++)
+            {
+                Tile t = World.current.GetTileAt(xpos, ypos + 1);
+                if (t != null && t.furniture != null && t.furniture.cbOnChanged != null)
+                {
+                    t.furniture.cbOnChanged(t.furniture);
+                }
+            }
         }
 
         World.current.InvalidateTileGraph();


### PR DESCRIPTION
When placing or removing furniture, all surrounding furniture gets
updated. Regardless if they are same type or connects to neighbours.
This also works for furniture larger than 1x1.

So when placing a wall north/south of a door, will now make the door rotate correctly.
Still not a perfect solution for rotating furniture like this.