### PR TITLE
Remove log spam

### DIFF
--- a/Assets/Scripts/Controllers/MouseController.cs
+++ b/Assets/Scripts/Controllers/MouseController.cs
@@ -165,7 +165,6 @@ public class MouseController : MonoBehaviour
                     mySelection.subSelection = (mySelection.subSelection + 1) % mySelection.stuffInTile.Length;
                 } while(mySelection.stuffInTile[mySelection.subSelection] == null);
             }
-            Debug.Log(mySelection.subSelection);
         }
     }
 

--- a/Assets/Scripts/Models/Character.cs
+++ b/Assets/Scripts/Models/Character.cs
@@ -133,7 +133,7 @@ public class Character : IXmlSerializable, ISelectable
         {
             myJob = new Job(CurrTile,
                 "Waiting",
-                (j) => Debug.Log("Finished waiting for available Jobs"),
+                null,
                 UnityEngine.Random.Range(0.1f, 0.5f),
                 null,
                 false);


### PR DESCRIPTION
Some leftover debug code from testing features is filling the debug log with hundreds of messages. This addresses #94 