### PR TITLE
Add preview for building floors

### DIFF
--- a/Assets/Scripts/Controllers/JobSpriteController.cs
+++ b/Assets/Scripts/Controllers/JobSpriteController.cs
@@ -24,7 +24,7 @@ public class JobSpriteController : MonoBehaviour
     void OnJobCreated(Job job)
     {
 
-        if (job.jobObjectType == null)
+        if (job.jobObjectType == null && job.jobTileType == TileType.Empty)
         {
             // This job doesn't really have an associated sprite with it, so no need to render.
             return;
@@ -47,11 +47,24 @@ public class JobSpriteController : MonoBehaviour
         jobGameObjectMap.Add(job, job_go);
 
         job_go.name = "JOB_" + job.jobObjectType + "_" + job.tile.X + "_" + job.tile.Y;
-        job_go.transform.position = new Vector3(job.tile.X + ((job.furniturePrototype.Width - 1) / 2f), job.tile.Y + ((job.furniturePrototype.Height - 1) / 2f), 0);
         job_go.transform.SetParent(this.transform, true);
 
         SpriteRenderer sr = job_go.AddComponent<SpriteRenderer>();
-        sr.sprite = fsc.GetSpriteForFurniture(job.jobObjectType);
+        if (job.jobTileType != TileType.Empty)
+        {
+            //This job is for building a tile
+            //For now, the only tile that could be is the floor, so just show a floor sprite
+            //until the graphics system for tiles is fleshed out further
+
+            job_go.transform.position = new Vector3(job.tile.X, job.tile.Y, 0);
+            sr.sprite = SpriteManager.current.GetSprite("Tile", "Empty");
+        }
+        else
+        {
+            //This is a normal furniture job.
+            job_go.transform.position = new Vector3(job.tile.X + ((job.furniturePrototype.Width - 1) / 2f), job.tile.Y + ((job.furniturePrototype.Height - 1) / 2f), 0);
+            sr.sprite = fsc.GetSpriteForFurniture (job.jobObjectType);
+        }
         sr.color = new Color(0.5f, 1f, 0.5f, 0.25f);
         sr.sortingLayerName = "Jobs";
 


### PR DESCRIPTION
Since floors require the player to build them I decided to add in the preview sprite. Unfortunately since the job system isn't fleshed out yet, the approach is a bit hackish. However, it works perfectly fine and can easily be updated once the job system is redone (specifically the job sprite system)