### PR TITLE
Add jobTileType to job copy constructor

### DIFF
--- a/Assets/Scripts/Models/Job.cs
+++ b/Assets/Scripts/Models/Job.cs
@@ -107,6 +107,7 @@ public class Job
     {
         this.tile = other.tile;
         this.jobObjectType = other.jobObjectType;
+        this.jobTileType = other.jobTileType;
         this.cbJobCompleted = other.cbJobCompleted;
         this.jobTime = other.jobTime;
 


### PR DESCRIPTION
Whenever the jobTileType variable was added to the Job class for tile construction jobs, the copy constructor wasn't updated.