### PR TITLE
Ignoring .db files

### DIFF
--- a/Assets/Scripts/Controllers/SpriteManager.cs
+++ b/Assets/Scripts/Controllers/SpriteManager.cs
@@ -66,7 +66,7 @@ public class SpriteManager : MonoBehaviour {
 		// TODO:  LoadImage is returning TRUE for things like .meta and .xml files.  What??!
 		//		So as a temporary fix, let's just bail if we have something we KNOW should not
 		//  	be an image.
-		if(filePath.Contains(".xml") || filePath.Contains(".meta")) {
+        if(filePath.Contains(".xml") || filePath.Contains(".meta") || filePath.Contains(".db")) {
 			return;
 		}
 


### PR DESCRIPTION
For some bizarre reason, Unity was trying to load "thumbs.db" file like
it was an image... added this bit to just ignore .db files (guess we
won't use them anyway)