### PR TITLE
Fix off by one error with time scale

### DIFF
--- a/Assets/Scripts/Controllers/WorldController.cs
+++ b/Assets/Scripts/Controllers/WorldController.cs
@@ -89,7 +89,7 @@ public class WorldController : MonoBehaviour
 
         if (Input.GetKeyDown(KeyCode.Plus) || Input.GetKeyDown(KeyCode.KeypadPlus))
         {
-            if (currentTimeScalePosition == possibleTimeScales.Length)
+            if (currentTimeScalePosition == possibleTimeScales.Length - 1)
             {
                 // We are on the top of possibleTimeScales so just bail out.
                 return;


### PR DESCRIPTION
An out of bounds error would be thrown when attempting to increase the time scale beond the maximum allowed amount, due to an off-by-one error.