### PR TITLE
Avoid full map search for items that doesn't exist

### DIFF
--- a/Assets/Scripts/Models/Character.cs
+++ b/Assets/Scripts/Models/Character.cs
@@ -334,6 +334,7 @@ public class Character : IXmlSerializable, ISelectable
     {
         NextTile = DestTile = CurrTile;
         World.current.jobQueue.Enqueue(myJob);
+        myJob.cbJobStopped -= OnJobStopped;
         myJob = null;
     }
 

--- a/Assets/Scripts/Models/InventoryManager.cs
+++ b/Assets/Scripts/Models/InventoryManager.cs
@@ -145,23 +145,44 @@ public class InventoryManager
     /// <param name="t">T.</param>
     /// <param name="desiredAmount">Desired amount. If no stack has enough, it instead returns the largest</param>
     public Inventory GetClosestInventoryOfType(string objectType, Tile t, int desiredAmount, bool canTakeFromStockpile)
-    { 
+    {
         Path_AStar path = GetPathToClosestInventoryOfType(objectType, t, desiredAmount, canTakeFromStockpile);
         return path.EndTile().inventory;
     }
 
     public Path_AStar GetPathToClosestInventoryOfType(string objectType, Tile t, int desiredAmount, bool canTakeFromStockpile)
-    { 
-        if (inventories.ContainsKey(objectType) == false 
-            || (!canTakeFromStockpile && inventories[objectType].TrueForAll ( i => i.tile != null && i.tile.furniture != null && i.tile.furniture.IsStockpile()))) //we can also avoid going through the Astar construction if we know that all available inventories are stockpiles and we are not allowed to touch those
+    {
+        // If the inventories doesn't contain the objectType, we know that no
+        // stacks of this type exists and can return.
+        if (inventories.ContainsKey(objectType) == false)
         {
-            //Debug.LogError("GetClosestInventoryOfType -- no items of desired type.");
             return null;
         }
 
+        // We know that there is a list for objectType, we still need to test if
+        // the list contains anything
+        if (inventories[objectType].Count == 0)
+        {
+            return null;
+        }
+
+        // We can also avoid going through the Astar construction if we know
+        // that all available inventories are stockpiles and we are not allowed
+        // to touch those
+        if (!canTakeFromStockpile && inventories[objectType].TrueForAll(i => i.tile != null && i.tile.furniture != null && i.tile.furniture.IsStockpile()))
+        {
+            return null;
+        }
+
+        // Test that there is at least one stack on the floor, otherwise the
+        // search below might cause a full map search for nothing.
+        if (inventories[objectType].Find(i => i.tile != null) == null)
+        {
+            return null;
+        }
+
+        // We know the objects are out there, now find the closest.
         Path_AStar path = new Path_AStar(World.current, t, null, objectType, desiredAmount, canTakeFromStockpile);
-
         return path;
-
     }
 }

--- a/Assets/Scripts/UI/MouseOverFurnitureTypeText.cs
+++ b/Assets/Scripts/UI/MouseOverFurnitureTypeText.cs
@@ -39,7 +39,7 @@ public class MouseOverFurnitureTypeText : MonoBehaviour
 
         string s = "NULL";
 
-        if (t.furniture != null)
+        if (t != null && t.furniture != null)
         {
             s = t.furniture.Name;
         }

--- a/Assets/Scripts/UI/MouseOverRoomIndexText.cs
+++ b/Assets/Scripts/UI/MouseOverRoomIndexText.cs
@@ -39,7 +39,7 @@ public class MouseOverRoomIndexText : MonoBehaviour
 
         string roomID = "N/A";
 
-        if (t.room != null)
+        if (t != null && t.room != null)
         {
             roomID = t.room.ID.ToString();
         }

--- a/Assets/Scripts/UI/MouseOverTileTypeText.cs
+++ b/Assets/Scripts/UI/MouseOverTileTypeText.cs
@@ -36,6 +36,13 @@ public class MouseOverTileTypeText : MonoBehaviour
     void Update()
     {
         Tile t = mouseController.GetMouseOverTile();
-        myText.text = "Tile Type: " + t.Type.ToString();
+        string tileType = "Unknown";
+
+        if (t != null)
+        {
+            tileType = t.Type.ToString();
+        }
+
+        myText.text = "Tile Type: " + tileType;
     }
 }


### PR DESCRIPTION
This bug is triggered if you try to build a base in a new game. The conditions are:
- Building in open space
- There is no stacks of steel on the ground (I have a mining droid, but it doesn't change anything)
- The character tries to build a wall

`GetPathToClosestInventoryOfType` will trigger a search that can't find anything and do so on the entire map. It is very, very slow to search all 10k tiles.

The fix assumes that `InventoryManager` knows about all stacks on the floor, which is true according to my testing. It now verifies that there is a stack to find before starting the search. To help make it a little easier to follow, it's also broken into several checks with individual comments.

I also included two misc bug fixes that I got errors for while trying to figure out why my game pauses occasionally.