### PR TITLE
Added custom logging class wrapping unity logger.

### DIFF
--- a/Assets/Scripts/Utilities/Logger.cs
+++ b/Assets/Scripts/Utilities/Logger.cs
@@ -1,0 +1,134 @@
+﻿using System;
+using UnityEngine;
+
+public static class Logger
+{
+    public enum Level
+    {
+        Exception,
+        Assertion,
+        Error,
+        Warning,
+        Info,
+        Verbose
+    }
+
+    // TODO: Not used yet but it's the logical next step.
+    public enum Channel
+    {
+        Default
+    }
+
+    static Level minimumLevel = Level.Info;
+
+    public static void LogException(Exception exception)
+    {
+        // Exceptions are special as they support neither formatting nor message
+        if (minimumLevel <= Level.Exception)
+        {
+            Debug.LogException(exception);
+        }
+    }
+
+    public static void LogAssertion(string message)
+    {
+        Log(Level.Assertion, message);
+    }
+
+    public static void LogAssertionFormat(string format, params object[] args)
+    {
+        Log(Level.Assertion, format, args);
+    }
+
+    public static void LogError(string message)
+    {
+        Log(Level.Error, message);
+    }
+
+    public static void LogErrorFormat(string format, params object[] args)
+    {
+        Log(Level.Error, format, args);
+    }
+
+    public static void LogWarning(string message)
+    {
+        Log(Level.Warning, message);
+    }
+
+    public static void LogWarningFormat(string format, params object[] args)
+    {
+        Log(Level.Warning, format, args);
+    }
+
+    public static void LogInfo(string message)
+    {
+        Log(Level.Info, message);
+    }
+
+    public static void LogInfoFormat(string format, params object[] args)
+    {
+        Log(Level.Info, format, args);
+    }
+
+    public static void LogVerbose(string message)
+    {
+        Log(Level.Verbose, message);
+    }
+
+    public static void LogVerboseFormat(string format, params object[] args)
+    {
+        Log(Level.Verbose, format, args);
+    }
+
+    /// <summary>
+    /// Alias for info.
+    /// </summary>
+    public static void Log(string message)
+    {
+        Log(Level.Info, message);
+    }
+
+    /// <summary>
+    /// Alias for info.
+    /// </summary>
+    public static void LogFormat(string message, params object[] args)
+    {
+        Log(Level.Info, message, args);
+    }
+
+    public static void Log(Level level, string message, params object[] formatArgs)
+    {
+        if (level > minimumLevel)
+        {
+            return;
+        }
+
+        if (formatArgs.Length > 0)
+        {
+            message = string.Format(message, formatArgs);
+        }
+
+        switch (level)
+        {
+            case Level.Exception:
+                throw new InvalidOperationException("Exceptions are logged in a special way. You shouldnt see this message");
+            case Level.Assertion:
+                Debug.LogAssertion(message);
+                break;
+            case Level.Error:
+                Debug.LogError(message);
+                break;
+            case Level.Warning:
+                Debug.LogWarning(message);
+                break;
+            case Level.Info:
+                Debug.Log(message);
+                break;
+            case Level.Verbose:
+                Debug.Log(message);
+                break;
+            default:
+                throw new ArgumentException("Unhandled level: " + level, "level");    
+        }
+    }
+}

--- a/Assets/Scripts/Utilities/Logger.cs
+++ b/Assets/Scripts/Utilities/Logger.cs
@@ -96,7 +96,7 @@ public static class Logger
         Log(Level.Info, message, args);
     }
 
-    public static void Log(Level level, string message, params object[] formatArgs)
+    private static void Log(Level level, string message, params object[] formatArgs)
     {
         if (level > minimumLevel)
         {

--- a/Assets/Scripts/Utilities/Logger.cs.meta
+++ b/Assets/Scripts/Utilities/Logger.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 2b408738830d1804d9108edfaa90eab9
+timeCreated: 1471541137
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This was discussed in #94.

I've made the methods look like the ones already in Unity so that you can simply swap anywhere it says `Debug.LogError()` to say `Logger.LogError()` and all its variants. 

It has a minimum level that defaults to `Info`, only that level and more severe levels are logged. This means by default the level `Verbose` is hidden.

Verbose is the only new "level" compared to what Unity has. It's intended for everyone to go completely nuts with logging here. Since its hidden by default it wont affect anyone and should only be enabled when developing or debugging. This addresses the concerns with how much you are allowed to log, and how much of your debugging logging you should strip out when you make a pull request.

There is a neat trick to using this that might not be immediately obvious. What you do is set the `minimumLevel` to `Exception`, essentially hiding _all_ logging. Then you **don't** use the logging class but instead use the regular Unity `Debug.Log` thereby bypassing the filter. When you are done, you change all your logging lines to use `Logger`.