### PR TITLE
Added localization support for tiles

### DIFF
--- a/Assets/Scripts/Models/Tile.cs
+++ b/Assets/Scripts/Models/Tile.cs
@@ -339,12 +339,12 @@ public class Tile :IXmlSerializable, ISelectable
 
     public string GetName()
     {
-        return this._type.ToString();
+        return "tile_"+this._type.ToString();
     }
 
     public string GetDescription()
     {
-        return "The tile.";
+        return "tile_"+this._type.ToString()+"_desc";
     }
 
     public string GetHitPointString()

--- a/Assets/StreamingAssets/Localization/en_US.lang
+++ b/Assets/StreamingAssets/Localization/en_US.lang
@@ -25,3 +25,7 @@ furn_mining_drone_station=Mining Drone
 furn_mining_drone_station_desc=Mining materials out of nothing.
 furn_airlock=Airlock
 furn_airlock_desc=An Airlock prevents air from leaving the base
+tile_Empty=Empty
+tile_Empty_desc=An empty tile.
+tile_Floor=Floor
+tile_Floor_desc=Meets the highest non-skid standards.


### PR DESCRIPTION
When selecting a tile (empty or floor), no localization support was present for the selection dialog.