### PR TITLE
Quieter logging for less log spam

### DIFF
--- a/Assets/Scripts/Localization/LocalizationTable.cs
+++ b/Assets/Scripts/Localization/LocalizationTable.cs
@@ -149,7 +149,7 @@ namespace ProjectPorcupine.Localization
             {
 #if UNITY_EDITOR //TODO: Think if #if is a good idea or not.
                 //Log a warning into the console if this operation fails.
-                Debug.LogWarning("Translation for " + key + " failed: Key not in dictionary.");
+                Logger.LogVerbose("Translation for " + key + " failed: Key not in dictionary.");
 #endif
 
                 //Switch the fallback mode.

--- a/Assets/Scripts/Models/Character.cs
+++ b/Assets/Scripts/Models/Character.cs
@@ -234,13 +234,13 @@ public class Character : IXmlSerializable, ISelectable
             // At this point, the job still requires inventory, but we aren't carrying it!
 
             // Are we standing on a tile with goods that are desired by the job?
-            Debug.Log("Standing on Tile check");
+            Logger.LogVerbose("Standing on Tile check");
             if (CurrTile.inventory != null &&
                 myJob.DesiresInventoryType(CurrTile.inventory) > 0 &&
                 (myJob.canTakeFromStockpile || CurrTile.furniture == null || CurrTile.furniture.IsStockpile() == false))
             {
                 // Pick up the stuff!
-                Debug.Log("Pick up the stuff");
+                Logger.LogVerbose("Pick up the stuff");
 
                 World.current.inventoryManager.PlaceInventory(
                     this,
@@ -252,8 +252,8 @@ public class Character : IXmlSerializable, ISelectable
             else
             {
                 // Walk towards a tile containing the required goods.
-                Debug.Log("Walk to the stuff");
-                Debug.Log(myJob.canTakeFromStockpile);
+                Logger.LogVerbose("Walk to the stuff");
+                Logger.LogVerbose(myJob.canTakeFromStockpile.ToString());
 
 
                 // Find the first thing in the Job that isn't satisfied.
@@ -289,7 +289,7 @@ public class Character : IXmlSerializable, ISelectable
                         return false;
                     }
 
-                    Debug.Log("pathAStar returned with length of: " + newPath.Length());                    
+                    Logger.LogVerbose("pathAStar returned with length of: " + newPath.Length());                    
 
                     DestTile = newPath.EndTile();
 


### PR DESCRIPTION
A fix for the general issue in #209, based on the suggestion from @quill18 to use the new Logger's "verbose" output for the failed localization message so it only appears if verbose logging is enabled.

I also took the opportunity to apply a similar treatment to the other messages commonly filling up the console, which come from method-tracing debit messages in `Character.cs`. I think this is a safer short-term solution to those, rather than commenting them out or removing them, so they will still appear if verbose logging is enabled but won't clutter the output during normal game operation. If that's not desired I'm happy to fully disable them instead.

Debug messages in the Character class that were clearly *errors* remain unchanged. I'm willing to tackle converting all the Debug calls in the project to use the new Logger and appropriate levels but I wanted to quiet down the spam quickly first.