### PR TITLE
Replaced all Debug.Log with Logger.Log

### DIFF
--- a/Assets/Scripts/Controllers/BuildModeController.cs
+++ b/Assets/Scripts/Controllers/BuildModeController.cs
@@ -110,7 +110,7 @@ public class BuildModeController : MonoBehaviour
                 }
                 else
                 {
-                    Debug.LogError("There is no furniture job prototype for '" + furnitureType + "'");
+                    Logger.LogError("There is no furniture job prototype for '" + furnitureType + "'");
                     j = new Job(t, furnitureType, FurnitureActions.JobComplete_FurnitureBuilding, 0.1f, null);
                 }
 
@@ -188,7 +188,7 @@ public class BuildModeController : MonoBehaviour
         }
         else
         {
-            Debug.LogError("UNIMPLMENTED BUILD MODE");
+            Logger.LogError("UNIMPLMENTED BUILD MODE");
         }
 
     }

--- a/Assets/Scripts/Controllers/CharacterSpriteController.cs
+++ b/Assets/Scripts/Controllers/CharacterSpriteController.cs
@@ -33,7 +33,7 @@ public class CharacterSpriteController : MonoBehaviour
 
     public void OnCharacterCreated(Character c)
     {
-//		Debug.Log("OnCharacterCreated");
+//		Logger.Log("OnCharacterCreated");
         // Create a visual GameObject linked to this data.
 
         // FIXME: Does not consider multi-tile objects nor rotated objects
@@ -69,7 +69,7 @@ public class CharacterSpriteController : MonoBehaviour
 
     void OnCharacterChanged(Character c)
     {
-        //Debug.Log("OnFurnitureChanged");
+        //Logger.Log("OnFurnitureChanged");
         // Make sure the furniture's graphics are correct.
         SpriteRenderer inv_sr = characterGameObjectMap[c].transform.GetChild(0).gameObject.GetComponent<SpriteRenderer>();
         if (c.inventory != null)
@@ -84,13 +84,13 @@ public class CharacterSpriteController : MonoBehaviour
 
         if (characterGameObjectMap.ContainsKey(c) == false)
         {
-            Debug.LogError("OnCharacterChanged -- trying to change visuals for character not in our map.");
+            Logger.LogError("OnCharacterChanged -- trying to change visuals for character not in our map.");
             return;
         }
 
         GameObject char_go = characterGameObjectMap[c];
-        //Debug.Log(furn_go);
-        //Debug.Log(furn_go.GetComponent<SpriteRenderer>());
+        //Logger.Log(furn_go);
+        //Logger.Log(furn_go.GetComponent<SpriteRenderer>());
 
         //char_go.GetComponent<SpriteRenderer>().sprite = GetSpriteForFurniture(furn);
 

--- a/Assets/Scripts/Controllers/FurnitureSpriteController.cs
+++ b/Assets/Scripts/Controllers/FurnitureSpriteController.cs
@@ -37,7 +37,7 @@ public class FurnitureSpriteController : MonoBehaviour
 
     public void OnFurnitureCreated(Furniture furn)
     {
-        //Debug.Log("OnFurnitureCreated");
+        //Logger.Log("OnFurnitureCreated");
         // Create a visual GameObject linked to this data.
 
         // FIXME: Does not consider multi-tile objects nor rotated objects
@@ -87,7 +87,7 @@ public class FurnitureSpriteController : MonoBehaviour
     {
         if (furnitureGameObjectMap.ContainsKey(furn) == false)
         {
-            Debug.LogError("OnFurnitureRemoved -- trying to change visuals for furniture not in our map.");
+            Logger.LogError("OnFurnitureRemoved -- trying to change visuals for furniture not in our map.");
             return;
         }
 
@@ -98,18 +98,18 @@ public class FurnitureSpriteController : MonoBehaviour
 
     void OnFurnitureChanged(Furniture furn)
     {
-        //Debug.Log("OnFurnitureChanged");
+        //Logger.Log("OnFurnitureChanged");
         // Make sure the furniture's graphics are correct.
 
         if (furnitureGameObjectMap.ContainsKey(furn) == false)
         {
-            Debug.LogError("OnFurnitureChanged -- trying to change visuals for furniture not in our map.");
+            Logger.LogError("OnFurnitureChanged -- trying to change visuals for furniture not in our map.");
             return;
         }
 
         GameObject furn_go = furnitureGameObjectMap[furn];
-        //Debug.Log(furn_go);
-        //Debug.Log(furn_go.GetComponent<SpriteRenderer>());
+        //Logger.Log(furn_go);
+        //Logger.Log(furn_go.GetComponent<SpriteRenderer>());
 
         furn_go.GetComponent<SpriteRenderer>().sprite = GetSpriteForFurniture(furn);
         furn_go.GetComponent<SpriteRenderer>().color = furn.tint;
@@ -150,7 +150,7 @@ public class FurnitureSpriteController : MonoBehaviour
                     // Door is a fully open
                     spriteName = "Door_openness_3";
                 }
-                //Debug.Log(spriteName);
+                //Logger.Log(spriteName);
             }
             if (furn.objectType == "Airlock")
             {
@@ -174,11 +174,11 @@ public class FurnitureSpriteController : MonoBehaviour
                     // Airlock is a fully open
                     spriteName = "Airlock_openness_3";
                 }
-                //Debug.Log(spriteName);
+                //Logger.Log(spriteName);
             }
 
             /*if(furnitureSprites.ContainsKey(spriteName) == false) {
-				Debug.Log("furnitureSprites has no definition for: " + spriteName);
+				Logger.Log("furnitureSprites has no definition for: " + spriteName);
 				return null;
 			}
 */
@@ -223,7 +223,7 @@ public class FurnitureSpriteController : MonoBehaviour
         //       Wall_NESW
 
 /*		if(furnitureSprites.ContainsKey(spriteName) == false) {
-			Debug.LogError("GetSpriteForInstalledObject -- No sprites with name: " + spriteName);
+			Logger.LogError("GetSpriteForInstalledObject -- No sprites with name: " + spriteName);
 			return null;
 		}
 */

--- a/Assets/Scripts/Controllers/InventorySpriteController.cs
+++ b/Assets/Scripts/Controllers/InventorySpriteController.cs
@@ -39,7 +39,7 @@ public class InventorySpriteController : MonoBehaviour
 
     public void OnInventoryCreated(Inventory inv)
     {
-        //Debug.Log("OnInventoryCreated");
+        //Logger.Log("OnInventoryCreated");
         // Create a visual GameObject linked to this data.
 
         // FIXME: Does not consider multi-tile objects nor rotated objects
@@ -58,7 +58,7 @@ public class InventorySpriteController : MonoBehaviour
         sr.sprite = SpriteManager.current.GetSprite("Inventory", inv.objectType);
         if (sr.sprite == null)
         {
-            Debug.LogError("No sprite for: " + inv.objectType);
+            Logger.LogError("No sprite for: " + inv.objectType);
         }
         sr.sortingLayerName = "Inventory";
 
@@ -83,12 +83,12 @@ public class InventorySpriteController : MonoBehaviour
     void OnInventoryChanged(Inventory inv)
     {
 
-        //Debug.Log("OnFurnitureChanged");
+        //Logger.Log("OnFurnitureChanged");
         // Make sure the furniture's graphics are correct.
 
         if (inventoryGameObjectMap.ContainsKey(inv) == false)
         {
-            Debug.LogError("OnCharacterChanged -- trying to change visuals for inventory not in our map.");
+            Logger.LogError("OnCharacterChanged -- trying to change visuals for inventory not in our map.");
             return;
         }
 

--- a/Assets/Scripts/Controllers/JobSpriteController.cs
+++ b/Assets/Scripts/Controllers/JobSpriteController.cs
@@ -36,7 +36,7 @@ public class JobSpriteController : MonoBehaviour
 
         if (jobGameObjectMap.ContainsKey(job))
         {
-            //Debug.LogError("OnJobCreated for a jobGO that already exists -- most likely a job being RE-QUEUED, as opposed to created.");
+            //Logger.LogError("OnJobCreated for a jobGO that already exists -- most likely a job being RE-QUEUED, as opposed to created.");
             return;
         }
 

--- a/Assets/Scripts/Controllers/MouseController.cs
+++ b/Assets/Scripts/Controllers/MouseController.cs
@@ -78,7 +78,7 @@ public class MouseController : MonoBehaviour
             }
             else if (currentMode == MouseMode.SELECT)
             {
-                Debug.Log("Show game menu?");
+                Logger.Log("Show game menu?");
             }
         }
 
@@ -137,7 +137,7 @@ public class MouseController : MonoBehaviour
 
             if (mySelection == null || mySelection.tile != tileUnderMouse)
             {
-                //Debug.Log("new tile");
+                //Logger.Log("new tile");
                 // We have just selected a brand new tile, reset the info.
                 mySelection = new SelectionInfo();
                 mySelection.tile = tileUnderMouse;

--- a/Assets/Scripts/Controllers/SpriteManager.cs
+++ b/Assets/Scripts/Controllers/SpriteManager.cs
@@ -37,7 +37,7 @@ public class SpriteManager : MonoBehaviour
 
     void LoadSpritesFromDirectory(string filePath)
     {
-        Debug.Log("LoadSpritesFromDirectory: " + filePath);
+        Logger.Log("LoadSpritesFromDirectory: " + filePath);
         // First, we're going to see if we have any more sub-directories,
         // if so -- call LoadSpritesFromDirectory on that.
 
@@ -68,7 +68,7 @@ public class SpriteManager : MonoBehaviour
 
     void LoadImage(string spriteCategory, string filePath)
     {
-        //Debug.Log("LoadImage: " + filePath);
+        //Logger.Log("LoadImage: " + filePath);
 
         // TODO:  LoadImage is returning TRUE for things like .meta and .xml files.  What??!
         //		So as a temporary fix, let's just bail if we have something we KNOW should not
@@ -114,7 +114,7 @@ public class SpriteManager : MonoBehaviour
                 }
                 else
                 {
-                    Debug.LogError("Could not find a <Sprites> tag.");
+                    Logger.LogError("Could not find a <Sprites> tag.");
                     return;
                 }
 
@@ -137,7 +137,7 @@ public class SpriteManager : MonoBehaviour
 
     void ReadSpriteFromXml(string spriteCategory, XmlReader reader, Texture2D imageTexture)
     {
-        //Debug.Log("ReadSpriteFromXml");
+        //Logger.Log("ReadSpriteFromXml");
         string name = reader.GetAttribute("name");
         int x = int.Parse(reader.GetAttribute("x"));
         int y = int.Parse(reader.GetAttribute("y"));
@@ -151,7 +151,7 @@ public class SpriteManager : MonoBehaviour
     void LoadSprite(string spriteCategory, string spriteName, Texture2D imageTexture, Rect spriteCoordinates, int pixelsPerUnit)
     {
         spriteName = spriteCategory + "/" + spriteName;
-        //Debug.Log("LoadSprite: " + spriteName);
+        //Logger.Log("LoadSprite: " + spriteName);
         Vector2 pivotPoint = new Vector2(0.5f, 0.5f);	// Ranges from 0..1 -- so 0.5f == center
 
         Sprite s = Sprite.Create(imageTexture, spriteCoordinates, pivotPoint, pixelsPerUnit);
@@ -161,14 +161,14 @@ public class SpriteManager : MonoBehaviour
 
     public Sprite GetSprite(string categoryName, string spriteName)
     {
-        //Debug.Log(spriteName);
+        //Logger.Log(spriteName);
 
 
         spriteName = categoryName + "/" + spriteName;
 
         if (sprites.ContainsKey(spriteName) == false)
         {
-            //Debug.LogError("No sprite with name: " + spriteName);
+            //Logger.LogError("No sprite with name: " + spriteName);
             return null;	// TODO: What if we return a "dummy" sprite, like a purple square?
         }
 

--- a/Assets/Scripts/Controllers/TileSpriteController.cs
+++ b/Assets/Scripts/Controllers/TileSpriteController.cs
@@ -88,7 +88,7 @@ public class TileSpriteController : MonoBehaviour
 
         if (tileGameObjectMap.ContainsKey(tile_data) == false)
         {
-            Debug.LogError("tileGameObjectMap doesn't contain the tile_data -- did you forget to add the tile to the dictionary? Or maybe forget to unregister a callback?");
+            Logger.LogError("tileGameObjectMap doesn't contain the tile_data -- did you forget to add the tile to the dictionary? Or maybe forget to unregister a callback?");
             return;
         }
 
@@ -96,7 +96,7 @@ public class TileSpriteController : MonoBehaviour
 
         if (tile_go == null)
         {
-            Debug.LogError("tileGameObjectMap's returned GameObject is null -- did you forget to add the tile to the dictionary? Or maybe forget to unregister a callback?");
+            Logger.LogError("tileGameObjectMap's returned GameObject is null -- did you forget to add the tile to the dictionary? Or maybe forget to unregister a callback?");
             return;
         }
 
@@ -110,7 +110,7 @@ public class TileSpriteController : MonoBehaviour
         }
         else
         {
-            Debug.LogError("OnTileTypeChanged - Unrecognized tile type.");
+            Logger.LogError("OnTileTypeChanged - Unrecognized tile type.");
         }
 
 

--- a/Assets/Scripts/Controllers/WorldController.cs
+++ b/Assets/Scripts/Controllers/WorldController.cs
@@ -52,7 +52,7 @@ public class WorldController : MonoBehaviour
     {
         if (Instance != null)
         {
-            Debug.LogError("There should never be two world controllers.");
+            Logger.LogError("There should never be two world controllers.");
         }
         Instance = this;
 
@@ -90,7 +90,7 @@ public class WorldController : MonoBehaviour
         if (Input.GetKeyDown(KeyCode.Space))
         {
             IsPaused = !IsPaused;
-            Debug.Log("Game " + (IsPaused ? "paused" : "resumed"));
+            Logger.Log("Game " + (IsPaused ? "paused" : "resumed"));
         }
 
         if (Input.GetKeyDown(KeyCode.Plus) || Input.GetKeyDown(KeyCode.KeypadPlus))
@@ -139,7 +139,7 @@ public class WorldController : MonoBehaviour
     public void SetTimeScale(float timeScale)
     {
         this.timeScale = timeScale;
-        Debug.Log("Game speed set to " + timeScale + "x");
+        Logger.Log("Game speed set to " + timeScale + "x");
     }
 
     /// <summary>
@@ -157,7 +157,7 @@ public class WorldController : MonoBehaviour
 
     public void NewWorld()
     {
-        Debug.Log("NewWorld button was clicked.");
+        Logger.Log("NewWorld button was clicked.");
 
         SceneManager.LoadScene(SceneManager.GetActiveScene().name);
     }
@@ -169,7 +169,7 @@ public class WorldController : MonoBehaviour
 
     public void LoadWorld(string fileName)
     {
-        Debug.Log("LoadWorld button was clicked.");
+        Logger.Log("LoadWorld button was clicked.");
 
         // Reload the scene to reset all data (and purge old references)
         loadWorldFromFile = fileName;
@@ -187,7 +187,7 @@ public class WorldController : MonoBehaviour
 
     void CreateWorldFromSaveFile()
     {
-        Debug.Log("CreateWorldFromSaveFile");
+        Logger.Log("CreateWorldFromSaveFile");
         // Create a world from our save file data.
 
         XmlSerializer serializer = new XmlSerializer(typeof(World));
@@ -199,7 +199,7 @@ public class WorldController : MonoBehaviour
         TextReader reader = new StringReader(saveGameText);
 
 
-        Debug.Log(reader.ToString());
+        Logger.Log(reader.ToString());
         world = (World)serializer.Deserialize(reader);
         reader.Close();
 

--- a/Assets/Scripts/Localization/LocalizationLoader.cs
+++ b/Assets/Scripts/Localization/LocalizationLoader.cs
@@ -37,7 +37,7 @@ namespace ProjectPorcupine.Localization
                     LocalizationTable.LoadLocalizationFile(file);
 
                     //Just write a little debug info into the console.
-                    Debug.Log("Loaded localization at path\n" + file);
+                    Logger.Log("Loaded localization at path\n" + file);
                 }
             }
 

--- a/Assets/Scripts/Localization/LocalizationTable.cs
+++ b/Assets/Scripts/Localization/LocalizationTable.cs
@@ -149,7 +149,7 @@ namespace ProjectPorcupine.Localization
             {
 #if UNITY_EDITOR //TODO: Think if #if is a good idea or not.
                 //Log a warning into the console if this operation fails.
-                Debug.LogWarning("Translation for " + key + " failed: Key not in dictionary.");
+                Logger.LogWarning("Translation for " + key + " failed: Key not in dictionary.");
 #endif
 
                 //Switch the fallback mode.

--- a/Assets/Scripts/Models/Character.cs
+++ b/Assets/Scripts/Models/Character.cs
@@ -153,7 +153,7 @@ public class Character : IXmlSerializable, ISelectable
         Profiler.EndSample();
         if (pathAStar.Length() == 0)
         {
-            Debug.LogError("Path_AStar returned no path to target job tile!");
+            Logger.LogError("Path_AStar returned no path to target job tile!");
             AbandonJob();
             DestTile = CurrTile;
         }
@@ -234,13 +234,13 @@ public class Character : IXmlSerializable, ISelectable
             // At this point, the job still requires inventory, but we aren't carrying it!
 
             // Are we standing on a tile with goods that are desired by the job?
-            Debug.Log("Standing on Tile check");
+            Logger.Log("Standing on Tile check");
             if (CurrTile.inventory != null &&
                 myJob.DesiresInventoryType(CurrTile.inventory) > 0 &&
                 (myJob.canTakeFromStockpile || CurrTile.furniture == null || CurrTile.furniture.IsStockpile() == false))
             {
                 // Pick up the stuff!
-                Debug.Log("Pick up the stuff");
+                Logger.Log("Pick up the stuff");
 
                 World.current.inventoryManager.PlaceInventory(
                     this,
@@ -252,9 +252,8 @@ public class Character : IXmlSerializable, ISelectable
             else
             {
                 // Walk towards a tile containing the required goods.
-                Debug.Log("Walk to the stuff");
-                Debug.Log(myJob.canTakeFromStockpile);
-
+                Logger.Log("Walk to the stuff");
+                Logger.Log(myJob.canTakeFromStockpile);
 
                 // Find the first thing in the Job that isn't satisfied.
                 Inventory desired = myJob.GetFirstDesiredInventory();
@@ -282,14 +281,14 @@ public class Character : IXmlSerializable, ISelectable
 
                     if (newPath == null || newPath.Length() < 1)
                     {
-                        //Debug.Log("pathAStar is null and we have no path to object of type: " + desired.objectType);
+                        //Logger.Log("pathAStar is null and we have no path to object of type: " + desired.objectType);
                         // Cancel the job, since we have no way to get any raw materials!
-                        Debug.Log("No tile contains objects of type '" + desired.objectType + "' to satisfy job requirements.");
+                        Logger.Log("No tile contains objects of type '" + desired.objectType + "' to satisfy job requirements.");
                         AbandonJob();
                         return false;
                     }
 
-                    Debug.Log("pathAStar returned with length of: " + newPath.Length());                    
+                    Logger.Log("pathAStar returned with length of: " + newPath.Length());
 
                     DestTile = newPath.EndTile();
 
@@ -322,7 +321,7 @@ public class Character : IXmlSerializable, ISelectable
 
         //if (World.current.inventoryManager.PlaceInventory(CurrTile, inventory) == false)
         //{
-        //    Debug.LogError("Character tried to dump inventory into an invalid tile (maybe there's already something here). FIXME: Setting inventory to null and leaking for now");
+        //    Logger.LogError("Character tried to dump inventory into an invalid tile (maybe there's already something here). FIXME: Setting inventory to null and leaking for now");
         //    // FIXME: For the sake of continuing on, we are still going to dump any
         //    // reference to the current inventory, but this means we are "leaking"
         //    // inventory.  This is permanently lost now.
@@ -360,7 +359,7 @@ public class Character : IXmlSerializable, ISelectable
                 pathAStar = new Path_AStar(World.current, CurrTile, DestTile);	// This will calculate a path from curr to dest.
                 if (pathAStar.Length() == 0)
                 {
-                    Debug.LogError("Path_AStar returned no path to destination!");
+                    Logger.LogError("Path_AStar returned no path to destination!");
                     AbandonJob();
                     return;
                 }
@@ -376,7 +375,7 @@ public class Character : IXmlSerializable, ISelectable
 
             if (NextTile == CurrTile)
             {
-                //Debug.LogError("Update_DoMovement - nextTile is currTile?");
+                //Logger.LogError("Update_DoMovement - nextTile is currTile?");
             }
         }
 
@@ -398,7 +397,7 @@ public class Character : IXmlSerializable, ISelectable
             //		  so that we don't waste a bunch of time walking towards a dead end.
             //		  To save CPU, maybe we can only check every so often?
             //		  Or maybe we should register a callback to the OnTileChanged event?
-            // Debug.LogError("FIXME: A character was trying to enter an unwalkable tile.");
+            // Logger.LogError("FIXME: A character was trying to enter an unwalkable tile.");
             NextTile = null;	// our next tile is a no-go
             pathAStar = null;	// clearly our pathfinding info is out of date.
             return;
@@ -457,7 +456,7 @@ public class Character : IXmlSerializable, ISelectable
 
         if (j != myJob)
         {
-            Debug.LogError("Character being told about job that isn't his. You forgot to unregister something.");
+            Logger.LogError("Character being told about job that isn't his. You forgot to unregister something.");
             return;
         }
 

--- a/Assets/Scripts/Models/Furniture.cs
+++ b/Assets/Scripts/Models/Furniture.cs
@@ -255,7 +255,7 @@ public class Furniture : IXmlSerializable, ISelectable
     {
         if (proto.funcPositionValidation(tile) == false)
         {
-            Debug.LogError("PlaceInstance -- Position Validity Function returned FALSE.");
+            Logger.LogError("PlaceInstance -- Position Validity Function returned FALSE.");
             return null;
         }
 
@@ -399,7 +399,7 @@ public class Furniture : IXmlSerializable, ISelectable
 
     public void ReadXmlPrototype(XmlReader reader_parent)
     {
-        //Debug.Log("ReadXmlPrototype");
+        //Logger.Log("ReadXmlPrototype");
 
         objectType = reader_parent.GetAttribute("objectType");
 
@@ -660,7 +660,7 @@ public class Furniture : IXmlSerializable, ISelectable
 
     public void Deconstruct()
     {
-        Debug.Log("Deconstruct");
+        Logger.Log("Deconstruct");
 
         tile.UnplaceFurniture();
 

--- a/Assets/Scripts/Models/FurnitureActions.cs
+++ b/Assets/Scripts/Models/FurnitureActions.cs
@@ -72,7 +72,7 @@ public class FurnitureActions
 
             if (func == null)
             {
-                Debug.LogError("'" + fn + "' is not a LUA function.");
+                Logger.LogError("'" + fn + "' is not a LUA function.");
                 return;
             }
 
@@ -80,14 +80,14 @@ public class FurnitureActions
 
             if (result.Type == DataType.String)
             {
-                Debug.Log(result.String);
+                Logger.Log(result.String);
             }
         }
     }
 
     static public DynValue CallFunction(string functionName, params object[] args)
     {
-        //Debug.Log("Calling function: " + functionName);
+        //Logger.Log("Calling function: " + functionName);
         object func = _Instance.myLuaScript.Globals[functionName];
 
         return _Instance.myLuaScript.Call(func, args);
@@ -116,7 +116,7 @@ public class FurnitureActions
 
 
     /*	public static void Door_UpdateAction(Furniture furn, float deltaTime) {
-		//Debug.Log("Door_UpdateAction: " + furn.furnParameters["openness"]);
+		//Logger.Log("Door_UpdateAction: " + furn.furnParameters["openness"]);
 
 		if(furn.GetParameter("is_opening") >= 1) {
 			furn.ChangeParameter("openness", deltaTime * 4);	// FIXME: Maybe a door open speed parameter?
@@ -136,7 +136,7 @@ public class FurnitureActions
 	}
 
 	public static ENTERABILITY Door_IsEnterable(Furniture furn) {
-		//Debug.Log("Door_IsEnterable");
+		//Logger.Log("Door_IsEnterable");
 		furn.SetParameter("is_opening", 1);
 
 		if(furn.GetParameter("openness") >= 1) {
@@ -189,7 +189,7 @@ public class FurnitureActions
 
 		// Third possibility: Something is WHACK
 		if( furn.tile.inventory != null && furn.tile.inventory.stackSize == 0 ) {
-			Debug.LogError("Stockpile has a zero-size stack. This is clearly WRONG!");
+			Logger.LogError("Stockpile has a zero-size stack. This is clearly WRONG!");
 			furn.CancelJobs();
 			return;
 		}
@@ -207,11 +207,11 @@ public class FurnitureActions
 		Inventory[] itemsDesired;
 
 		if( furn.tile.inventory == null ) {
-			Debug.Log("Creating job for new stack.");
+			Logger.Log("Creating job for new stack.");
 			itemsDesired = Stockpile_GetItemsFromFilter();
 		}
 		else {
-			Debug.Log("Creating job for existing stack.");
+			Logger.Log("Creating job for existing stack.");
 			Inventory desInv = furn.tile.inventory.Clone();
 			desInv.maxStackSize -= desInv.stackSize;
 			desInv.stackSize = 0;
@@ -236,7 +236,7 @@ public class FurnitureActions
 	}
 
 	static void Stockpile_JobWorked(Job j) {
-		Debug.Log("Stockpile_JobWorked");
+		Logger.Log("Stockpile_JobWorked");
 		j.CancelJob();
 
 		// TODO: Change this when we figure out what we're doing for the all/any pickup job.
@@ -253,7 +253,7 @@ public class FurnitureActions
 	public static void OxygenGenerator_UpdateAction(Furniture furn, float deltaTime) {
 
 		if(furn.tile.room== null)  {
-			Debug.LogError("Why are we in a null room?");
+			Logger.LogError("Why are we in a null room?");
 			return;
 		}
 			

--- a/Assets/Scripts/Models/InventoryManager.cs
+++ b/Assets/Scripts/Models/InventoryManager.cs
@@ -76,7 +76,7 @@ public class InventoryManager
     {
         if (job.inventoryRequirements.ContainsKey(inv.objectType) == false)
         {
-            Debug.LogError("Trying to add inventory to a job that it doesn't want.");
+            Logger.LogError("Trying to add inventory to a job that it doesn't want.");
             return false;
         }
 
@@ -116,7 +116,7 @@ public class InventoryManager
         }
         else if (character.inventory.objectType != sourceInventory.objectType)
         {
-            Debug.LogError("Character is trying to pick up a mismatched inventory object type.");
+            Logger.LogError("Character is trying to pick up a mismatched inventory object type.");
             return false;
         }
 

--- a/Assets/Scripts/Models/Job.cs
+++ b/Assets/Scripts/Models/Job.cs
@@ -161,7 +161,7 @@ public class Job
         // If not, don't register the work time.
         if (HasAllMaterial() == false)
         {
-            //Debug.LogError("Tried to do work on a job that doesn't have all the material.");
+            //Logger.LogError("Tried to do work on a job that doesn't have all the material.");
 
             // Job can't actually be worked, but still call the callbacks
             // so that animations and whatnot can be updated.

--- a/Assets/Scripts/Models/JobQueue.cs
+++ b/Assets/Scripts/Models/JobQueue.cs
@@ -20,7 +20,7 @@ public class JobQueue
 
     public void Enqueue(Job j)
     {
-        //Debug.Log("Adding job to queue. Existing queue size: " + jobQueue.Count);
+        //Logger.Log("Adding job to queue. Existing queue size: " + jobQueue.Count);
         if (j.jobTime < 0)
         {
             // Job has a negative job time, so it's not actually
@@ -52,7 +52,7 @@ public class JobQueue
 
         if (jobs.Contains(j) == false)
         {
-            //Debug.LogError("Trying to remove a job that doesn't exist on the queue.");
+            //Logger.LogError("Trying to remove a job that doesn't exist on the queue.");
             // Most likely, this job wasn't on the queue because a character was working it!
             return;
         }

--- a/Assets/Scripts/Models/PowerSystem.cs
+++ b/Assets/Scripts/Models/PowerSystem.cs
@@ -36,11 +36,11 @@ public class PowerSystem {
     {
         if (currentPower < furn.powerValue)
         {
-            //Debug.LogWarning("Not enough power for " + furn.Name + " to run");
+            //Logger.LogWarning("Not enough power for " + furn.Name + " to run");
             return;
         }
 
-        //Debug.Log("Added " + furn.Name + " to power consumer list");
+        //Logger.Log("Added " + furn.Name + " to power consumer list");
         powerConsumers.Add(furn);
         CalculatePower();
 
@@ -80,7 +80,7 @@ public class PowerSystem {
 
         currentPower = powerValues;
 
-        Debug.Log("Current Power level: " + currentPower);
+        Logger.Log("Current Power level: " + currentPower);
     }
 
 

--- a/Assets/Scripts/Models/Room.cs
+++ b/Assets/Scripts/Models/Room.cs
@@ -217,7 +217,7 @@ public class Room : IXmlSerializable
 
                 if (oldRoom.tiles.Count > 0)
                 {
-                    Debug.LogError("'oldRoom' still has tiles assigned to it. This is clearly wrong.");
+                    Logger.LogError("'oldRoom' still has tiles assigned to it. This is clearly wrong.");
                 }
 
                 world.DeleteRoom(oldRoom);
@@ -237,7 +237,7 @@ public class Room : IXmlSerializable
 
     protected static void ActualFloodFill(Tile tile, Room oldRoom, int sizeOfOldRoom)
     {
-        //Debug.Log("ActualFloodFill");
+        //Logger.Log("ActualFloodFill");
 
         if (tile == null)
         {
@@ -329,7 +329,7 @@ public class Room : IXmlSerializable
             }
         }
 
-        //Debug.Log("ActualFloodFill -- Processed Tiles: " + processedTiles);
+        //Logger.Log("ActualFloodFill -- Processed Tiles: " + processedTiles);
 
         if (isConnectedToSpace)
         {

--- a/Assets/Scripts/Models/Tile.cs
+++ b/Assets/Scripts/Models/Tile.cs
@@ -140,7 +140,7 @@ public class Tile :IXmlSerializable, ISelectable
 
         if (objInstance.IsValidPosition(this) == false)
         {
-            Debug.LogError("Trying to assign a furniture to a tile that isn't valid!");
+            Logger.LogError("Trying to assign a furniture to a tile that isn't valid!");
             return false;
         }
 		
@@ -172,7 +172,7 @@ public class Tile :IXmlSerializable, ISelectable
 
             if (inventory.objectType != inv.objectType)
             {
-                Debug.LogError("Trying to assign inventory to a tile that already has some of a different type.");
+                Logger.LogError("Trying to assign inventory to a tile that already has some of a different type.");
                 return false;
             }
 

--- a/Assets/Scripts/Models/World.cs
+++ b/Assets/Scripts/Models/World.cs
@@ -104,7 +104,7 @@ public class World : IXmlSerializable
     {
         if (r == GetOutsideRoom())
         {
-            Debug.LogError("Tried to delete the outside room.");
+            Logger.LogError("Tried to delete the outside room.");
             return;
         }
 
@@ -143,7 +143,7 @@ public class World : IXmlSerializable
             }
         }
 
-        Debug.Log("World created with " + (Width * Height) + " tiles.");
+        Logger.Log("World created with " + (Width * Height) + " tiles.");
 
         CreateFurniturePrototypes();
 
@@ -170,7 +170,7 @@ public class World : IXmlSerializable
 
     public Character CreateCharacter(Tile t)
     {
-        Debug.Log("CreateCharacter");
+        Logger.Log("CreateCharacter");
         Character c = new Character(t); 
 
         characters.Add(c);
@@ -192,8 +192,8 @@ public class World : IXmlSerializable
         filePath = System.IO.Path.Combine(filePath, "Furniture.lua");
         string myLuaCode = System.IO.File.ReadAllText(filePath);
 
-        //Debug.Log("My LUA Code");
-        //Debug.Log(myLuaCode);
+        //Logger.Log("My LUA Code");
+        //Logger.Log(myLuaCode);
 
         // Instantiate the singleton
         new FurnitureActions(myLuaCode);
@@ -233,7 +233,7 @@ public class World : IXmlSerializable
                         furn.ReadXmlPrototype(reader);
                     }
                     catch {
-                        Debug.LogError("Error reading furniture prototype for: " + furn.objectType);
+                        Logger.LogError("Error reading furniture prototype for: " + furn.objectType);
                     }
 
 
@@ -245,15 +245,15 @@ public class World : IXmlSerializable
             }
             else
             {
-                Debug.LogError("The furniture prototype definition file doesn't have any 'Furniture' elements.");
+                Logger.LogError("The furniture prototype definition file doesn't have any 'Furniture' elements.");
             }
         }
         else
         {
-            Debug.LogError("Did not find a 'Furnitures' element in the prototype definition file.");
+            Logger.LogError("Did not find a 'Furnitures' element in the prototype definition file.");
         }
 
-        Debug.Log("Furniture prototypes read: " + furnCount.ToString());
+        Logger.Log("Furniture prototypes read: " + furnCount.ToString());
 
         // This bit will come from parsing a LUA file later, but for now we still need to
         // implement furniture behaviour directly in C# code.
@@ -372,7 +372,7 @@ public class World : IXmlSerializable
     /// </summary>
     public void RandomizeTiles()
     {
-        Debug.Log("RandomizeTiles");
+        Logger.Log("RandomizeTiles");
         for (int x = 0; x < Width; x++)
         {
             for (int y = 0; y < Height; y++)
@@ -393,7 +393,7 @@ public class World : IXmlSerializable
 
     public void SetupPathfindingExample()
     {
-        Debug.Log("SetupPathfindingExample");
+        Logger.Log("SetupPathfindingExample");
 
         // Make a set of floors/walls to test pathfinding with.
 
@@ -432,7 +432,7 @@ public class World : IXmlSerializable
     {
         if (x >= Width || x < 0 || y >= Height || y < 0)
         {
-            //Debug.LogError("Tile ("+x+","+y+") is out of range.");
+            //Logger.LogError("Tile ("+x+","+y+") is out of range.");
             return null;
         }
         return tiles[x, y];
@@ -441,12 +441,12 @@ public class World : IXmlSerializable
 
     public Furniture PlaceFurniture(string objectType, Tile t, bool doRoomFloodFill = true)
     {
-        //Debug.Log("PlaceInstalledObject");
+        //Logger.Log("PlaceInstalledObject");
         // TODO: This function assumes 1x1 tiles -- change this later!
 
         if (furniturePrototypes.ContainsKey(objectType) == false)
         {
-            Debug.LogError("furniturePrototypes doesn't contain a proto for key: " + objectType);
+            Logger.LogError("furniturePrototypes doesn't contain a proto for key: " + objectType);
             return null;
         }
 
@@ -520,7 +520,7 @@ public class World : IXmlSerializable
     {
         if (furniturePrototypes.ContainsKey(objectType) == false)
         {
-            Debug.LogError("No furniture with type: " + objectType);
+            Logger.LogError("No furniture with type: " + objectType);
             return null;
         }
 
@@ -609,13 +609,13 @@ public class World : IXmlSerializable
 		writer.WriteEndElement();
 */
 
-        //Debug.Log(writer.ToString());
+        //Logger.Log(writer.ToString());
 	
     }
 
     public void ReadXml(XmlReader reader)
     {
-        Debug.Log("World::ReadXml");
+        Logger.Log("World::ReadXml");
         // Load info here
 
         Width = int.Parse(reader.GetAttribute("Width"));
@@ -674,7 +674,7 @@ public class World : IXmlSerializable
 
     void ReadXml_Tiles(XmlReader reader)
     {
-        Debug.Log("ReadXml_Tiles");
+        Logger.Log("ReadXml_Tiles");
         // We are in the "Tiles" element, so read elements until
         // we run out of "Tile" nodes.
 
@@ -695,7 +695,7 @@ public class World : IXmlSerializable
 
     void ReadXml_Inventories(XmlReader reader)
     {
-        Debug.Log("ReadXml_Inventories");
+        Logger.Log("ReadXml_Inventories");
 
         if(reader.ReadToDescendant("Inventory"))
         {
@@ -716,7 +716,7 @@ public class World : IXmlSerializable
 
     void ReadXml_Furnitures(XmlReader reader)
     {
-        Debug.Log("ReadXml_Furnitures");
+        Logger.Log("ReadXml_Furnitures");
 
         if (reader.ReadToDescendant("Furniture"))
         {
@@ -742,7 +742,7 @@ public class World : IXmlSerializable
 
     void ReadXml_Rooms(XmlReader reader)
     {
-        Debug.Log("ReadXml_Rooms");
+        Logger.Log("ReadXml_Rooms");
 
         if (reader.ReadToDescendant("Room"))
         {
@@ -768,7 +768,7 @@ public class World : IXmlSerializable
 
     void ReadXml_Characters(XmlReader reader)
     {
-        Debug.Log("ReadXml_Characters");
+        Logger.Log("ReadXml_Characters");
         if (reader.ReadToDescendant("Character"))
         {
             do

--- a/Assets/Scripts/Pathfinding/Path_AStar.cs
+++ b/Assets/Scripts/Pathfinding/Path_AStar.cs
@@ -27,7 +27,7 @@ public class Path_AStar
         // Make sure our start/end tiles are in the list of nodes!
         if (nodes.ContainsKey(tileStart) == false)
         {
-            Debug.LogError("Path_AStar: The starting tile isn't in the list of nodes!");
+            Logger.LogError("Path_AStar: The starting tile isn't in the list of nodes!");
 
             return;
         }
@@ -42,7 +42,7 @@ public class Path_AStar
         {
             if (nodes.ContainsKey(tileEnd) == false)
             {
-                Debug.LogError("Path_AStar: The ending tile isn't in the list of nodes!");
+                Logger.LogError("Path_AStar: The ending tile isn't in the list of nodes!");
                 return;
             }
 
@@ -222,12 +222,12 @@ public class Path_AStar
     {
         if (path == null)
         {
-            Debug.LogError("Attempting to dequeue from an null path.");
+            Logger.LogError("Attempting to dequeue from an null path.");
             return null;
         }
         if (path.Count <= 0)
         {
-            Debug.LogError("what???");
+            Logger.LogError("what???");
             return null;
         }
         return path.Dequeue();
@@ -245,7 +245,7 @@ public class Path_AStar
     {
         if (path == null || path.Count == 0)
         {
-            Debug.Log("Path is null or empty.");
+            Logger.Log("Path is null or empty.");
             return null;
         }
 

--- a/Assets/Scripts/Pathfinding/Path_TileGraph.cs
+++ b/Assets/Scripts/Pathfinding/Path_TileGraph.cs
@@ -19,7 +19,7 @@ public class Path_TileGraph
     public Path_TileGraph(World world)
     {
 
-        Debug.Log("Path_TileGraph");
+        Logger.Log("Path_TileGraph");
 
         // Loop through all tiles of the world
         // For each tile, create a node
@@ -44,7 +44,7 @@ public class Path_TileGraph
             }
         }
 
-        Debug.Log("Path_TileGraph: Created " + nodes.Count + " nodes.");
+        Logger.Log("Path_TileGraph: Created " + nodes.Count + " nodes.");
 
 
         // Now loop through all nodes again

--- a/Assets/Scripts/UI/DialogBox/FileSaveLoad/DialogBoxLoadGame.cs
+++ b/Assets/Scripts/UI/DialogBox/FileSaveLoad/DialogBoxLoadGame.cs
@@ -70,7 +70,7 @@ public class DialogBoxLoadGame : DialogBoxLoadSaveGame
 		{
 			// TODO: Do file overwrite dialog box.
 
-			Debug.LogError("File doesn't exist.  What?");
+			Logger.LogError("File doesn't exist.  What?");
 			CloseDialog();
 			return;
 		}
@@ -101,7 +101,7 @@ public class DialogBoxLoadGame : DialogBoxLoadSaveGame
 		if (File.Exists(filePath) == false)
 		{
 
-			Debug.LogError("File doesn't exist.  What?");
+			Logger.LogError("File doesn't exist.  What?");
 			CloseDialog();
 			return;
 		}
@@ -130,7 +130,7 @@ public class DialogBoxLoadGame : DialogBoxLoadSaveGame
 
 		// Get the file name from the save file dialog box
 
-		Debug.Log("LoadWorld button was clicked.");
+		Logger.Log("LoadWorld button was clicked.");
 
 		WorldController.Instance.LoadWorld(filePath);
 	}

--- a/Assets/Scripts/UI/DialogBox/FileSaveLoad/DialogBoxLoadSaveGame.cs
+++ b/Assets/Scripts/UI/DialogBox/FileSaveLoad/DialogBoxLoadSaveGame.cs
@@ -26,7 +26,7 @@ public class DialogBoxLoadSaveGame : DialogBox
     {
         if (Directory.Exists(directoryPath) == false)
         {
-            Debug.LogWarning("Directory: " + directoryPath + " doesn't exist - creating.");
+            Logger.LogWarning("Directory: " + directoryPath + " doesn't exist - creating.");
             Directory.CreateDirectory(directoryPath);
         }
     }

--- a/Assets/Scripts/UI/DialogBox/FileSaveLoad/DialogBoxSaveGame.cs
+++ b/Assets/Scripts/UI/DialogBox/FileSaveLoad/DialogBoxSaveGame.cs
@@ -45,7 +45,7 @@ public class DialogBoxSaveGame : DialogBoxLoadSaveGame
         {
             // TODO: Do file overwrite dialog box.
 
-            Debug.LogWarning("File already exists -- overwriting the file for now.");
+            Logger.LogWarning("File already exists -- overwriting the file for now.");
         }
 
         CloseDialog();
@@ -60,14 +60,14 @@ public class DialogBoxSaveGame : DialogBoxLoadSaveGame
 
         // Get the file name from the save file dialog box
 
-        Debug.Log("SaveWorld button was clicked.");
+        Logger.Log("SaveWorld button was clicked.");
 
         XmlSerializer serializer = new XmlSerializer(typeof(World));
         TextWriter writer = new StringWriter();
         serializer.Serialize(writer, WorldController.Instance.world);
         writer.Close();
 
-        Debug.Log(writer.ToString());
+        Logger.Log(writer.ToString());
 
         //PlayerPrefs.SetString("SaveGame00", writer.ToString());
 

--- a/Assets/Scripts/UI/MouseOverFurnitureTypeText.cs
+++ b/Assets/Scripts/UI/MouseOverFurnitureTypeText.cs
@@ -19,7 +19,7 @@ public class MouseOverFurnitureTypeText : MonoBehaviour
 
         if (myText == null)
         {
-            Debug.LogError("MouseOverTileTypeText: No 'Text' UI component on this object.");
+            Logger.LogError("MouseOverTileTypeText: No 'Text' UI component on this object.");
             this.enabled = false;
             return;
         }
@@ -27,7 +27,7 @@ public class MouseOverFurnitureTypeText : MonoBehaviour
         mouseController = GameObject.FindObjectOfType<MouseController>();
         if (mouseController == null)
         {
-            Debug.LogError("How do we not have an instance of mouse controller?");
+            Logger.LogError("How do we not have an instance of mouse controller?");
             return;
         }
     }

--- a/Assets/Scripts/UI/MouseOverRoomDetails.cs
+++ b/Assets/Scripts/UI/MouseOverRoomDetails.cs
@@ -19,7 +19,7 @@ public class MouseOverRoomDetails : MonoBehaviour
 
         if (myText == null)
         {
-            Debug.LogError("MouseOverTileTypeText: No 'Text' UI component on this object.");
+            Logger.LogError("MouseOverTileTypeText: No 'Text' UI component on this object.");
             this.enabled = false;
             return;
         }
@@ -27,7 +27,7 @@ public class MouseOverRoomDetails : MonoBehaviour
         mouseController = GameObject.FindObjectOfType<MouseController>();
         if (mouseController == null)
         {
-            Debug.LogError("How do we not have an instance of mouse controller?");
+            Logger.LogError("How do we not have an instance of mouse controller?");
             return;
         }
     }

--- a/Assets/Scripts/UI/MouseOverRoomIndexText.cs
+++ b/Assets/Scripts/UI/MouseOverRoomIndexText.cs
@@ -19,7 +19,7 @@ public class MouseOverRoomIndexText : MonoBehaviour
 
         if (myText == null)
         {
-            Debug.LogError("MouseOverTileTypeText: No 'Text' UI component on this object.");
+            Logger.LogError("MouseOverTileTypeText: No 'Text' UI component on this object.");
             this.enabled = false;
             return;
         }
@@ -27,7 +27,7 @@ public class MouseOverRoomIndexText : MonoBehaviour
         mouseController = GameObject.FindObjectOfType<MouseController>();
         if (mouseController == null)
         {
-            Debug.LogError("How do we not have an instance of mouse controller?");
+            Logger.LogError("How do we not have an instance of mouse controller?");
             return;
         }
     }

--- a/Assets/Scripts/UI/MouseOverTileTypeText.cs
+++ b/Assets/Scripts/UI/MouseOverTileTypeText.cs
@@ -19,7 +19,7 @@ public class MouseOverTileTypeText : MonoBehaviour
 
         if (myText == null)
         {
-            Debug.LogError("MouseOverTileTypeText: No 'Text' UI component on this object.");
+            Logger.LogError("MouseOverTileTypeText: No 'Text' UI component on this object.");
             this.enabled = false;
             return;
         }
@@ -27,7 +27,7 @@ public class MouseOverTileTypeText : MonoBehaviour
         mouseController = GameObject.FindObjectOfType<MouseController>();
         if (mouseController == null)
         {
-            Debug.LogError("How do we not have an instance of mouse controller?");
+            Logger.LogError("How do we not have an instance of mouse controller?");
             return;
         }
     }

--- a/Assets/Scripts/Utilities/Logger.cs
+++ b/Assets/Scripts/Utilities/Logger.cs
@@ -30,7 +30,7 @@ public static class Logger
         }
     }
 
-    public static void LogAssertion(string message)
+    public static void LogAssertion(object message)
     {
         Log(Level.Assertion, message);
     }
@@ -40,7 +40,7 @@ public static class Logger
         Log(Level.Assertion, format, args);
     }
 
-    public static void LogError(string message)
+    public static void LogError(object message)
     {
         Log(Level.Error, message);
     }
@@ -50,7 +50,7 @@ public static class Logger
         Log(Level.Error, format, args);
     }
 
-    public static void LogWarning(string message)
+    public static void LogWarning(object message)
     {
         Log(Level.Warning, message);
     }
@@ -60,7 +60,7 @@ public static class Logger
         Log(Level.Warning, format, args);
     }
 
-    public static void LogInfo(string message)
+    public static void LogInfo(object message)
     {
         Log(Level.Info, message);
     }
@@ -70,7 +70,7 @@ public static class Logger
         Log(Level.Info, format, args);
     }
 
-    public static void LogVerbose(string message)
+    public static void LogVerbose(object message)
     {
         Log(Level.Verbose, message);
     }
@@ -83,7 +83,7 @@ public static class Logger
     /// <summary>
     /// Alias for info.
     /// </summary>
-    public static void Log(string message)
+    public static void Log(object message)
     {
         Log(Level.Info, message);
     }
@@ -94,6 +94,17 @@ public static class Logger
     public static void LogFormat(string message, params object[] args)
     {
         Log(Level.Info, message, args);
+    }
+
+    private static void Log(Level level, object message)
+    {
+        // This method just formats the messsage, but just in case ToString is expensive on this object we check level first.
+        if (level > minimumLevel)
+        {
+            return;
+        }
+
+        Log(level, message == null ? null : message.ToString());
     }
 
     private static void Log(Level level, string message, params object[] formatArgs)

--- a/Assets/Scripts/Utilities/SimplePool.cs
+++ b/Assets/Scripts/Utilities/SimplePool.cs
@@ -204,7 +204,7 @@ public static class SimplePool
         PoolMember pm = obj.GetComponent<PoolMember>();
         if (pm == null)
         {
-            //Debug.Log ("Object '"+obj.name+"' wasn't spawned from a pool. Destroying it instead.");
+            //Logger.Log ("Object '"+obj.name+"' wasn't spawned from a pool. Destroying it instead.");
             GameObject.Destroy(obj);
         }
         else


### PR DESCRIPTION
This is the obvious follow up to #185, replacing all log calls with the new Logger.

There's also a ninja fix in here, I realized I was wrong before when I said I matched the method signatures of the built in logger. Turns out, it takes `object` rather than `string` so you can have it implicitly call `ToString()` if you want. That trick was used in [Characters.cs:255](https://github.com/TeamPorcupine/ProjectPorcupine/compare/master...Mizipzor:logger?expand=1#diff-64cc1db7319ecf3cdbc22cea181b644bR256).

No log lines have been added or removed and none have changed level.

This change is obviously rather intrusive, I will do my best to keep up with new commits to keep this conflict free. If there are conflicts, please dont close, I'd rather fix it. :)