### PR TITLE
Raw Iron WorldGen

### DIFF
--- a/Assets/Scripts/Models/WorldGenerator.cs
+++ b/Assets/Scripts/Models/WorldGenerator.cs
@@ -33,7 +33,7 @@ public class WorldGenerator {
                     if (Random.value >= asteroidRessourceChance)
                     {
                         int stackSize = Random.Range(asteroidRessourceMin, asteroidRessourceMax);
-                        Inventory inv = Inventory.New("Steel Plate", 50, stackSize);
+                        Inventory inv = Inventory.New("Raw Iron", 50, stackSize);
                         world.inventoryManager.PlaceInventory(t, inv);
                     }
                 }


### PR DESCRIPTION
This changes the world generation to now generate raw iron, which added in #245, instead of steel plates.

As such, this depends on #245. 