### PR TITLE
Restricting character movement to floors.

### DIFF
--- a/Assets/Scripts/Models/Tile.cs
+++ b/Assets/Scripts/Models/Tile.cs
@@ -85,6 +85,20 @@ public class Tile :IXmlSerializable, ISelectable
             //if (Type == TileType.Empty)
             //    return 0;	// 0 is unwalkable
 
+            if(Type == TileType.Empty)
+            {
+                Tile[] ns = GetNeighbours();
+
+                bool canMove = false;
+
+                foreach (Tile n in ns) // Loop through all the horizontal/vertical neighbours of the empty tile.
+                {
+                    canMove = canMove || (n != null && n.Type == TileType.Floor); // If the neighbour is a floor tile, set canMove to true.
+                }
+
+                return canMove ? baseTileMovementCost : 0f; // If canMove is true, return baseTileMovementCost, else, return 0f.
+            }
+
             if (furniture == null)
                 return baseTileMovementCost;
 


### PR DESCRIPTION
The character will only walk on floors and empty tiles that have at least one floor tile adjacent to them.

This was the easiest way I could think of to still allow placing floors.

This does mean the character will still 'jump' over gaps up to 2 tiles wide.