### PR TITLE
Tell .gitattributes that .txt files are text.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,3 +7,4 @@
 *.cs text
 *.xml text
 *.lua text
+*.txt text


### PR DESCRIPTION
Attempts to fix some end-of-line issues that were causing problems for everyone.