### PR TITLE
Added support for executing jobs on an adjacent tile.

### DIFF
--- a/Assets/Scripts/Controllers/BuildModeController.cs
+++ b/Assets/Scripts/Controllers/BuildModeController.cs
@@ -160,7 +160,8 @@ public class BuildModeController : MonoBehaviour
                     Tile.ChangeTileTypeJobComplete, 
                     0.1f, 
                     null, 
-                    false);
+                    false,
+                    true);
 
 
                 // FIXME: I don't like having to manually and explicitly set

--- a/Assets/Scripts/Models/Job.cs
+++ b/Assets/Scripts/Models/Job.cs
@@ -61,6 +61,11 @@ public class Job
 
     public Dictionary<string, Inventory> inventoryRequirements;
 
+    /// <summary>
+    /// If true, the work will be carried out on any adjacent tile of the target tile rather than on it.
+    /// </summary>
+    public bool adjacent;
+
     public Job(Tile tile, string jobObjectType, Action<Job> cbJobComplete, float jobTime, Inventory[] inventoryRequirements, bool jobRepeats = false)
     {
         this.tile = tile;
@@ -82,13 +87,14 @@ public class Job
         }
     }
 
-    public Job(Tile tile, TileType jobTileType, Action<Job> cbJobComplete, float jobTime, Inventory[] inventoryRequirements, bool jobRepeats = false)
+    public Job(Tile tile, TileType jobTileType, Action<Job> cbJobComplete, float jobTime, Inventory[] inventoryRequirements, bool jobRepeats = false, bool adjacent = false)
     {
         this.tile = tile;
         this.jobTileType = jobTileType;
         this.cbJobCompleted += cbJobComplete;
         this.jobTimeRequired = this.jobTime = jobTime;
         this.jobRepeats = jobRepeats;
+        this.adjacent = adjacent;
 
         cbJobWorkedLua = new List<string>();
         cbJobCompletedLua = new List<string>();

--- a/Assets/Scripts/Pathfinding/Path_AStar.cs
+++ b/Assets/Scripts/Pathfinding/Path_AStar.cs
@@ -5,8 +5,16 @@ using System.Linq;
 
 public class Path_AStar
 {
-
     Queue<Tile> path;
+
+    public Path_AStar(Queue<Tile> path)
+    {
+        if (path == null || !path.Any())
+        {
+            Logger.LogWarning("Created path with no tiles, is this intended?");
+        }
+        this.path = path;
+    }
 
     public Path_AStar(World world, Tile tileStart, Tile tileEnd, string objectType = null, int desiredAmount = 0, bool canTakeFromStockpile = false)
     {
@@ -252,4 +260,8 @@ public class Path_AStar
         return path.Last();
     }
 
+    public IEnumerable<Tile> Reverse()
+    {
+        return path == null ? null : path.Reverse();
+    }
 }


### PR DESCRIPTION
The character should walk to the tile, but stop beside it rather than on it.
This currently only happens when constructing floors.
Implemented by essentially removing the last tile from the found path.