### PR TITLE
Make Metal Smelter consistent with new Job prototype

### DIFF
--- a/Assets/StreamingAssets/LUA/Furniture.lua
+++ b/Assets/StreamingAssets/LUA/Furniture.lua
@@ -232,6 +232,7 @@ function MetalSmelter_UpdateAction(furniture, deltaTime)
 			nil,
 			0.4,
 			itemsDesired,
+			Job.JobPriority.Medium,
 			false
 			)
 			


### PR DESCRIPTION
Metal Smelter needs to include a priority. Set it at medium.