### PR TITLE
Change BaseType to TypeTag, and allow multiples

### DIFF
--- a/Assets/Scripts/Models/Furniture.cs
+++ b/Assets/Scripts/Models/Furniture.cs
@@ -184,7 +184,7 @@ public class Furniture : IXmlSerializable, ISelectable
     {
         this.objectType = other.objectType;
         this.Name = other.Name;
-        this.typeTags = other.typeTags;
+        this.typeTags = new HashSet<string>(other.typeTags);
         this.Description = other.Description;
         this.movementCost = other.movementCost;
         this.roomEnclosure = other.roomEnclosure;

--- a/Assets/Scripts/Models/Furniture.cs
+++ b/Assets/Scripts/Models/Furniture.cs
@@ -472,7 +472,7 @@ public class Furniture : IXmlSerializable, ISelectable
                     roomEnclosure = reader.ReadContentAsBoolean();
                     break;
                 case "CanReplaceFurniture":
-                    replaceableFurniture.Add(reader.GetAttribute("baseType").ToString());
+                    replaceableFurniture.Add(reader.GetAttribute("typeTag").ToString());
                     break;
                 case "DragType":
                     reader.Read();

--- a/Assets/Scripts/Models/Furniture.cs
+++ b/Assets/Scripts/Models/Furniture.cs
@@ -97,7 +97,7 @@ public class Furniture : IXmlSerializable, ISelectable
     }
 	
     // This is the generic type of object this is, allowing things to interact with it based on it's generic type
-    private string baseType;
+    private HashSet<string> typeTags;
 
     private string _Name = null;
 
@@ -172,6 +172,7 @@ public class Furniture : IXmlSerializable, ISelectable
         updateActions = new List<string>();
         furnParameters = new Dictionary<string, float>();
         jobs = new List<Job>();
+        typeTags = new HashSet<string>();
         this.funcPositionValidation = this.DEFAULT__IsValidPosition;
         this.Height = 1;
         this.Width = 1;
@@ -183,7 +184,7 @@ public class Furniture : IXmlSerializable, ISelectable
     {
         this.objectType = other.objectType;
         this.Name = other.Name;
-        this.baseType = other.baseType;
+        this.typeTags = other.typeTags;
         this.Description = other.Description;
         this.movementCost = other.movementCost;
         this.roomEnclosure = other.roomEnclosure;
@@ -345,7 +346,7 @@ public class Furniture : IXmlSerializable, ISelectable
                 {
                     for (int i = 0; i < ReplaceableFurniture.Count; i++)
                     {
-                        if (t2.furniture.baseType == ReplaceableFurniture[i])
+                        if (t2.furniture.HasTypeTag(ReplaceableFurniture[i]))
                         {
                             isReplaceable = true;
                         }
@@ -442,9 +443,9 @@ public class Furniture : IXmlSerializable, ISelectable
                     reader.Read();
                     Name = reader.ReadContentAsString();
                     break;
-                case "BaseType":
+                case "TypeTag":
                     reader.Read();
-                    baseType = reader.ReadContentAsString();
+                    typeTags.Add(reader.ReadContentAsString());
                     break;
                 case "Description":
                     reader.Read();
@@ -721,6 +722,13 @@ public class Furniture : IXmlSerializable, ISelectable
     public Tile GetSpawnSpotTile()
     {
         return World.current.GetTileAt(tile.X + (int)jobSpawnSpotOffset.x, tile.Y + (int)jobSpawnSpotOffset.y);
+    }
+
+    // Returns true if furniture has typeTag, though simple, the intent is to separate the interaction with
+    //  the Furniture's typeTags from the implementation.
+    public bool HasTypeTag(string typeTag)
+    {
+        return typeTags.Contains(typeTag);
     }
 
     #region ISelectableInterface implementation

--- a/Assets/StreamingAssets/Data/Furniture.xml
+++ b/Assets/StreamingAssets/Data/Furniture.xml
@@ -3,7 +3,7 @@
     <Furniture objectType="furn_SteelWall">
         <Name>Basic Wall</Name>
 		<Description>This is a basic wall.</Description>
-		<BaseType>Wall</BaseType>
+		<TypeTag>Wall</TypeTag>
         <MovementCost>0</MovementCost>
         <Width>1</Width>
         <Height>1</Height>
@@ -28,13 +28,13 @@
     <Furniture objectType="Door">
         <Name>Door</Name>
 		<Description>A door that characters can walk through.</Description>
-		<BaseType>Door</BaseType>
+		<TypeTag>Door</TypeTag>
         <MovementCost>1</MovementCost>
         <Width>1</Width>
         <Height>1</Height>
         <LinksToNeighbours>false</LinksToNeighbours>
         <EnclosesRooms>true</EnclosesRooms>
-        <CanReplaceFurniture baseType="Wall" />
+        <CanReplaceFurniture typeTag="Wall" />
 
 
         <Params>
@@ -68,7 +68,7 @@
         <Height>1</Height>
         <LinksToNeighbours>false</LinksToNeighbours>
         <EnclosesRooms>true</EnclosesRooms>
-        <CanReplaceFurniture baseType="Wall" />
+        <CanReplaceFurniture typeTag="Wall" />
 
 
         <Params>
@@ -98,7 +98,7 @@
 	<Furniture objectType="Stockpile">
 		<Name>Stockpile</Name>
 		<Description>Characters will brings inventory here for storage.</Description>
-		<BaseType>Storage</BaseType>
+		<TypeTag>Storage</TypeTag>
         <MovementCost>1</MovementCost>
         <LinksToNeighbours>true</LinksToNeighbours>
 
@@ -114,7 +114,7 @@
 	<Furniture objectType="Oxygen Generator">
 		<Name>Oxygen Generator</Name>
 		<Description>Create O2 in the room in which it is built.</Description>
-		<BaseType>Generator</BaseType>
+		<TypeTag>Generator</TypeTag>
         <MovementCost>10</MovementCost>
         <Width>2</Width>
         <Height>2</Height>
@@ -140,7 +140,7 @@
 	<Furniture objectType="Mining Drone Station">
 		<Name>Mining Drone Station</Name>
 		<Description>Creates Steel Plates when worked by a character.</Description>
-		<BaseType>Workstation</BaseType>
+		<TypeTag>Workstation</TypeTag>
         <MovementCost>1</MovementCost>
         <Width>3</Width>
         <Height>3</Height>
@@ -161,7 +161,7 @@
 
 	<Furniture objectType="Power Generator">
 	<Name>Power Generator</Name>
-	<BaseType>Generator</BaseType>
+	<TypeTag>Generator</TypeTag>
 	<MovementCost>10</MovementCost>
 	<Width>2</Width>
 	<Height>2</Height>


### PR DESCRIPTION
Per further discussion in #31, BaseType was changed to TypeTag (to more closely match new functionality), and now allows multiples (previously it would be set to the last one found). Added bool HasTypeTag(String) method to separate usage from implementation (future-proofing for any potential changes in the future).