### PR TITLE
A few pathfinding tweaks to increase efficiency a little bit.

### DIFF
--- a/Assets/Scripts/Pathfinding/Path_AStar.cs
+++ b/Assets/Scripts/Pathfinding/Path_AStar.cs
@@ -67,23 +67,15 @@ public class Path_AStar
 		OpenSet.Add( start );
 */
 
-        SimplePriorityQueue<Path_Node<Tile>> OpenSet = new SimplePriorityQueue<Path_Node<Tile>>();
+        PathfindingPriorityQueue<Path_Node<Tile>> OpenSet = new PathfindingPriorityQueue<Path_Node<Tile>>();
         OpenSet.Enqueue(start, 0);
 
         Dictionary<Path_Node<Tile>, Path_Node<Tile>> Came_From = new Dictionary<Path_Node<Tile>, Path_Node<Tile>>();
 
         Dictionary<Path_Node<Tile>, float> g_score = new Dictionary<Path_Node<Tile>, float>();
-        foreach (Path_Node<Tile> n in nodes.Values)
-        {
-            g_score[n] = Mathf.Infinity;
-        }
         g_score[start] = 0;
 
         Dictionary<Path_Node<Tile>, float> f_score = new Dictionary<Path_Node<Tile>, float>();
-        foreach (Path_Node<Tile> n in nodes.Values)
-        {
-            f_score[n] = Mathf.Infinity;
-        }
         f_score[start] = heuristic_cost_estimate(start, goal);
 
         while (OpenSet.Count > 0)
@@ -135,15 +127,7 @@ public class Path_AStar
                 g_score[neighbor] = tentative_g_score;
                 f_score[neighbor] = g_score[neighbor] + heuristic_cost_estimate(neighbor, goal);
 
-                if (OpenSet.Contains(neighbor) == false)
-                {
-                    OpenSet.Enqueue(neighbor, f_score[neighbor]);
-                }
-                else
-                {
-                    OpenSet.UpdatePriority(neighbor, f_score[neighbor]);
-                }
-
+                OpenSet.EnqueueOrUpdate(neighbor, f_score[neighbor]);
             } // foreach neighbour
         } // while
 

--- a/Assets/Scripts/Pathfinding/PathfindingPriorityQueue.cs
+++ b/Assets/Scripts/Pathfinding/PathfindingPriorityQueue.cs
@@ -22,7 +22,7 @@ public class PathfindingPriorityQueue<T>
     protected Dictionary<T, WrappedNode> _mapDataToWrappedNode;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="PriorityQueueWrapper`1"/> class.
+    /// Initializes a new instance of the <see cref="PathfindingPriorityQueue`1"/> class.
     /// </summary>
     /// <param name="startingSize">The starting size.</param>
     public PathfindingPriorityQueue(int startingSize = 10)
@@ -42,7 +42,7 @@ public class PathfindingPriorityQueue<T>
         public readonly T data;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="PriorityQueueWrapper`1+WrappedNode"/> class.
+        /// Initializes a new instance of the <see cref="PathfindingPriorityQueue`1+WrappedNode"/> class.
         /// </summary>
         /// <param name="data">The data that this WrappedNode represents in the queue.</param>
         public WrappedNode(T data)

--- a/Assets/Scripts/Pathfinding/PathfindingPriorityQueue.cs
+++ b/Assets/Scripts/Pathfinding/PathfindingPriorityQueue.cs
@@ -1,0 +1,134 @@
+﻿using UnityEngine;
+using System.Collections.Generic;
+using Priority_Queue;
+using System;
+
+/// <summary>
+/// Wraps the FastPriorityQueue class so that it's both easy-to-use,
+/// and faster than SimplePriorityQueue (which sports an O(n) Contains
+/// and an O(n) UpdatePriority -- not exactly ideal).
+/// </summary>
+public class PathfindingPriorityQueue<T>
+{
+    /// <summary>
+    /// The underlying FastPriorityQueue instance.
+    /// </summary>
+    protected FastPriorityQueue<WrappedNode> _underlyingQueue;
+
+    /// <summary>
+    /// The map between data and WrappedNodes.
+    /// Used to make operations like Contains and UpdatePriority more efficient.
+    /// </summary>
+    protected Dictionary<T, WrappedNode> _mapDataToWrappedNode;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PriorityQueueWrapper`1"/> class.
+    /// </summary>
+    /// <param name="startingSize">The starting size.</param>
+    public PathfindingPriorityQueue(int startingSize = 10)
+    {
+        _underlyingQueue = new FastPriorityQueue<WrappedNode>(startingSize);
+        _mapDataToWrappedNode = new Dictionary<T, WrappedNode>();
+    }
+
+    /// <summary>
+    /// A version of a PriorityQueueNode that contains a reference to data.
+    /// </summary>
+    protected class WrappedNode : FastPriorityQueueNode
+    {
+        /// <summary>
+        /// The data that this WrappedNode represents in the queue.
+        /// </summary>
+        public readonly T data;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PriorityQueueWrapper`1+WrappedNode"/> class.
+        /// </summary>
+        /// <param name="data">The data that this WrappedNode represents in the queue.</param>
+        public WrappedNode(T data)
+        {
+            this.data = data;
+        }
+    }
+
+    /// <summary>
+    /// Checks whether the PQ contains the specified data.
+    /// Uses a Dictionary for lookup, so it should only take O(1).
+    /// </summary>
+    /// <param name="data">Data.</param>
+    public bool Contains(T data)
+    {
+        return _mapDataToWrappedNode.ContainsKey(data);
+    }
+
+    /// <summary>
+    /// Enqueue the specified data and priority.
+    /// If the data already exists in the queue, it updates the priority instead.
+    /// Should take O(log n) -- O(1) amortized for the resizing, and O(log n) for the insertion.
+    /// </summary>
+    /// <param name="data">The data to be enqueued.</param>
+    /// <param name="priority">The priority of the data.</param>
+    public void Enqueue(T data, float priority)
+    {
+        if (_mapDataToWrappedNode.ContainsKey(data))
+        {
+            throw new InvalidOperationException("Can't re-enqueue a node that's already enqueued.");
+        }
+
+        if (_underlyingQueue.Count == _underlyingQueue.MaxSize)
+        {
+            _underlyingQueue.Resize(2 * _underlyingQueue.MaxSize + 1);
+        }
+
+        WrappedNode toAdd = new WrappedNode(data);
+        _underlyingQueue.Enqueue(toAdd, priority);
+        _mapDataToWrappedNode[data] = toAdd;
+    }
+
+    /// <summary>
+    /// Updates the priority associated with the given data.
+    /// </summary>
+    /// <param name="data">The data whose priority needs updating.</param>
+    /// <param name="priority">The new priority value.</param>
+    public void UpdatePriority(T data, float priority)
+    {
+        WrappedNode node = _mapDataToWrappedNode[data];
+        _underlyingQueue.UpdatePriority(node, priority);
+    }
+
+    /// <summary>
+    /// Enqueues the or update.
+    /// </summary>
+    /// <param name="data">Data.</param>
+    /// <param name="priority">Priority.</param>
+    public void EnqueueOrUpdate(T data, float priority)
+    {
+        if (_mapDataToWrappedNode.ContainsKey(data))
+            UpdatePriority(data, priority);
+        else
+            Enqueue(data, priority);
+    }
+
+    /// <summary>
+    /// Pops the item with the lowest priority off of the queue.
+    /// </summary>
+    public T Dequeue()
+    {
+        WrappedNode popped = _underlyingQueue.Dequeue();
+        _mapDataToWrappedNode.Remove(popped.data);
+        return popped.data;
+    }
+
+    /// <summary>
+    /// Returns the number of items in the queue.
+    /// </summary>
+    /// <value>The count.</value>
+    public int Count
+    {
+        get
+        {
+            return _underlyingQueue.Count;
+        }
+    }
+}
+

--- a/Assets/Scripts/Pathfinding/PathfindingPriorityQueue.cs
+++ b/Assets/Scripts/Pathfinding/PathfindingPriorityQueue.cs
@@ -72,7 +72,8 @@ public class PathfindingPriorityQueue<T>
     {
         if (_mapDataToWrappedNode.ContainsKey(data))
         {
-            throw new InvalidOperationException("Can't re-enqueue a node that's already enqueued.");
+            Logger.LogError("Priority Queue can't re-enqueue a node that's already enqueued.");
+            return;
         }
 
         if (_underlyingQueue.Count == _underlyingQueue.MaxSize)

--- a/Assets/Scripts/Pathfinding/PathfindingPriorityQueue.cs.meta
+++ b/Assets/Scripts/Pathfinding/PathfindingPriorityQueue.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 4c09b20521b824f67bc97a11523c36c9
+timeCreated: 1471654158
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
While looking through the pathfinding code, I discovered that the SimplePriorityQueue being used by the pathfinding system has worst-case O(n) Contains and UpdatePriority, both of which are used frequently by the pathfinding system (resulting in a worst-case O(n^2) algorithm, at least in theory). FastPriorityQueue has O(1) Contains and O(log n) UpdatePriority, but the process of wrapping SimplePriorityQueue around it introduces a fair amount of overhead. So I wrote a variant of the SimplePriorityQueue class that uses Dictionaries to speed things up a bit. Pathfinding is still a bottleneck, but hopefully this can make the neck a little wider?

I also removed the lines initializing all of the f_scores and g_scores, since the process that the algorithm goes through adds f_scores and g_scores for everything in the open set and closed set, and they're not accessed for anything outside of those sets. (And initializing them for all 10000 tiles can be kind of waste of time if you're just trying to move a few tiles over.)