### PR TITLE
Fixed bug in save dialog from the delete button

### DIFF
--- a/Assets/UI/DialogListItem.cs
+++ b/Assets/UI/DialogListItem.cs
@@ -21,10 +21,13 @@ public class DialogListItem : MonoBehaviour, IPointerClickHandler
 
 		inputField.text = fileName;
 		GameObject go = GameObject.FindGameObjectWithTag("DeleteButton");
-		go.GetComponent<Image>().color = new Color(255, 255, 255, 255);
-		Component text = transform.GetComponentInChildren<Text>();
-		GetComponentInParent<DialogBoxLoadGame>().pressedDelete = true;
-		GetComponentInParent<DialogBoxLoadGame>().SetFileItem(text);
+        if (go != null)
+        {
+            go.GetComponent<Image>().color = new Color(255, 255, 255, 255);
+            Component text = transform.GetComponentInChildren<Text>();
+            GetComponentInParent<DialogBoxLoadGame>().pressedDelete = true;
+            GetComponentInParent<DialogBoxLoadGame>().SetFileItem(text);
+        }
 
         if (eventData.clickCount > 1)
         {


### PR DESCRIPTION
Delete button does not show in the save dialog. By design or by mistake of #194. I added a quick fix to check if GO is found. A proper refactor of the delete button might be in order.