### PR TITLE
Missing localization keys are now only logged once.

### DIFF
--- a/Assets/Scripts/Localization/LocalizationTable.cs
+++ b/Assets/Scripts/Localization/LocalizationTable.cs
@@ -168,6 +168,7 @@ namespace ProjectPorcupine.Localization
                         {
                             return key + " " + additionalValues[0];
                         }
+
                         return key;
                     case FallbackMode.ReturnEnglish:
                         return GetLocalization(key, FallbackMode.ReturnKey, "en_US", additionalValues);

--- a/Assets/Scripts/Localization/LocalizationTable.cs
+++ b/Assets/Scripts/Localization/LocalizationTable.cs
@@ -70,8 +70,10 @@ namespace ProjectPorcupine.Localization
 
             // The key that the loop assembled.
             string currentKey = "";
+
             // The value that the loop assembled.
             string currentValue = "";
+
             // Is the loop already done with figuring out the key?
             bool searchingValue = false;
 
@@ -82,8 +84,10 @@ namespace ProjectPorcupine.Localization
 
                 // Set searching value to false.
                 searchingValue = false;
+
                 // Set the key to an empty string.
                 currentKey = "";
+
                 // Set the value to an empty string.
                 currentValue = "";
 

--- a/Assets/Scripts/Localization/LocalizationTable.cs
+++ b/Assets/Scripts/Localization/LocalizationTable.cs
@@ -16,15 +16,15 @@ namespace ProjectPorcupine.Localization
             ReturnKey, ReturnEmpty, ReturnEnglish
         }
 
-        //The dictionary that stores all the localization values.
-        static Dictionary<string, string> localizationTable = new Dictionary<string, string>();
-
         //The current language. This will be automatically be set by the LocalizationLoader.
         //Default is English.
         public static string currentLanguage = "en_US";
 
         //Used by the LocalizationLoader to ensure that the localization files are only loaded once.
         public static bool initialized = false;
+
+        //The dictionary that stores all the localization values.
+        static Dictionary<string, string> localizationTable = new Dictionary<string, string>();
 
         //List with all languages.
         static List<string> registeredLanguages = new List<string>();

--- a/Assets/Scripts/Localization/LocalizationTable.cs
+++ b/Assets/Scripts/Localization/LocalizationTable.cs
@@ -94,9 +94,11 @@ namespace ProjectPorcupine.Localization
                 // Go through each char contained in this line.
                 foreach (char c in chars)
                 {
-                    if (!searchingValue) // Check if the loop is searching for a value.
+                    // Check if the loop is searching for a value.
+                    if (!searchingValue)
                     {
-                        if (c != '=') // Check if the current char is an '=', if not, add the char to the key.
+                        // Check if the current char is an '=', if not, add the char to the key.
+                        if (c != '=')
                         {
                             // Add the char to the key.
                             currentKey += c;

--- a/Assets/Scripts/Localization/LocalizationTable.cs
+++ b/Assets/Scripts/Localization/LocalizationTable.cs
@@ -77,7 +77,7 @@ namespace ProjectPorcupine.Localization
             // Is the loop already done with figuring out the key?
             bool searchingValue = false;
 
-            foreach(string line in lines)
+            foreach (string line in lines)
             {
                 // Reuse the array (for reducing RAM usage).
                 chars = line.ToCharArray();

--- a/Assets/Scripts/Localization/LocalizationTable.cs
+++ b/Assets/Scripts/Localization/LocalizationTable.cs
@@ -16,17 +16,17 @@ namespace ProjectPorcupine.Localization
             ReturnKey, ReturnEmpty, ReturnEnglish
         }
 
-        //The current language. This will be automatically be set by the LocalizationLoader.
-        //Default is English.
+        // The current language. This will be automatically be set by the LocalizationLoader.
+        // Default is English.
         public static string currentLanguage = "en_US";
 
-        //Used by the LocalizationLoader to ensure that the localization files are only loaded once.
+        // Used by the LocalizationLoader to ensure that the localization files are only loaded once.
         public static bool initialized = false;
 
-        //The dictionary that stores all the localization values.
+        // The dictionary that stores all the localization values.
         static Dictionary<string, string> localizationTable = new Dictionary<string, string>();
 
-        //List with all languages.
+        // List with all languages.
         static List<string> registeredLanguages = new List<string>();
 
         // Keeps track of what keys we've already logged are missing.
@@ -61,56 +61,56 @@ namespace ProjectPorcupine.Localization
          */
         public static void LoadLocalizationFile(string path, string localizationCode)
         {
-            //Read the contents of the file. This might throw an exception!
+            // Read the contents of the file. This might throw an exception!
             string[] lines = File.ReadAllLines(path);
 
-            //Create an empty char array outside the foreach loop, for optimization reasons.
-            //This is used as a storage for the chars in the line.
+            // Create an empty char array outside the foreach loop, for optimization reasons.
+            // This is used as a storage for the chars in the line.
             char[] chars;
 
-            //The key that the loop assembled.
+            // The key that the loop assembled.
             string currentKey = "";
-            //The value that the loop assembled.
+            // The value that the loop assembled.
             string currentValue = "";
-            //Is the loop already done with figuring out the key?
+            // Is the loop already done with figuring out the key?
             bool searchingValue = false;
 
             foreach(string line in lines)
             {
-                //Reuse the array (for reducing RAM usage).
+                // Reuse the array (for reducing RAM usage).
                 chars = line.ToCharArray();
 
-                //Set searching value to false.
+                // Set searching value to false.
                 searchingValue = false;
-                //Set the key to an empty string.
+                // Set the key to an empty string.
                 currentKey = "";
-                //Set the value to an empty string.
+                // Set the value to an empty string.
                 currentValue = "";
 
-                //Go through each char contained in this line.
+                // Go through each char contained in this line.
                 foreach (char c in chars)
                 {
-                    if (!searchingValue) //Check if the loop is searching for a value.
+                    if (!searchingValue) // Check if the loop is searching for a value.
                     {
-                        if (c != '=') //Check if the current char is an '=', if not, add the char to the key.
+                        if (c != '=') // Check if the current char is an '=', if not, add the char to the key.
                         {
-                            //Add the char to the key.
+                            // Add the char to the key.
                             currentKey += c;
                         }
                         else
                         {
-                            //The char is an '=', set searchingValue to true and ignore the current char.
+                            // The char is an '=', set searchingValue to true and ignore the current char.
                             searchingValue = true;
                         }
                     }
                     else
                     {
-                        //The loop is searching for a value. Add the current char, regardless of what it is.
+                        // The loop is searching for a value. Add the current char, regardless of what it is.
                         currentValue += c;
                     }
                 }
 
-                //Add the new key+value to the localization table.
+                // Add the new key+value to the localization table.
                 localizationTable.Add(localizationCode + "_" + currentKey, currentValue);
             }
 
@@ -132,7 +132,7 @@ namespace ProjectPorcupine.Localization
          */
         public static string GetLocalization(string key, params string[] additionalValues)
         {
-            //Return the localization of the advanced method.
+            // Return the localization of the advanced method.
             return GetLocalization(key, FallbackMode.ReturnEnglish, currentLanguage, additionalValues);
         }
 


### PR DESCRIPTION
As discussed in #247.

Now in hindsight this turned out rather simple and maybe I should have left it for a beginners task. But it does increase performance by not spamming log with the same message.