### PR TITLE
Added functionality to remove the designation of furniture

### DIFF
--- a/Assets/Scripts/Controllers/BuildModeController.cs
+++ b/Assets/Scripts/Controllers/BuildModeController.cs
@@ -184,6 +184,10 @@ public class BuildModeController : MonoBehaviour
             {
                 t.furniture.Deconstruct();
             }
+            else if (t.pendingBuildJob != null)
+            {
+                t.pendingBuildJob.CancelJob();
+            }
 
         }
         else


### PR DESCRIPTION
If you had a bunch of jobs, you could not remove any of the designations