### PR TITLE
Issue #303 - Allow Airlocks to replace Doors

### DIFF
--- a/Assets/StreamingAssets/Data/Furniture.xml
+++ b/Assets/StreamingAssets/Data/Furniture.xml
@@ -69,6 +69,7 @@
         <LinksToNeighbours>false</LinksToNeighbours>
         <EnclosesRooms>true</EnclosesRooms>
         <CanReplaceFurniture typeTag="Wall" />
+        <CanReplaceFurniture typeTag="Door" />
 
 
         <Params>


### PR DESCRIPTION
Fixes #303.
Ability to upgrade doors to Airlocks is added.