### PR TITLE
Lock inventory

### DIFF
--- a/Assets/Scripts/Models/Character.cs
+++ b/Assets/Scripts/Models/Character.cs
@@ -236,7 +236,7 @@ public class Character : IXmlSerializable, ISelectable
             // Are we standing on a tile with goods that are desired by the job?
             Debug.Log("Standing on Tile check");
             if (CurrTile.inventory != null &&
-                myJob.DesiresInventoryType(CurrTile.inventory) > 0 &&
+                myJob.DesiresInventoryType(CurrTile.inventory) > 0 && !CurrTile.inventory.isLocked &&
                 (myJob.canTakeFromStockpile || CurrTile.furniture == null || CurrTile.furniture.IsStockpile() == false))
             {
                 // Pick up the stuff!

--- a/Assets/Scripts/Models/Inventory.cs
+++ b/Assets/Scripts/Models/Inventory.cs
@@ -46,6 +46,9 @@ public class Inventory : IXmlSerializable, ISelectable
     public Tile tile;
     public Character character;
 
+    //Should this inventory be allowed to be picked up for completing a job?
+    public bool isLocked = false;
+
     public Inventory()
     {
 		
@@ -68,6 +71,7 @@ public class Inventory : IXmlSerializable, ISelectable
         objectType = other.objectType;
         maxStackSize = other.maxStackSize;
         stackSize = other.stackSize;
+        isLocked = other.isLocked;
     }
 
     public virtual Inventory Clone()

--- a/Assets/Scripts/Models/InventoryManager.cs
+++ b/Assets/Scripts/Models/InventoryManager.cs
@@ -173,6 +173,12 @@ public class InventoryManager
         {
             return null;
         }
+        
+        //We shouldn't search if all inventories are locked.
+        if (inventories[objectType].TrueForAll(i => i.tile != null && i.tile.furniture != null && i.tile.inventory.isLocked))
+        {
+            return null;
+        }
 
         // Test that there is at least one stack on the floor, otherwise the
         // search below might cause a full map search for nothing.

--- a/Assets/Scripts/Pathfinding/Path_AStar.cs
+++ b/Assets/Scripts/Pathfinding/Path_AStar.cs
@@ -95,9 +95,9 @@ public class Path_AStar
             {
                 // We don't have a POSITIONAL goal, we're just trying to find
                 // some king of inventory.  Have we reached it?
-                if (current.data.inventory != null && current.data.inventory.objectType == objectType)
+                if (current.data.inventory != null && current.data.inventory.objectType == objectType && !current.data.inventory.isLocked)
                 {
-                    // Type is correct
+                    // Type is correct and we are allowed to pick it up
                     if (canTakeFromStockpile || current.data.furniture == null || current.data.furniture.IsStockpile() == false)
                     {
                         // Stockpile status is fine

--- a/Assets/StreamingAssets/LUA/Furniture.lua
+++ b/Assets/StreamingAssets/LUA/Furniture.lua
@@ -270,7 +270,7 @@ function MetalSmelter_JobComplete(j)
 	for k, inv in pairs(j.inventoryRequirements) do
 		if(inv.stackSize > 0) then
 			World.current.inventoryManager.PlaceInventory(spawnSpot, inv)
-
+			spawnSpot.inventory.isLocked = true
 			return
 		end
 	end


### PR DESCRIPTION
I added the ability for inventories to be "locked". This basically means that inventories that are locked can't be picked up for completing jobs. This is a fix for #339.