### PR TITLE
Fixed typo get -> git in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ If you would like to contribute to this project by modifying/adding to the progr
 6. [optional]  It is recommended that you rebase your branch on top of the latest master, to minimize excess commit messages.
  * From the command line:  
      `git fetch upstream master`  
-     `get rebase upstream/master`  
+     `git rebase upstream/master`  
 6. Make your changes.
  * Avoid making changes to more files than necessary for your feature (i.e. refrain from combining your "real" pull request with incidental bug fixes). This will simplify the merging process and make your changes clearer.
  * Very much avoid making changes to the Unity-specific files, like the scene and the project settings unless absolutely necessary. Changes here are very likely to cause difficult to merge conflicts. Work in code as much as possible. (We will be trying to change the UI to be more code-driven in the future.) Making changes to prefabs should generally be safe -- but create a copy of the main scene and work there instead (then delete your copy of the scene before committing).


### PR DESCRIPTION
Just copy pasted commands to my terminal and noticed at line 17 there was an typo.
This PR fixes that typo get -> git.