### PR TITLE
made construction buttons toggles

### DIFF
--- a/Assets/Scripts/UI/MenuController.cs
+++ b/Assets/Scripts/UI/MenuController.cs
@@ -38,6 +38,11 @@ public class MenuController : MonoBehaviour {
 		floorMenu.SetActive (false);
 	}
 
+    //toggles whether menu is active
+    public void ToggleMenu(GameObject menu) {
+        menu.SetActive(!menu.activeSelf);
+    }
+
 	void Update() {
 		if (Input.GetKey (KeyCode.Escape)) {
 			DeactivateAll ();

--- a/Assets/_SCENE_.unity
+++ b/Assets/_SCENE_.unity
@@ -3515,26 +3515,15 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 1567433674}
-        m_MethodName: DeactivateSubs
-        m_Mode: 1
+        m_MethodName: ToggleMenu
+        m_Mode: 2
         m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_ObjectArgument: {fileID: 1376947278}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.GameObject, UnityEngine
           m_IntArgument: 0
           m_FloatArgument: 0
           m_StringArgument: 
           m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: 1376947278}
-        m_MethodName: SetActive
-        m_Mode: 6
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 1
         m_CallState: 2
     m_TypeName: UnityEngine.UI.Button+ButtonClickedEvent, UnityEngine.UI, Version=1.0.0.0,
       Culture=neutral, PublicKeyToken=null
@@ -14085,22 +14074,11 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 1567433674}
-        m_MethodName: DeactivateSubs
-        m_Mode: 1
+        m_MethodName: ToggleMenu
+        m_Mode: 2
         m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 12345
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: 1046262019}
-        m_MethodName: SetActive
-        m_Mode: 6
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_ObjectArgument: {fileID: 1046262019}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.GameObject, UnityEngine
           m_IntArgument: 0
           m_FloatArgument: 0
           m_StringArgument: 


### PR DESCRIPTION
Issue:  the construction menu has buttons for furniture and floor which yield more buttons when clicked. However, when you click furniture again, the furniture buttons don't go away.

Fix: turned furniture and floor buttons into toggles so their menus can be hidden by pressing them again

note: this required scene modification to change the buttons OnClick targets

![toggle](https://cloud.githubusercontent.com/assets/7608114/17831994/623bd054-66c6-11e6-8cd7-7a9dcff3f488.gif)
