### PR TITLE
Fixed link to video tutorial in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ If you would like to contribute to this project by modifying/adding to the progr
     `git push origin my-feature-branch-name`  
 8. Make a "Pull Request" from your branch here on Github.
   * Include screenshots demonstrating your change if applicable.
-9. For a video tutorial, please see: https://www.youtube.com/watch?v=-R2fl17eEpwI
+9. For a video tutorial, please see: https://www.youtube.com/watch?v=R2fl17eEpwI
 
 # Resolving Merge Conflicts
 


### PR DESCRIPTION
Current link is broken and leading to this:

![82ba70fd1e754a719878ceeb391ad2ba](https://cloud.githubusercontent.com/assets/15272275/17832374/664a5c58-670a-11e6-8f23-b0e5371937ce.png)

I fixed it to the real link.