### PR TITLE
Fixed O2Gen producing O2 after powerloss

### DIFF
--- a/Assets/Scripts/Models/Furniture.cs
+++ b/Assets/Scripts/Models/Furniture.cs
@@ -384,7 +384,10 @@ public class Furniture : IXmlSerializable, ISelectable
         {
             if (World.current.powerSystem.RequestPower(this) == true)
             {
-                return true;
+                if (World.current.powerSystem.PowerLevel > 0)
+                    return true;
+                else
+                    return false;                
             }
             else
             {

--- a/Assets/Scripts/Models/Furniture.cs
+++ b/Assets/Scripts/Models/Furniture.cs
@@ -384,10 +384,7 @@ public class Furniture : IXmlSerializable, ISelectable
         {
             if (World.current.powerSystem.RequestPower(this) == true)
             {
-                if (World.current.powerSystem.PowerLevel > 0)
-                    return true;
-                else
-                    return false;                
+                return World.current.powerSystem.PowerLevel > 0;
             }
             else
             {


### PR DESCRIPTION
Bug Fix  - O2Gen would produce O2 when the PowerLevel dropped to 0 or below