### PR TITLE
Enabled StyleCop rule enforcing file headers.

### DIFF
--- a/Settings.StyleCop
+++ b/Settings.StyleCop
@@ -2,11 +2,6 @@
   <Analyzers>
     <Analyzer AnalyzerId="StyleCop.CSharp.DocumentationRules">
       <Rules>
-        <Rule Name="FileMustHaveHeader">
-          <RuleSettings>
-            <BooleanProperty Name="Enabled">False</BooleanProperty>
-          </RuleSettings>
-        </Rule>
         <Rule Name="ElementsMustBeDocumented">
           <RuleSettings>
             <BooleanProperty Name="Enabled">False</BooleanProperty>
@@ -198,11 +193,6 @@
           </RuleSettings>
         </Rule>
         <Rule Name="FileHeaderMustShowCopyright">
-          <RuleSettings>
-            <BooleanProperty Name="Enabled">False</BooleanProperty>
-          </RuleSettings>
-        </Rule>
-        <Rule Name="FileHeaderMustHaveCopyrightText">
           <RuleSettings>
             <BooleanProperty Name="Enabled">False</BooleanProperty>
           </RuleSettings>


### PR DESCRIPTION
Specifically SA1633 and SA1635.

Now that #287 has been merged.

Maybe one day the list of deviations in this file will reach zero. :)