### PR TITLE
[Bugfix] Prevent both floor and furn menu being open at the same time

### DIFF
--- a/Assets/Scripts/UI/MenuController.cs
+++ b/Assets/Scripts/UI/MenuController.cs
@@ -40,6 +40,7 @@ public class MenuController : MonoBehaviour {
 
     //toggles whether menu is active
     public void ToggleMenu(GameObject menu) {
+        DeactivateSubs();
         menu.SetActive(!menu.activeSelf);
     }
 


### PR DESCRIPTION
My last PR #400 introduced a bug where both the "build furniture" and "build floor" menus could be open at the same time. This PR fixes that issue.