### PR TITLE
Power System - Fixed supply reduction issue

### DIFF
--- a/Assets/Scripts/Models/Furniture.cs
+++ b/Assets/Scripts/Models/Furniture.cs
@@ -213,10 +213,6 @@ public class Furniture : IXmlSerializable, ISelectable
         {
             World.current.powerSystem.RegisterPowerSupply(this);
         }
-        else if(powerValue < 0)
-        {
-            World.current.powerSystem.RegisterPowerConsumer(this);
-        }
 
         if (other.funcPositionValidation != null)
             this.funcPositionValidation = (Func<Tile, bool>)other.funcPositionValidation.Clone();
@@ -388,8 +384,7 @@ public class Furniture : IXmlSerializable, ISelectable
             }
             else
             {
-                World.current.powerSystem.RegisterPowerConsumer(this);
-                return false;
+                return (World.current.powerSystem.RegisterPowerConsumer(this));
             }
         }
 

--- a/Assets/Scripts/Models/PowerSystem.cs
+++ b/Assets/Scripts/Models/PowerSystem.cs
@@ -40,26 +40,32 @@ public class PowerSystem {
     public void RemovePowerSupply(Furniture furn)
     {
         powerGenerators.Remove(furn);
+        powerConsumers = new List<Furniture>();
         CalculatePower();
     }
 
-    public void RegisterPowerConsumer(Furniture furn)
+    public bool RegisterPowerConsumer(Furniture furn)
     {
         if (PowerLevel + furn.powerValue < 0)
         {
-            return;
+            return false;
         }
 
         powerConsumers.Add(furn);
         CalculatePower();
 
         furn.cbOnRemoved += RemovePowerConsumer;
+
+        return true;
     }
 
     public void RemovePowerConsumer(Furniture furn)
     {
         powerGenerators.Remove(furn);
         CalculatePower();
+
+        furn.cbOnRemoved -= RemovePowerConsumer;
+
     }
 
 
@@ -69,9 +75,9 @@ public class PowerSystem {
         {
             return true;
         }
-        
         return false;
     }
+    
 
     void CalculatePower()
     {


### PR DESCRIPTION
Fixed issue where reducing the supply of power did not cause furnitures to run out of power if they had already been "powered" by the system. Now when supply is reduced the consumers must re-register for power.

As part of this the registration process has been improved and should now only be called when the furniture first needs to use power or when its waiting for power to become available. As soon as power is available it will then be able to run rather then waiting till then next update.