### PR TITLE
Furniture tab tooltip #507

### DIFF
--- a/Assets/Scripts/UI/MouseOverFurnitureTypeText.cs
+++ b/Assets/Scripts/UI/MouseOverFurnitureTypeText.cs
@@ -58,8 +58,5 @@ public class MouseOverFurnitureTypeText : MonoBehaviour
             myText.text = "";
         }
 
-       
-
-
     }
 }

--- a/Assets/Scripts/UI/MouseOverFurnitureTypeText.cs
+++ b/Assets/Scripts/UI/MouseOverFurnitureTypeText.cs
@@ -9,6 +9,7 @@
 using UnityEngine;
 using System.Collections;
 using UnityEngine.UI;
+using ProjectPorcupine.Localization;
 
 public class MouseOverFurnitureTypeText : MonoBehaviour
 {
@@ -38,6 +39,7 @@ public class MouseOverFurnitureTypeText : MonoBehaviour
             Logger.LogError("How do we not have an instance of mouse controller?");
             return;
         }
+
     }
 	
     // Update is called once per frame
@@ -50,12 +52,14 @@ public class MouseOverFurnitureTypeText : MonoBehaviour
         if (t != null && t.furniture != null)
         {
             s = t.furniture.Name;
-            myText.text = "Furniture: " + s;
+            myText.text = LocalizationTable.GetLocalization("furniture") + ": " + s;
         } else
         {
             myText.text = "";
         }
 
-        
+       
+
+
     }
 }

--- a/Assets/Scripts/UI/MouseOverFurnitureTypeText.cs
+++ b/Assets/Scripts/UI/MouseOverFurnitureTypeText.cs
@@ -50,8 +50,12 @@ public class MouseOverFurnitureTypeText : MonoBehaviour
         if (t != null && t.furniture != null)
         {
             s = t.furniture.Name;
+            myText.text = "Furniture: " + s;
+        } else
+        {
+            myText.text = "";
         }
 
-        myText.text = "Furniture: " + s;
+        
     }
 }

--- a/Assets/StreamingAssets/Data/Furniture.xml
+++ b/Assets/StreamingAssets/Data/Furniture.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Furnitures>
     <Furniture objectType="furn_SteelWall">
-        <Name>Basic Wall</Name>
-        <Description>This is a basic wall.</Description>
+        <Name>Steel Wall</Name>
+        <Description>This is a steel wall.</Description>
         <TypeTag>Wall</TypeTag>
         <MovementCost>0</MovementCost>
         <Width>1</Width>

--- a/Assets/StreamingAssets/Localization/en_US.lang
+++ b/Assets/StreamingAssets/Localization/en_US.lang
@@ -8,6 +8,7 @@ menu_floor=Floor
 menu_save=Save
 menu_resume=Resume
 menu_quit=Quit
+furniture=Furniture
 build_floor=Build Floor
 remove_floor=Remove Floor
 deconstruct_furniture=Deconstruct Furniture


### PR DESCRIPTION
Fix https://github.com/TeamPorcupine/ProjectPorcupine/issues/507

    Don't include the tag if there isn't furniture (As shown above)
    Steel Wall has the tool tip "basic wall". That seems off.

