### PR TITLE
Fixed newline splitting to deal with both CRLF and LF

### DIFF
--- a/Assets/Scripts/Controllers/CharacterSpriteController.cs
+++ b/Assets/Scripts/Controllers/CharacterSpriteController.cs
@@ -76,7 +76,7 @@ public class CharacterSpriteController : MonoBehaviour
 
         // Adds a random name to the Character
         TextAsset names = Resources.Load("names") as TextAsset;
-        string[] lines = Regex.Split( names.text, "\r\n" );
+        string[] lines = names.text.Split( new string[]  { "\r\n", "\n" }, System.StringSplitOptions.RemoveEmptyEntries );
         c.name = lines[Random.Range(0, lines.Length-1)];
 
 


### PR DESCRIPTION
I don't like that characters are being given names in the Sprite Controller (seems like it should be part of the model instead), but in any case this particular fix needs to happen regardless of where we put the file.