### PR TITLE
Added small accessability check before pathfinding

### DIFF
--- a/Assets/Scripts/Models/Character.cs
+++ b/Assets/Scripts/Models/Character.cs
@@ -161,6 +161,14 @@ public class Character : IXmlSerializable, ISelectable
         // Get our destination from the job
         DestTile = myJob.tile;
 
+        // If the dest tile does not have neighbours it's very
+        if (DestTile.HasNeighboursOfType(TileType.Floor) == false)
+        {
+            Logger.LogVerbose("No neighbouring floor tiles! Abandoning job.");
+            AbandonJob(false);
+            return;
+        }
+
         myJob.cbJobStopped += OnJobStopped;
 
         // Immediately check to see if the job tile is reachable.

--- a/Assets/Scripts/Models/Tile.cs
+++ b/Assets/Scripts/Models/Tile.cs
@@ -289,6 +289,22 @@ public class Tile :IXmlSerializable, ISelectable
         return ns;
     }
 
+    /// <summary>
+    /// If one of the 8 neighbouring tiles is of TileType type then this returns true.
+    /// </summary>
+    /// <param name="type"></param>
+    /// <returns></returns>
+    public bool HasNeighboursOfType(TileType type)
+    {
+        foreach (Tile tile in GetNeighbours(true))
+        {
+            if (tile.Type == type)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
 
     public XmlSchema GetSchema()
     {


### PR DESCRIPTION
This removes the need to make a full A* to find that the tile is not accessible.