### PR TITLE
[Pathfinding] Fixed slow ClosedSet contains queries.

### DIFF
--- a/Assets/Scripts/Pathfinding/Path_AStar.cs
+++ b/Assets/Scripts/Pathfinding/Path_AStar.cs
@@ -69,7 +69,7 @@ public class Path_AStar
         // Mostly following this pseusocode:
         // https://en.wikipedia.org/wiki/A*_search_algorithm
 
-        Dictionary<Path_Node<Tile>, bool> inClosedSet = new Dictionary<Path_Node<Tile>, bool>();
+        HashSet<Path_Node<Tile>> ClosedSet = new HashSet<Path_Node<Tile>>();
 
 /*		List<Path_Node<Tile>> OpenSet = new List<Path_Node<Tile>>();
 		OpenSet.Add( start );
@@ -115,13 +115,13 @@ public class Path_AStar
                 }
             }
 
-            inClosedSet[current] = true;
+            ClosedSet.Add(current);
 
             foreach (Path_Edge<Tile> edge_neighbor in current.edges)
             {
                 Path_Node<Tile> neighbor = edge_neighbor.node;
 
-                if (inClosedSet.ContainsKey(neighbor) && inClosedSet[neighbor] == true)
+                if (ClosedSet.Contains(neighbor))
                     continue; // ignore this already completed neighbor
 
                 float movement_cost_to_neighbor = neighbor.data.movementCost * dist_between(current, neighbor);

--- a/Assets/Scripts/Pathfinding/Path_AStar.cs
+++ b/Assets/Scripts/Pathfinding/Path_AStar.cs
@@ -69,7 +69,7 @@ public class Path_AStar
         // Mostly following this pseusocode:
         // https://en.wikipedia.org/wiki/A*_search_algorithm
 
-        List<Path_Node<Tile>> ClosedSet = new List<Path_Node<Tile>>();
+        Dictionary<Path_Node<Tile>, bool> inClosedSet = new Dictionary<Path_Node<Tile>, bool>();
 
 /*		List<Path_Node<Tile>> OpenSet = new List<Path_Node<Tile>>();
 		OpenSet.Add( start );
@@ -115,13 +115,13 @@ public class Path_AStar
                 }
             }
 
-            ClosedSet.Add(current);
+            inClosedSet[current] = true;
 
             foreach (Path_Edge<Tile> edge_neighbor in current.edges)
             {
                 Path_Node<Tile> neighbor = edge_neighbor.node;
 
-                if (ClosedSet.Contains(neighbor) == true)
+                if (inClosedSet.ContainsKey(neighbor) && inClosedSet[neighbor] == true)
                     continue; // ignore this already completed neighbor
 
                 float movement_cost_to_neighbor = neighbor.data.movementCost * dist_between(current, neighbor);


### PR DESCRIPTION
I just realized that the pathfinding code is currently storing the Closed Set as a list. The only operation it's ever performing on that list is Contains, which is very slow (asymptotically O(n)) on CSharp's built-in list. This changes it to a dictionary, which can check containment much faster (close to O(1)).

I'm pretty sure this drastically speeds up pathfinding. I'll try to get my pathfinding tests working again so that I can actually give some hard numbers, but in the one test that I've managed to get working, it changed one of the searches from ~2.5s to ~0.25s.

EDIT: Thanks to a suggestion by @Mizipzor, I changed from a Dictionary to a HashSet. It's about the same speed, but it's more elegant. Also, I got the tests working again, with my results posted in the comments below. Eight of the twelve tests I used are over 10x faster, and the two slower ones seem to fall within standard deviation.