### PR TITLE
Disabled StyleCop SA1513

### DIFF
--- a/Settings.StyleCop
+++ b/Settings.StyleCop
@@ -265,5 +265,15 @@
       </Rules>
       <AnalyzerSettings />
     </Analyzer>
+    <Analyzer AnalyzerId="StyleCop.CSharp.LayoutRules">
+      <Rules>
+        <Rule Name="ClosingCurlyBracketMustBeFollowedByBlankLine">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+      </Rules>
+      <AnalyzerSettings />
+    </Analyzer>
   </Analyzers>
 </StyleCopSettings>


### PR DESCRIPTION
Heres a case where I think StyleCop is trying too much. The rationale is that space between code increases readability by decreasing clutter.
	
> SA1503 : CSharp.Layout : The body of the if statement must be wrapped in opening and closing curly brackets.

	 if (i < 0 || i > rooms.Count - 1)
	     return 
	 return rooms[i]; // not good

But doing the obvious is not enough because then another rule pops up.

> SA1513 : CSharp.Layout : Statements or elements wrapped in curly brackets must be followed by a blank line.
	
	 if (i < 0 || i > rooms.Count - 1)
	 {
	     return null;
	 }
	 return rooms[i]; // not good either

So it wants this:

	 if (i < 0 || i > rooms.Count - 1)
	 {
	     return null;
	 }
	 
	 return rooms[i];

I think both rules tries to address the same problem in the same place. And it results in a double dip, a tad too much.

I think this is one of the (rare) cases where its best left up to the individual developer. This commit disables the latter rule.