### PR TITLE
[Small] Fixed an error message that contained old method name.

### DIFF
--- a/Assets/Scripts/Controllers/TileSpriteController.cs
+++ b/Assets/Scripts/Controllers/TileSpriteController.cs
@@ -113,7 +113,7 @@ public class TileSpriteController : MonoBehaviour
         }
         else
         {
-            Logger.LogError("OnTileTypeChanged - Unrecognized tile type.");
+            Logger.LogError("OnTileChanged - Unrecognized tile type.");
         }
 
 


### PR DESCRIPTION
OnTileTypeChanged was renamed to OnTileChanged. I just fixed a reference to that old method name in the error logging, because I couldn't find that method when I got the error message.