### PR TITLE
[Small] Make 'Loaded localization' log message LogVerbose

### DIFF
--- a/Assets/Scripts/Localization/LocalizationLoader.cs
+++ b/Assets/Scripts/Localization/LocalizationLoader.cs
@@ -44,8 +44,8 @@ namespace ProjectPorcupine.Localization
                     //The file extention is .lang, load it.
                     LocalizationTable.LoadLocalizationFile(file);
 
-                    //Just write a little debug info into the console.
-                    Logger.Log("Loaded localization at path\n" + file);
+                    // Just write a little debug info into the console.
+                    Logger.LogVerbose("Loaded localization at path\n" + file);
                 }
             }
 


### PR DESCRIPTION
currently localization spams each lang file to the log on start. Changed so that this only occurs in verbose mode.

Bonus: added space to preceding comment 