### PR TITLE
Fixed enumeration modification error in cbJobCallbackComplete

### DIFF
--- a/Assets/Scripts/Models/Job.cs
+++ b/Assets/Scripts/Models/Job.cs
@@ -182,32 +182,8 @@ public class Job
 
     public void DoWork(float workTime)
     {
-        // Check to make sure we actually have everything we need. 
-        // If not, don't register the work time.
-        if (HasAllMaterial() == false)
-        {
-            ////Logger.LogError("Tried to do work on a job that doesn't have all the material.");
-
-            // Job can't actually be worked, but still call the callbacks
-            // so that animations and whatnot can be updated.
-            if (cbJobWorked != null)
-            {
-                cbJobWorked(this);
-            }
-
-            if (cbJobWorkedLua != null)
-            {
-                foreach (string luaFunction in cbJobCompletedLua.ToList())
-                {
-                    FurnitureActions.CallFunction(luaFunction, this);
-                }
-            }
-
-            return;
-        }
-
-        jobTime -= workTime;
-
+        // We don't know if the Job can actually be worked, but still call the callbacks
+        // so that animations and whatnot can be updated.
         if (cbJobWorked != null)
         {
             cbJobWorked(this);
@@ -215,12 +191,22 @@ public class Job
 
         if (cbJobWorkedLua != null)
         {
-            foreach (string luaFunction in cbJobCompletedLua.ToList())
+            foreach (string luaFunction in cbJobWorkedLua.ToList())
             {
                 FurnitureActions.CallFunction(luaFunction, this);
             }
         }
 
+        // Check to make sure we actually have everything we need. 
+        // If not, don't register the work time.
+        if (HasAllMaterial() == false)
+        {
+            ////Logger.LogError("Tried to do work on a job that doesn't have all the material.");
+            return;
+        }
+
+        jobTime -= workTime;
+        
         if (jobTime <= 0)
         {
             // Do whatever is supposed to happen with a job cycle completes.
@@ -233,7 +219,7 @@ public class Job
             {
                 FurnitureActions.CallFunction(luaFunction, this);
             }
-
+            
             if (jobRepeats == false)
             {
                 // Let everyone know that the job is officially concluded

--- a/Assets/Scripts/Models/Job.cs
+++ b/Assets/Scripts/Models/Job.cs
@@ -197,7 +197,7 @@ public class Job
 
             if (cbJobWorkedLua != null)
             {
-                foreach (string luaFunction in cbJobWorkedLua)
+                foreach (string luaFunction in cbJobCompletedLua.ToList())
                 {
                     FurnitureActions.CallFunction(luaFunction, this);
                 }
@@ -215,7 +215,7 @@ public class Job
 
         if (cbJobWorkedLua != null)
         {
-            foreach (string luaFunction in cbJobWorkedLua)
+            foreach (string luaFunction in cbJobCompletedLua.ToList())
             {
                 FurnitureActions.CallFunction(luaFunction, this);
             }
@@ -229,9 +229,9 @@ public class Job
                 cbJobCompleted(this);
             }
 
-            for (int i = 0; i < cbJobCompletedLua.Count; i++)
+            foreach (string luaFunction in cbJobCompletedLua.ToList())
             {
-                FurnitureActions.CallFunction(cbJobCompletedLua[i], this);
+                FurnitureActions.CallFunction(luaFunction, this);
             }
 
             if (jobRepeats == false)

--- a/Assets/Scripts/Models/Job.cs
+++ b/Assets/Scripts/Models/Job.cs
@@ -229,9 +229,9 @@ public class Job
                 cbJobCompleted(this);
             }
 
-            foreach (string luaFunc in cbJobCompletedLua)
+            for (int i = 0; i < cbJobCompletedLua.Count; i++)
             {
-                FurnitureActions.CallFunction(luaFunc, this);
+                FurnitureActions.CallFunction(cbJobCompletedLua[i], this);
             }
 
             if (jobRepeats == false)


### PR DESCRIPTION
There was a problem with a lua function registering a callback which modified a currently enumerated list causing a enumeration modification error. This changes the iteration so that they iterate through a copy list.