### PR TITLE
Revert "Disabled SA1513 ClosingCurlyBracketMustBeFollowedByBlankLine"

### DIFF
--- a/Settings.StyleCop
+++ b/Settings.StyleCop
@@ -265,15 +265,5 @@
       </Rules>
       <AnalyzerSettings />
     </Analyzer>
-    <Analyzer AnalyzerId="StyleCop.CSharp.LayoutRules">
-      <Rules>
-        <Rule Name="ClosingCurlyBracketMustBeFollowedByBlankLine">
-          <RuleSettings>
-            <BooleanProperty Name="Enabled">False</BooleanProperty>
-          </RuleSettings>
-        </Rule>
-      </Rules>
-      <AnalyzerSettings />
-    </Analyzer>
   </Analyzers>
 </StyleCopSettings>


### PR DESCRIPTION
This reverts commit 3e3a8b4831108f79a9cddf9ae0824da8a8c4be24.

Reverts pull request #562. It got voted down but then got merged anyway. Mistakes happen, but this corrects that. :)



