### PR TITLE
Fixing metal smelter bug issue #577 (with hacks)

### DIFF
--- a/Assets/StreamingAssets/LUA/Furniture.lua
+++ b/Assets/StreamingAssets/LUA/Furniture.lua
@@ -224,7 +224,8 @@ end
 function MetalSmelter_UpdateAction(furniture, deltaTime)
 	spawnSpot = furniture.GetSpawnSpotTile()
 
-	if(spawnSpot.inventory == nil) then
+	--if(spawnSpot.inventory == nil) then
+	if(furniture.GetParameter("smelting") == 0) then
 		if(furniture.JobCount() == 0) then
 			itemsDesired = {Inventory.__new("Raw Iron", 50, 0)}
 
@@ -245,6 +246,11 @@ function MetalSmelter_UpdateAction(furniture, deltaTime)
 			furniture.AddJob(j)
 		end
 	else
+		-- ugly hack because spawnSpot inventory is disappearing, so just reset it to what it should be if it's gone
+		if(spawnSpot.inventory == nil) then
+			spawnSpot.inventory = Inventory.__new("Raw Iron", 50, 0)
+		end
+
 		furniture.ChangeParameter("smelttime", deltaTime)
 
 		if(furniture.GetParameter("smelttime") >= furniture.GetParameter("smelttime_required")) then
@@ -266,12 +272,14 @@ function MetalSmelter_UpdateAction(furniture, deltaTime)
 
 			if(spawnSpot.inventory.stackSize <= 0) then
 				spawnSpot.inventory = nil
+				furniture.ChangeParameter("smelting", 0)
 			end
 		end
 	end
 end
 
 function MetalSmelter_JobComplete(j)
+	j.furniture.ChangeParameter("smelting", 1)
     j.UnregisterJobCompletedCallback("MetalSmelter_JobComplete")
     j.UnregisterJobWorkedCallback("MetalSmelter_JobWorked")
 end


### PR DESCRIPTION
Hack to fix issue https://github.com/TeamPorcupine/ProjectPorcupine/issues/577 (correct me if this issue is about a slightly different bug! This fixes the only smelter weirdness I can reproduce.)
The problem is that the spawn spot inventory is disappearing so the smelting never gets started. I've just turned the smelter into a little finite state machine using a furniture param "smelting" as flag and manually resetting the spawn spot inventory. I'm sure there's a better way to fix this but it's working for now.