### PR TITLE
Made GetSpriteForFurniture less hard coded

### DIFF
--- a/Assets/Scripts/Controllers/FurnitureSpriteController.cs
+++ b/Assets/Scripts/Controllers/FurnitureSpriteController.cs
@@ -197,68 +197,10 @@ public class FurnitureSpriteController
 
     public Sprite GetSpriteForFurniture(Furniture furn)
     {
-        string spriteName = furn.objectType;
+        string spriteName = furn.GetSpriteName();
 
         if (furn.linksToNeighbour == false)
         {
-
-            // If this is a DOOR, let's check OPENNESS and update the sprite.
-            // FIXME: All this hardcoding needs to be generalized later.
-            if (furn.objectType == "Door")
-            {
-                if (furn.GetParameter("openness") < 0.1f)
-                {
-                    // Door is closed
-                    spriteName = "Door";
-                }
-                else if (furn.GetParameter("openness") < 0.5f)
-                {
-                    // Door is a bit open
-                    spriteName = "Door_openness_1";
-                }
-                else if (furn.GetParameter("openness") < 0.9f)
-                {
-                    // Door is a lot open
-                    spriteName = "Door_openness_2";
-                }
-                else
-                {
-                    // Door is a fully open
-                    spriteName = "Door_openness_3";
-                }
-                //Debug.Log(spriteName);
-            }
-            if (furn.objectType == "Airlock")
-            {
-                if (furn.GetParameter("openness") < 0.1f)
-                {
-                    // Airlock is closed
-                    spriteName = "Airlock";
-                }
-                else if (furn.GetParameter("openness") < 0.5f)
-                {
-                    // Airlock is a bit open
-                    spriteName = "Airlock_openness_1";
-                }
-                else if (furn.GetParameter("openness") < 0.9f)
-                {
-                    // Airlock is a lot open
-                    spriteName = "Airlock_openness_2";
-                }
-                else
-                {
-                    // Airlock is a fully open
-                    spriteName = "Airlock_openness_3";
-                }
-                //Debug.Log(spriteName);
-            }
-
-            /*if(furnitureSprites.ContainsKey(spriteName) == false) {
-				Debug.Log("furnitureSprites has no definition for: " + spriteName);
-				return null;
-			}
-*/
-
             return SpriteManager.current.GetSprite("Furniture", spriteName); // furnitureSprites[spriteName];
         }
 

--- a/Assets/Scripts/Controllers/FurnitureSpriteController.cs
+++ b/Assets/Scripts/Controllers/FurnitureSpriteController.cs
@@ -201,53 +201,36 @@ public class FurnitureSpriteController
 
         if (furn.linksToNeighbour == false)
         {
-            return SpriteManager.current.GetSprite("Furniture", spriteName); // furnitureSprites[spriteName];
+            return SpriteManager.current.GetSprite("Furniture", spriteName);
         }
 
         // Otherwise, the sprite name is more complicated.
-
-        spriteName = furn.objectType + "_";
+        spriteName += "_";
 
         // Check for neighbours North, East, South, West
-
         int x = furn.tile.X;
         int y = furn.tile.Y;
 
-        Tile t;
-
-        t = world.GetTileAt(x, y + 1);
-        if (t != null && t.Furniture != null && t.Furniture.objectType == furn.objectType)
-        {
-            spriteName += "N";
-        }
-        t = world.GetTileAt(x + 1, y);
-        if (t != null && t.Furniture != null && t.Furniture.objectType == furn.objectType)
-        {
-            spriteName += "E";
-        }
-        t = world.GetTileAt(x, y - 1);
-        if (t != null && t.Furniture != null && t.Furniture.objectType == furn.objectType)
-        {
-            spriteName += "S";
-        }
-        t = world.GetTileAt(x - 1, y);
-        if (t != null && t.Furniture != null && t.Furniture.objectType == furn.objectType)
-        {
-            spriteName += "W";
-        }
+        spriteName += GetSuffixForNeighbour(x, y + 1, "N");
+        spriteName += GetSuffixForNeighbour(x + 1, y, "E");
+        spriteName += GetSuffixForNeighbour(x, y - 1, "S");
+        spriteName += GetSuffixForNeighbour(x - 1, y, "W");
 
         // For example, if this object has all four neighbours of
         // the same type, then the string will look like:
         //       Wall_NESW
-
-        /*		if(furnitureSprites.ContainsKey(spriteName) == false) {
-                    Debug.LogError("GetSpriteForInstalledObject -- No sprites with name: " + spriteName);
-                    return null;
-                }
-        */
-
-        return SpriteManager.current.GetSprite("Furniture", spriteName); //furnitureSprites[spriteName];
-
+        
+        return SpriteManager.current.GetSprite("Furniture", spriteName);
+    }
+    
+    private function GetSuffixForNeighbour(int x, int y, string suffix)
+    {
+         Tile t = world.GetTileAt(x, y);
+         if (t != null && t.Furniture != null && t.Furniture.objectType == furn.objectType)
+         {
+             return suffix;
+         }
+         return "";
     }
 
     Sprite GetPowerStatusSprite()

--- a/Assets/Scripts/Controllers/FurnitureSpriteController.cs
+++ b/Assets/Scripts/Controllers/FurnitureSpriteController.cs
@@ -211,10 +211,10 @@ public class FurnitureSpriteController
         int x = furn.tile.X;
         int y = furn.tile.Y;
 
-        spriteName += GetSuffixForNeighbour(x, y + 1, "N");
-        spriteName += GetSuffixForNeighbour(x + 1, y, "E");
-        spriteName += GetSuffixForNeighbour(x, y - 1, "S");
-        spriteName += GetSuffixForNeighbour(x - 1, y, "W");
+        spriteName += GetSuffixForNeighbour(furn, x, y + 1, "N");
+        spriteName += GetSuffixForNeighbour(furn, x + 1, y, "E");
+        spriteName += GetSuffixForNeighbour(furn, x, y - 1, "S");
+        spriteName += GetSuffixForNeighbour(furn, x - 1, y, "W");
 
         // For example, if this object has all four neighbours of
         // the same type, then the string will look like:
@@ -223,7 +223,7 @@ public class FurnitureSpriteController
         return SpriteManager.current.GetSprite("Furniture", spriteName);
     }
     
-    private function GetSuffixForNeighbour(int x, int y, string suffix)
+    private string GetSuffixForNeighbour(Furniture furn, int x, int y, string suffix)
     {
          Tile t = world.GetTileAt(x, y);
          if (t != null && t.Furniture != null && t.Furniture.objectType == furn.objectType)

--- a/Assets/Scripts/Models/Furniture.cs
+++ b/Assets/Scripts/Models/Furniture.cs
@@ -126,7 +126,6 @@ public class Furniture : IXmlSerializable, ISelectable, IContextActionProvider, 
         }
         
         DynValue ret = FurnitureActions.CallFunction(getSpriteNameAction, this);
-
         return ret.String;
     }
 

--- a/Assets/Scripts/Models/Furniture.cs
+++ b/Assets/Scripts/Models/Furniture.cs
@@ -48,8 +48,13 @@ public class Furniture : IXmlSerializable, ISelectable, IContextActionProvider, 
     /// </summary>
     protected List<string> uninstallActions;
     
-    // public Func<Furniture, ENTERABILITY> IsEnterable;
+    // protected Func<Furniture, ENTERABILITY> IsEnterable;
     protected string isEnterableAction;
+    
+    /// <summary>
+    /// These action is called to get the sprite name based on the furniture parameters
+    /// </summary>
+    protected string getSpriteNameAction;
 
     protected List<string> replaceableFurniture = new List<string>();
 
@@ -111,6 +116,18 @@ public class Furniture : IXmlSerializable, ISelectable, IContextActionProvider, 
         DynValue ret = FurnitureActions.CallFunction(isEnterableAction, this);
 
         return (ENTERABILITY)ret.Number;
+    }
+    
+    public string GetSpriteName()
+    {
+        if (getSpriteNameAction == null || getSpriteNameAction.Length == 0)
+        {
+            return objectType;
+        }
+        
+        DynValue ret = FurnitureActions.CallFunction(getSpriteNameAction, this);
+
+        return ret.String;
     }
 
     // If this furniture generates power then powerValue will be positive, if it consumer power then it will be negative
@@ -254,6 +271,7 @@ public class Furniture : IXmlSerializable, ISelectable, IContextActionProvider, 
         }
 
         this.isEnterableAction = other.isEnterableAction;
+        this.getSpriteNameAction = other.getSpriteNameAction;
 
         this.powerValue = other.powerValue;
 
@@ -521,41 +539,41 @@ public class Furniture : IXmlSerializable, ISelectable, IContextActionProvider, 
                     Job.JobPriority.High );
 
                 World.current.SetFurnitureJobPrototype(j, this);
-
                 break;
+            
             case "OnUpdate":
-
                 string functionName = reader.GetAttribute("FunctionName");
                 RegisterUpdateAction(functionName);
-                    break;
+                break;
+            
             case "OnInstall":
                 // Called when obj is installed
                 string functionInstallName = reader.GetAttribute("FunctionName");
                 RegisterInstallAction(functionInstallName);
-
                 break;
+            
             case "OnUninstall":
                 // Called when obj is uninstalled
                 string functionUninstallName = reader.GetAttribute("FunctionName");
                 RegisterUninstallAction(functionUninstallName);
-
                 break;
+            
             case "IsEnterable":
                 isEnterableAction = reader.GetAttribute("FunctionName");
-
+                break;
+            case "GetSpriteName":
+                getSpriteNameAction = reader.GetAttribute("FunctionName");
                 break;
 
             case "JobSpotOffset":
                 jobSpotOffset = new Vector2(
                     int.Parse(reader.GetAttribute("X")),
                     int.Parse(reader.GetAttribute("Y")));
-
                 break;
             case "JobSpawnSpotOffset":
                 jobSpawnSpotOffset = new Vector2(
                     int.Parse(reader.GetAttribute("X")),
                     int.Parse(reader.GetAttribute("Y")));
-
                 break;
 
             case "Power":

--- a/Assets/Scripts/Models/Furniture.cs
+++ b/Assets/Scripts/Models/Furniture.cs
@@ -36,23 +36,24 @@ public class Furniture : IXmlSerializable, ISelectable, IContextActionProvider, 
     /// </summary>
     // protected Action<Furniture, float> updateActions;
     protected List<string> updateActions;
-    
+
     /// <summary>
     /// These actions are called when an object is installed. They get passed the furniture and a delta
     /// time of 0
     /// </summary>
     protected List<string> installActions;
+
     /// <summary>
     /// These actions are called when an object is uninstalled. They get passed the furniture and a delta
     /// time of 0
     /// </summary>
     protected List<string> uninstallActions;
-    
-    // protected Func<Furniture, ENTERABILITY> IsEnterable;
+
+    // private Func<Furniture, ENTERABILITY> IsEnterable;
     protected string isEnterableAction;
-    
+
     /// <summary>
-    /// These action is called to get the sprite name based on the furniture parameters
+    /// This action is called to get the sprite name based on the furniture parameters
     /// </summary>
     protected string getSpriteNameAction;
 
@@ -117,20 +118,20 @@ public class Furniture : IXmlSerializable, ISelectable, IContextActionProvider, 
 
         return (ENTERABILITY)ret.Number;
     }
-    
+
     public string GetSpriteName()
     {
         if (getSpriteNameAction == null || getSpriteNameAction.Length == 0)
         {
             return objectType;
         }
-        
+
         DynValue ret = FurnitureActions.CallFunction(getSpriteNameAction, this);
         return ret.String;
     }
 
     // If this furniture generates power then powerValue will be positive, if it consumer power then it will be negative
-   
+
     private void InvokePowerValueChanged(IPowerRelated powerRelated)
     {
         Action<IPowerRelated> handler = PowerValueChanged;
@@ -203,7 +204,7 @@ public class Furniture : IXmlSerializable, ISelectable, IContextActionProvider, 
     public int Height { get; protected set; }
 
     public string localizationCode { get; protected set; }
-   
+
     public string unlocalizedDescription { get; protected set; }
 
     public Color tint = Color.white;
@@ -539,24 +540,24 @@ public class Furniture : IXmlSerializable, ISelectable, IContextActionProvider, 
 
                 World.current.SetFurnitureJobPrototype(j, this);
                 break;
-            
+
             case "OnUpdate":
                 string functionName = reader.GetAttribute("FunctionName");
                 RegisterUpdateAction(functionName);
                 break;
-            
+
             case "OnInstall":
                 // Called when obj is installed
                 string functionInstallName = reader.GetAttribute("FunctionName");
                 RegisterInstallAction(functionInstallName);
                 break;
-            
+
             case "OnUninstall":
                 // Called when obj is uninstalled
                 string functionUninstallName = reader.GetAttribute("FunctionName");
                 RegisterUninstallAction(functionUninstallName);
                 break;
-            
+
             case "IsEnterable":
                 isEnterableAction = reader.GetAttribute("FunctionName");
                 break;

--- a/Assets/StreamingAssets/Data/Furniture.xml
+++ b/Assets/StreamingAssets/Data/Furniture.xml
@@ -65,6 +65,7 @@
         <OnUpdate FunctionName="OnUpdate_Leak_Door" />
 
         <IsEnterable FunctionName="IsEnterable_Door" />
+        <GetSpriteName FunctionName="GetSpriteName_Door" />
 
         <LocalizationCode>furn_door</LocalizationCode>
         <UnlocalizedDescription>furn_door_desc</UnlocalizedDescription>
@@ -101,6 +102,7 @@
         <OnUpdate FunctionName="OnUpdate_Leak_Airlock" />
 
         <IsEnterable FunctionName="IsEnterable_Door" />
+        <GetSpriteName FunctionName="GetSpriteName_Airlock" />
 
         <LocalizationCode>furn_airlock</LocalizationCode>
         <UnlocalizedDescription>furn_airlock_desc</UnlocalizedDescription>

--- a/Assets/StreamingAssets/LUA/Furniture.lua
+++ b/Assets/StreamingAssets/LUA/Furniture.lua
@@ -68,45 +68,37 @@ function IsEnterable_Door( furniture )
 end
 
 function GetSpriteName_Door( furniture )
+	-- Door is closed
 	if (furniture.GetParameter("openness") < 0.1) then
-		-- Door is closed
-		spriteName = "Door";
-	
-	else if (furn.GetParameter("openness") < 0.5) then
-		-- Door is a bit open
-		spriteName = "Door_openness_1";
-	
-	else if (furn.GetParameter("openness") < 0.9) then
-		-- Door is a lot open
-		spriteName = "Door_openness_2";
-	
-	else
-		-- Door is a fully open
-		spriteName = "Door_openness_3";
+		return "Door"
 	end
-	
-	return spriteName
+	-- Door is a bit open
+	if (furniture.GetParameter("openness") < 0.5) then
+		return "Door_openness_1"
+	end
+	-- Door is a lot open
+	if (furniture.GetParameter("openness") < 0.9) then
+		return "Door_openness_2"
+	end
+	-- Door is a fully open
+	return "Door_openness_3"
 end
 
 function GetSpriteName_Airlock( furniture )
+	-- Door is closed
 	if (furniture.GetParameter("openness") < 0.1) then
-		-- Door is closed
-		spriteName = "Airlock";
-	
-	else if (furn.GetParameter("openness") < 0.5) then
-		-- Door is a bit open
-		spriteName = "Airlock_openness_1";
-	
-	else if (furn.GetParameter("openness") < 0.9) then
-		-- Door is a lot open
-		spriteName = "Airlock_openness_2";
-	
-	else
-		-- Door is a fully open
-		spriteName = "Airlock_openness_3";
+		return "Airlock"
 	end
-	
-	return spriteName
+	-- Door is a bit open
+	if (furniture.GetParameter("openness") < 0.5) then
+		return "Airlock_openness_1"
+	end
+	-- Door is a lot open
+	if (furniture.GetParameter("openness") < 0.9) then
+		return "Airlock_openness_2"
+	end
+	-- Door is a fully open
+	return "Airlock_openness_3"
 end
 
 function Stockpile_GetItemsFromFilter()

--- a/Assets/StreamingAssets/LUA/Furniture.lua
+++ b/Assets/StreamingAssets/LUA/Furniture.lua
@@ -67,6 +67,48 @@ function IsEnterable_Door( furniture )
 	return ENTERABILITY_SOON --ENTERABILITY.Soon
 end
 
+function GetSpriteName_Door( furniture )
+	if (furniture.GetParameter("openness") < 0.1) then
+		-- Door is closed
+		spriteName = "Door";
+	
+	else if (furn.GetParameter("openness") < 0.5) then
+		-- Door is a bit open
+		spriteName = "Door_openness_1";
+	
+	else if (furn.GetParameter("openness") < 0.9) then
+		-- Door is a lot open
+		spriteName = "Door_openness_2";
+	
+	else
+		-- Door is a fully open
+		spriteName = "Door_openness_3";
+	end
+	
+	return spriteName
+end
+
+function GetSpriteName_Airlock( furniture )
+	if (furniture.GetParameter("openness") < 0.1) then
+		-- Door is closed
+		spriteName = "Airlock";
+	
+	else if (furn.GetParameter("openness") < 0.5) then
+		-- Door is a bit open
+		spriteName = "Airlock_openness_1";
+	
+	else if (furn.GetParameter("openness") < 0.9) then
+		-- Door is a lot open
+		spriteName = "Airlock_openness_2";
+	
+	else
+		-- Door is a fully open
+		spriteName = "Airlock_openness_3";
+	end
+	
+	return spriteName
+end
+
 function Stockpile_GetItemsFromFilter()
 	-- TODO: This should be reading from some kind of UI for this
 	-- particular stockpile


### PR DESCRIPTION
This is my solution to make ```GetSpriteForFurniture``` to be less hard coded and is now posible to change the value for any furniture, mentioned in #657.

Eventually we might change this with a sprite animation manager, but for now this can be used for furniture animations.