### PR TITLE
Fixing stockpile logic: implementing taking multiple inventory types and any/all logic

### DIFF
--- a/Assets/Scripts/Models/Character.cs
+++ b/Assets/Scripts/Models/Character.cs
@@ -324,38 +324,40 @@ public class Character : IXmlSerializable, ISelectable, IContextActionProvider
     }
 
     /// <summary>
-    /// Checks weather the current job has all the materials in place and if not instructs the working character to get the materials there first.
+    /// Checks whether the current job has all the materials in place and if not instructs the working character to get the materials there first.
     /// Only ever returns true if all materials for the job are at the job location and thus signals to the calling code, that it can proceed with job execution.
     /// </summary>
     /// <returns></returns>
     private bool CheckForJobMaterials()
     {
+        List<string> fulfillableInventoryRequirements = new List<string>();
+
         if (myJob != null && myJob.isNeed && myJob.critical == false)
         {
             myJob.tile = jobTile = new Path_AStar (World.current, CurrTile, null, myJob.jobObjectType, 0, false, true).EndTile ();
         }
-        if (myJob == null || myJob.HasAllMaterial())
+        if (myJob == null || myJob.MaterialNeedsMet())
         {
             return true; //we can return early
         }
         else
         {
-            // Do a quick check, if any inventories with the desired objectType exists.
-            Inventory desired = myJob.GetFirstDesiredInventory ();
-            if (!World.current.inventoryManager.QuickCheck (desired.objectType))
+            fulfillableInventoryRequirements = FulfillableInventoryRequirements(myJob);
+
+            // if we somehow get here and fulfillableInventoryRequirements is empty then there is a problem!
+            if (fulfillableInventoryRequirements == null || fulfillableInventoryRequirements.Count() == 0)
             {
-                // If not, abandon the job and return false.
-                Debug.ULogChannel("Character", name + " does not have everything they need to complete their job.");
+                Debug.ULogChannel("Character","CheckForJobMaterials: no fulfillable inventory requirements");
                 AbandonJob(true);
                 return false;
             }
         }
 
-        // At this point we know, that the job still needs materials.
+        // At this point we know that the job still needs materials and these needs are satisfiable.
         // First we check if we carry any materials the job wants by chance.
         if (inventory != null)
         {
-            if (myJob.DesiresInventoryType(inventory) > 0)
+            if (myJob.AmountDesiredOfInventoryType(inventory) > 0)
             {
                 // If so, deliver the goods.
                 // Walk to the job tile, then drop off the stack into the job.
@@ -391,7 +393,7 @@ public class Character : IXmlSerializable, ISelectable, IContextActionProvider
             // Are we standing on a tile with goods that are desired by the job?
             //Debug.ULogChannel("Spammy", "Standing on Tile check");
             if (CurrTile.Inventory != null &&
-                myJob.DesiresInventoryType(CurrTile.Inventory) > 0 && !CurrTile.Inventory.isLocked &&
+                myJob.AmountDesiredOfInventoryType(CurrTile.Inventory) > 0 && !CurrTile.Inventory.isLocked &&
                 (myJob.canTakeFromStockpile || CurrTile.Furniture == null || CurrTile.Furniture.IsStockpile() == false))
             {
                 // Pick up the stuff!
@@ -400,17 +402,13 @@ public class Character : IXmlSerializable, ISelectable, IContextActionProvider
                 World.current.inventoryManager.PlaceInventory(
                     this,
                     CurrTile.Inventory,
-                    myJob.DesiresInventoryType(CurrTile.Inventory));
-                
+                    myJob.AmountDesiredOfInventoryType(CurrTile.Inventory));
             }
             else
             {
                 // Walk towards a tile containing the required goods.
                 //Debug.ULogChannel("Spammy", "Walk to the stuff");
                 //Debug.ULogChannel("Spammy", myJob.canTakeFromStockpile);
-
-                // Find the first thing in the Job that isn't satisfied.
-                Inventory desired = myJob.GetFirstDesiredInventory();
 
                 if (CurrTile != NextTile)
                 {
@@ -421,33 +419,46 @@ public class Character : IXmlSerializable, ISelectable, IContextActionProvider
                 // Any chance we already have a path that leads to the items we want?
 
                 // Check that we have an end tile and that it has content.
-                if (pathAStar != null && pathAStar.EndTile() != null && pathAStar.EndTile().Inventory != null &&
-                    // Check if it is a stockpile and we are allowed to grab from it or just not a stockpile
-                    !(pathAStar.EndTile().Furniture != null && (myJob.canTakeFromStockpile == false && pathAStar.EndTile().Furniture.IsStockpile() == true)) &&
-                    // Check if contains the desired objectType
-                    ( pathAStar.EndTile().Inventory.objectType == desired.objectType))
+                // Check if contains the desired objectType
+                if (WalkingToUsableInventory() && fulfillableInventoryRequirements.Contains(pathAStar.EndTile().Inventory.objectType))
                 {
                     // We are already moving towards a tile that contains what we want!
                     // so....do nothing?
+                    return false;
                 }
                 else
                 {
-                    Path_AStar newPath = World.current.inventoryManager.GetPathToClosestInventoryOfType(
+                    Inventory desired = null;
+                    Path_AStar newPath = null;
+                    foreach (string itemType in fulfillableInventoryRequirements)
+                    {
+                        desired = myJob.inventoryRequirements[itemType];
+                        newPath = World.current.inventoryManager.GetPathToClosestInventoryOfType(
                                              desired.objectType,
                                              CurrTile,
                                              desired.maxStackSize - desired.stackSize,
-                                             myJob.canTakeFromStockpile );
+                                             myJob.canTakeFromStockpile);
+
+                        if (newPath == null || newPath.Length() < 1)
+                        {
+                            // Try the next requirement
+                            Debug.ULogChannel("Character","No tile contains objects of type '" + desired.objectType + "' to satisfy job requirements.");
+                            continue;
+                        }
+
+                        // else, there is a valid path to an item that will satisfy the job
+                        break;
+                    }
 
                     if (newPath == null || newPath.Length() < 1)
                     {
-                        //Debug.ULogChannel("Character", "pathAStar is null and we have no path to object of type: " + desired.objectType);
-                        // Cancel the job, since we have no way to get any raw materials!
-                        Debug.ULogChannel("Character", "No tile contains objects of type '" + desired.objectType + "' to satisfy job requirements.");
+                        // tried all requirements and found no path
+                        Debug.ULogChannel("Character","No reachable tile contains objects able to satisfy job requirements.");
                         AbandonJob(true);
                         return false;
                     }
 
-                    Debug.ULogChannel("Character", "pathAStar returned with length of: " + newPath.Length());
+                    Debug.ULogChannel("Character","pathAStar returned with length of: " + newPath.Length());
 
                     DestTile = newPath.EndTile();
 
@@ -466,6 +477,46 @@ public class Character : IXmlSerializable, ISelectable, IContextActionProvider
         return false; // We can't continue until all materials are satisfied.
     }
 
+    /// <summary>
+    /// Fulfillable inventory requirements for job.
+    /// </summary>
+    /// <returns>A list of (string) objectTypes for job inventory requirements that can be met. Returns null if the job requires materials which do not exist on the map.</returns>
+    private List<string> FulfillableInventoryRequirements(Job job) 
+    {
+        List<string> fulfillableInventoryRequirements = new List<string>();
+
+        foreach (Inventory inv in job.GetInventoryRequirementValues())
+        {
+            if (job.acceptsAny == false)
+            {
+                if (World.current.inventoryManager.QuickCheck(inv.objectType) == false)
+                {
+                    // the job requires ALL inventory requirements to be met, and there is no source of a desired objectType
+                    ///AbandonJob(true);
+                    return null;
+                }
+                else
+                {
+                    fulfillableInventoryRequirements.Add(inv.objectType);
+                }
+            }
+            else if (World.current.inventoryManager.QuickCheck(inv.objectType))
+            {
+                // there is a source for a desired objectType that the job will accept
+                fulfillableInventoryRequirements.Add(inv.objectType);
+            }
+        }
+
+        return fulfillableInventoryRequirements;
+    }
+
+    private bool WalkingToUsableInventory()
+    {
+        bool destHasInventory = pathAStar != null && pathAStar.EndTile() != null && pathAStar.EndTile().Inventory != null;
+        return destHasInventory &&
+                !(pathAStar.EndTile().Furniture != null && (myJob.canTakeFromStockpile == false && pathAStar.EndTile().Furniture.IsStockpile() == true));
+    }
+    
     /// <summary>
     /// This function instructs the character to null its inventory.
     /// However in the fuure it should actually look for a place to dump the materials and then do so.
@@ -682,17 +733,16 @@ public class Character : IXmlSerializable, ISelectable, IContextActionProvider
 
         // Get the relevant job and dequeue it from the waiting queue.
         Job job = World.current.jobWaitingQueue.Dequeue();
+
         // Check if the initial job still exists.
         // It could have been deleted through the user
         // cancelling the job manually.
         if (job != null)
         {
-            // Get the (first) desired inventory for the job.
-            Inventory desired = job.GetFirstDesiredInventory();
+            List<string> desired = FulfillableInventoryRequirements(job);
 
-            // Checking if the objectType from the created inventory
-            // and the objectType from the desired one match.
-            if (inv.objectType == desired.objectType)
+            // Check if the created inventory can fulfill the waiting job
+            if (desired.Contains(inv.objectType))
             {
                 // If so, enqueue the job onto the (normal)
                 // job queue.

--- a/Assets/Scripts/Models/Furniture.cs
+++ b/Assets/Scripts/Models/Furniture.cs
@@ -738,8 +738,33 @@ public class Furniture : IXmlSerializable, ISelectable, IContextActionProvider, 
 
     public bool IsStockpile()
     {
-        return objectType == "Stockpile";
+        return HasTypeTag("Storage");
     }
+
+    /// <summary>
+    /// Accepts for storage.
+    /// </summary>
+    /// <returns>A list of Inventory which the Furniture accepts for storage.</returns>
+    public Inventory[] AcceptsForStorage()
+    {
+        if (IsStockpile() == false)
+        {
+            Debug.ULogChannel("Stockpile_messages", "Someone is asking a non-stockpile to store stuff!?");
+            return null;
+        }
+
+        // TODO: read this from furniture params
+        Dictionary<string, Inventory> invsDict = new Dictionary<string, Inventory>();
+        foreach (string objectType in World.current.inventoryPrototypes.Keys)
+        {
+            invsDict[objectType] = new Inventory(objectType, World.current.inventoryPrototypes[objectType].maxStackSize, 0);
+        }
+
+        Inventory[] invs = new Inventory[invsDict.Count];
+        invsDict.Values.CopyTo(invs, 0);
+        return invs;
+    }
+
 
     public void Deconstruct()
     {

--- a/Assets/Scripts/Models/Job.cs
+++ b/Assets/Scripts/Models/Job.cs
@@ -69,8 +69,6 @@ public class Job
     // The piece of furniture that owns this job. Frequently will be null.
     public Furniture furniture;
 
-    public bool acceptsAnyInventoryItem = false;
-
     // We have finished the work cycle and so things should probably get built or whatever.
     public event Action<Job> cbJobCompleted;
    
@@ -94,6 +92,14 @@ public class Job
     /// If true, the work will be carried out on any adjacent tile of the target tile rather than on it.
     /// </summary>
     public bool adjacent;
+
+    /// <summary>
+    /// If true the job is workable if ANY of the inventory requirements are met.
+    /// Otherwise ALL requirements must be met before work can start.
+    /// This is useful for stockpile/storage jobs which can accept many types of items.
+    /// Defaults to false.
+    /// </summary>
+    public bool acceptsAny;
 
     public Job(Tile tile, string jobObjectType, Action<Job> cbJobComplete, float jobTime, Inventory[] inventoryRequirements, JobPriority jobPriority, bool jobRepeats = false, bool isNeed = false, bool critical = false)
     {
@@ -154,6 +160,7 @@ public class Job
         this.jobPriority = other.jobPriority;
         this.adjacent = other.adjacent;
         this.JobDescription = other.JobDescription;
+        this.acceptsAny = other.acceptsAny;
 
         cbJobWorkedLua = new List<string>(other.cbJobWorkedLua);
         cbJobCompletedLua = new List<string>(other.cbJobWorkedLua);
@@ -217,7 +224,7 @@ public class Job
 
         // Check to make sure we actually have everything we need. 
         // If not, don't register the work time.
-        if (HasAllMaterial() == false)
+        if (MaterialNeedsMet() == false)
         {
             ////Debug.LogError("Tried to do work on a job that doesn't have all the material.");
             return;
@@ -266,10 +273,25 @@ public class Job
         World.current.jobQueue.Remove(this);
     }
 
+    public bool MaterialNeedsMet()
+    {
+        if (acceptsAny && HasAnyMaterial())
+        {
+            return true;
+        }
+        if ((acceptsAny == false) && HasAllMaterial())
+        {
+            return true;
+        }
+        return false;
+    }
+
     public bool HasAllMaterial()
     {
         if (inventoryRequirements == null)
+        {
             return true;
+        }
         foreach (Inventory inv in inventoryRequirements.Values)
         {
             if (inv.maxStackSize > inv.stackSize)
@@ -281,26 +303,39 @@ public class Job
         return true;
     }
 
-    public int DesiresInventoryType(Inventory inv)
+    public bool HasAnyMaterial()
     {
-        if (acceptsAnyInventoryItem)
+        foreach (Inventory inv in inventoryRequirements.Values)
         {
-            return inv.maxStackSize;
+            if (inv.stackSize > 0)
+            {
+                return true;
+            }
         }
 
-        if (inventoryRequirements.ContainsKey(inv.objectType) == false)
+        return false;
+    }
+
+    public int AmountDesiredOfInventoryType(string objectType)
+    {
+        if (inventoryRequirements.ContainsKey(objectType) == false)
         {
             return 0;
         }
 
-        if (inventoryRequirements[inv.objectType].stackSize >= inventoryRequirements[inv.objectType].maxStackSize)
+        if (inventoryRequirements[objectType].stackSize >= inventoryRequirements[objectType].maxStackSize)
         {
             // We already have all that we need!
             return 0;
         }
 
         // The inventory is of a type we want, and we still need more.
-        return inventoryRequirements[inv.objectType].maxStackSize - inventoryRequirements[inv.objectType].stackSize;
+        return inventoryRequirements[objectType].maxStackSize - inventoryRequirements[objectType].stackSize;
+    }
+
+    public int AmountDesiredOfInventoryType(Inventory inv)
+    {
+        return AmountDesiredOfInventoryType(inv.objectType);
     }
 
     public Inventory GetFirstDesiredInventory()

--- a/Assets/StreamingAssets/LUA/Furniture.lua
+++ b/Assets/StreamingAssets/LUA/Furniture.lua
@@ -97,7 +97,7 @@ function GetSpriteName_Airlock( furniture )
 	return "Airlock_openness_3"
 end
 
-function Stockpile_GetItemsFromFilter()
+function Stockpile_GetItemsFromFilter( furniture )
 	-- TODO: This should be reading from some kind of UI for this
 	-- particular stockpile
 
@@ -107,7 +107,8 @@ function Stockpile_GetItemsFromFilter()
 	-- Since jobs copy arrays automatically, we could already have
 	-- an Inventory[] prepared and just return that (as a sort of example filter)
 
-	return { Inventory.__new("Steel Plate", 50, 0) }
+	--return { Inventory.__new("Steel Plate", 50, 0) }
+	return furniture.AcceptsForStorage()
 end
 
 
@@ -164,7 +165,7 @@ function Stockpile_UpdateAction( furniture, deltaTime )
 
 	if( furniture.tile.Inventory == nil ) then
 		--ModUtils.ULog("Creating job for new stack.")
-		itemsDesired = Stockpile_GetItemsFromFilter()
+		itemsDesired = Stockpile_GetItemsFromFilter( furniture )
 	else
 		--ModUtils.ULog("Creating job for existing stack.")
 		desInv = furniture.tile.Inventory.Clone()
@@ -184,6 +185,7 @@ function Stockpile_UpdateAction( furniture, deltaTime )
 		false
 	)
 	j.JobDescription = "job_stockpile_moving_desc"
+	j.acceptsAny = true
 
 	-- TODO: Later on, add stockpile priorities, so that we can take from a lower
 	-- priority stockpile for a higher priority one.


### PR DESCRIPTION
Fixes #568 
This is still incomplete and could probably use a lot of refactoring. I'm putting it up to get feedback.

This PR implements any/all logic for stockpile type jobs. Jobs now have a `public bool acceptsAny` & material requirements can be checked in a unified way through the method `MaterialNeedsMet()` which calls `HasAllMaterial()` or `HasAnyMaterial()` as needed.

Character logic has been updated so that when working on an "any" job they will go pick up any reachable inventory listed in the Job's inventoryRequirements.

Furniture now has an `public Inventory[] AcceptsForStorage()` function which is hard coded for now for testing, but which will eventually be hooked up to stockpile UIs. The stockpile LUA has been updated to use this.

I'm thinking about implementing `AcceptsForStorage()` by using the furniture params. The easiest way at the moment would be to store say a JSON list of objectTypes or similar. This way the stockpile settings can be saved easily as well. If PR #552 gets merged this will have to change.

Thoughts?