### PR TITLE
ModUtils: Exposes static Unity C# functions to Lua

### DIFF
--- a/Assets/Scripts/Models/FurnitureActions.cs
+++ b/Assets/Scripts/Models/FurnitureActions.cs
@@ -35,7 +35,8 @@ public class FurnitureActions
         myLuaScript.Globals["Inventory"] = typeof(Inventory);
         myLuaScript.Globals["Job"] = typeof(Job);
 
-		myLuaScript.Globals ["ModUtils"] = typeof(ModUtils);
+        myLuaScript.Globals["ModUtils"] = typeof(ModUtils);
+
         // Also to access statics/globals
         myLuaScript.Globals["World"] = typeof(World);
     }

--- a/Assets/Scripts/Models/FurnitureActions.cs
+++ b/Assets/Scripts/Models/FurnitureActions.cs
@@ -35,6 +35,7 @@ public class FurnitureActions
         myLuaScript.Globals["Inventory"] = typeof(Inventory);
         myLuaScript.Globals["Job"] = typeof(Job);
 
+		myLuaScript.Globals ["ModUtils"] = typeof(ModUtils);
         // Also to access statics/globals
         myLuaScript.Globals["World"] = typeof(World);
     }

--- a/Assets/Scripts/Utilities/ModUtils.cs
+++ b/Assets/Scripts/Utilities/ModUtils.cs
@@ -1,0 +1,11 @@
+﻿using UnityEngine;
+using System.Collections;
+using MoonSharp.Interpreter;
+
+[MoonSharpUserData]
+public static class ModUtils {
+
+	public static float Clamp01(float value) {
+		return Mathf.Clamp01 (value);
+	}
+}

--- a/Assets/Scripts/Utilities/ModUtils.cs
+++ b/Assets/Scripts/Utilities/ModUtils.cs
@@ -1,11 +1,21 @@
-﻿using UnityEngine;
+﻿#region License
+// ====================================================
+// Project Porcupine Copyright(C) 2016 Team Porcupine
+// This program comes with ABSOLUTELY NO WARRANTY; This is free software, 
+// and you are welcome to redistribute it under certain conditions; See 
+// file LICENSE, which is part of this source code package, for details.
+// ====================================================
+#endregion
+
 using System.Collections;
 using MoonSharp.Interpreter;
+using UnityEngine;
 
 [MoonSharpUserData]
-public static class ModUtils {
-
-	public static float Clamp01(float value) {
-		return Mathf.Clamp01 (value);
-	}
+public static class ModUtils
+{
+    public static float Clamp01(float value) 
+    {
+        return Mathf.Clamp01(value); 
+    }
 }

--- a/Assets/Scripts/Utilities/ModUtils.cs
+++ b/Assets/Scripts/Utilities/ModUtils.cs
@@ -18,4 +18,19 @@ public static class ModUtils
     {
         return Mathf.Clamp01(value); 
     }
+
+    public static void Log(object obj) 
+    {
+        Debug.Log(obj);
+    }
+
+    public static void LogWarning(object obj) 
+    {
+        Debug.LogWarning(obj);
+    }
+
+    public static void LogError(object obj) 
+    {
+        Debug.LogError(obj);
+    }
 }

--- a/Assets/Scripts/Utilities/ModUtils.cs.meta
+++ b/Assets/Scripts/Utilities/ModUtils.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: b1f8f684557ab8146a1ff5bfed67c3e8
+timeCreated: 1471402247
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/StreamingAssets/LUA/Furniture.lua
+++ b/Assets/StreamingAssets/LUA/Furniture.lua
@@ -4,17 +4,6 @@ ENTERABILITY_YES  = 0
 ENTERABILITY_NO   = 1
 ENTERABILITY_SOON = 2
 
---------------------------------      UTILITY      --------------------------------
-function Clamp01( value )
-	if (value > 1) then
-		return 1
-	elseif (value < 0) then
-		return 0
-	end
-
-	return value
-end
-
 -------------------------------- Furniture Actions --------------------------------
 function OnUpdate_GasGenerator( furniture, deltaTime )
 	if ( furniture.HasPower() == false) then
@@ -44,7 +33,7 @@ function OnUpdate_Door( furniture, deltaTime )
 		furniture.ChangeParameter("openness", deltaTime * -4)
 	end
 
-	furniture.SetParameter("openness", Clamp01(furniture.GetParameter("openness")) )
+	furniture.SetParameter("openness", ModUtils.Clamp01(furniture.GetParameter("openness")) )
 
 	furniture.UpdateOnChanged(furniture);
 end


### PR DESCRIPTION
This is a replica of the previous modutils #37, without accidentally changing hundreds of files. I don't know if this is needed in the project, but the full discussion never got finished after I messed up that PR.

ModUtils exposes methods in c# by encapsulating them in methods within the ModUtils class. These can then be called in Lua with `ModUtils.MethodName()` and removes the need for a redundant "utilities" section in the Lua files, which was essentially for rewrites of existing c# functions, like `Mathf`.

Bonus: all changes are Style Cop compliant