### PR TITLE
No longer deconstructs walls when this would cause depressurisation

### DIFF
--- a/Assets/Scripts/Controllers/BuildModeController.cs
+++ b/Assets/Scripts/Controllers/BuildModeController.cs
@@ -181,6 +181,33 @@ public class BuildModeController
             // TODO
             if (t.Furniture != null)
             {
+                // check if this is a WALL neighbouring a pressured and pressureless environ & if so bail
+                if (t.Furniture.HasTypeTag("Wall"))
+                {
+                    Tile[] neighbors = t.GetNeighbours(); // diagOkay??
+                    int pressuredNeighbors = 0;
+                    int vacuumNeighbors = 0;
+                    foreach (Tile neighbor in neighbors)
+                    {
+                        if (neighbor != null && neighbor.Room != null)
+                        {
+                            if ((neighbor.Room == World.current.GetOutsideRoom()) || MathUtilities.IsZero(neighbor.Room.GetTotalGasPressure()))
+                            {
+                                vacuumNeighbors++;
+                            }
+                            else
+                            {
+                                pressuredNeighbors++;
+                            }
+                        }
+                    }
+
+                    if (vacuumNeighbors > 0 && pressuredNeighbors > 0)
+                    {
+                        Debug.Log("Someone tried to deconstruct a wall between a pressurised room and vacuum!");
+                        return;
+                    }
+                }
                 t.Furniture.Deconstruct();
             }
             else if (t.PendingBuildJob != null)

--- a/Assets/Scripts/Models/Room.cs
+++ b/Assets/Scripts/Models/Room.cs
@@ -180,6 +180,18 @@ public class Room : IXmlSerializable
         return atmosphericGasses[name] / t;
     }
 
+    public float GetTotalGasPressure()
+    {
+        float t = 0;
+
+        foreach (string n in atmosphericGasses.Keys)
+        {
+            t += atmosphericGasses[n];
+        }
+
+        return t;
+    }
+
     public string[] GetGasNames()
     {
         return atmosphericGasses.Keys.ToArray();


### PR DESCRIPTION
Fixes #685 
Note: need the fix for #639 to test this.

This fix affects deconstructing through the construction menu but not by the right click menu.