### PR TITLE
Door sprites updated

### DIFF
--- a/Assets/Scripts/Controllers/FurnitureSpriteController.cs
+++ b/Assets/Scripts/Controllers/FurnitureSpriteController.cs
@@ -61,9 +61,8 @@ public class FurnitureSpriteController
         // FIXME: This hardcoding is not ideal!
         if (furn.HasTypeTag("Door"))
         {
-            // By default, the door graphic is meant for walls to the east & west
             // Check to see if we actually have a wall north/south, and if so
-            // then rotate this GO by 90 degrees
+            // set the furniture verticalDoor flag to true.
 
             Tile northTile = world.GetTileAt(furn.tile.X, furn.tile.Y + 1);
             Tile southTile = world.GetTileAt(furn.tile.X, furn.tile.Y - 1);
@@ -71,8 +70,9 @@ public class FurnitureSpriteController
             if (northTile != null && southTile != null && northTile.Furniture != null && southTile.Furniture != null &&
                 northTile.Furniture.HasTypeTag("Wall") && southTile.Furniture.HasTypeTag("Wall"))
             {
-                furn_go.transform.rotation = Quaternion.Euler(0, 0, 90);
+                furn.verticalDoor = true;
             }
+            
         }
 
 
@@ -146,9 +146,8 @@ public class FurnitureSpriteController
 
         if (furn.HasTypeTag("Door"))
         {
-            // By default, the door graphic is meant for walls to the east & west
             // Check to see if we actually have a wall north/south, and if so
-            // then rotate this GO by 90 degrees
+            // set the furniture verticalDoor flag to true.
 
             Tile northTile = world.GetTileAt(furn.tile.X, furn.tile.Y + 1);
             Tile southTile = world.GetTileAt(furn.tile.X, furn.tile.Y - 1);
@@ -158,12 +157,12 @@ public class FurnitureSpriteController
             if (northTile != null && southTile != null && northTile.Furniture != null && southTile.Furniture != null &&
                 northTile.Furniture.HasTypeTag("Wall") && southTile.Furniture.HasTypeTag("Wall"))
             {
-                furn_go.transform.rotation = Quaternion.Euler(0, 0, 90);
+                furn.verticalDoor = true;
             }
             else if (eastTile != null && westTile != null && eastTile.Furniture != null && westTile.Furniture != null &&
                 eastTile.Furniture.HasTypeTag("Wall") && westTile.Furniture.HasTypeTag("Wall"))
             {
-                furn_go.transform.rotation = Quaternion.Euler(0, 0, 0);
+                furn.verticalDoor = false;
             }
         }
 

--- a/Assets/Scripts/Models/Furniture.cs
+++ b/Assets/Scripts/Models/Furniture.cs
@@ -111,6 +111,9 @@ public class Furniture : IXmlSerializable, ISelectable, IContextActionProvider, 
         }
     }
 
+    // Flag for Lua to check if this is a vertical or horizontal door and display the correct sprite.
+    public bool verticalDoor = false;
+
     public ENTERABILITY IsEnterable()
     {
         if (isEnterableAction == null || isEnterableAction.Length == 0)

--- a/Assets/StreamingAssets/Images/Furniture/DoorHorizontal.xml
+++ b/Assets/StreamingAssets/Images/Furniture/DoorHorizontal.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Sprites>
+	<Sprite name="DoorHorizontal_0"                x="0" y="128" w="64" h="64" pixelPerUnit="64" />
+	<Sprite name="DoorHorizontal_1"                x="64" y="128" w="64" h="64" pixelPerUnit="64" />
+  <Sprite name="DoorHorizontal_2"                x="0" y="64" w="64" h="64" pixelPerUnit="64" />
+  <Sprite name="DoorHorizontal_3"                x="64" y="64" w="64" h="64" pixelPerUnit="64" />
+	<Sprite name="DoorHorizontal_4"                x="0" y="0" w="64" h="64" pixelPerUnit="64" />
+	<Sprite name="DoorHorizontal_5"                x="64" y="0" w="64" h="64" pixelPerUnit="64" />
+</Sprites>

--- a/Assets/StreamingAssets/Images/Furniture/DoorHorizontal.xml
+++ b/Assets/StreamingAssets/Images/Furniture/DoorHorizontal.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Sprites>
-	<Sprite name="DoorHorizontal_0"                x="0" y="128" w="64" h="64" pixelPerUnit="64" />
-	<Sprite name="DoorHorizontal_1"                x="64" y="128" w="64" h="64" pixelPerUnit="64" />
-  <Sprite name="DoorHorizontal_2"                x="0" y="64" w="64" h="64" pixelPerUnit="64" />
-  <Sprite name="DoorHorizontal_3"                x="64" y="64" w="64" h="64" pixelPerUnit="64" />
-	<Sprite name="DoorHorizontal_4"                x="0" y="0" w="64" h="64" pixelPerUnit="64" />
-	<Sprite name="DoorHorizontal_5"                x="64" y="0" w="64" h="64" pixelPerUnit="64" />
+	<Sprite name="DoorHorizontal_0"	x="0"	y="128"	w="64"	h="64"	pixelPerUnit="64" />
+	<Sprite name="DoorHorizontal_1"	x="64"	y="128"	w="64"	h="64"	pixelPerUnit="64" />
+	<Sprite name="DoorHorizontal_2"	x="0"	y="64"	w="64"	h="64"	pixelPerUnit="64" />
+	<Sprite name="DoorHorizontal_3"	x="64"	y="64"	w="64"	h="64"	pixelPerUnit="64" />
+	<Sprite name="DoorHorizontal_4"	x="0"	y="0"	w="64"	h="64"	pixelPerUnit="64" />
+	<Sprite name="DoorHorizontal_5"	x="64"	y="0"	w="64"	h="64"	pixelPerUnit="64" />
 </Sprites>

--- a/Assets/StreamingAssets/Images/Furniture/DoorHorizontal.xml.meta
+++ b/Assets/StreamingAssets/Images/Furniture/DoorHorizontal.xml.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e4fb75b3a9899cb4e9fa4d020a7bad43
+timeCreated: 1472042717
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/StreamingAssets/Images/Furniture/DoorVertical.xml
+++ b/Assets/StreamingAssets/Images/Furniture/DoorVertical.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Sprites>
+	<Sprite name="DoorVertical_0"                x="0" y="128" w="64" h="64" pixelPerUnit="64" />
+	<Sprite name="DoorVertical_1"                x="64" y="128" w="64" h="64" pixelPerUnit="64" />
+  <Sprite name="DoorVertical_2"                x="0" y="64" w="64" h="64" pixelPerUnit="64" />
+  <Sprite name="DoorVertical_3"                x="64" y="64" w="64" h="64" pixelPerUnit="64" />
+	<Sprite name="DoorVertical_4"                x="0" y="0" w="64" h="64" pixelPerUnit="64" />
+	<Sprite name="DoorVertical_5"                x="64" y="0" w="64" h="64" pixelPerUnit="64" />
+</Sprites>

--- a/Assets/StreamingAssets/Images/Furniture/DoorVertical.xml
+++ b/Assets/StreamingAssets/Images/Furniture/DoorVertical.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Sprites>
-	<Sprite name="DoorVertical_0"                x="0" y="128" w="64" h="64" pixelPerUnit="64" />
-	<Sprite name="DoorVertical_1"                x="64" y="128" w="64" h="64" pixelPerUnit="64" />
-  <Sprite name="DoorVertical_2"                x="0" y="64" w="64" h="64" pixelPerUnit="64" />
-  <Sprite name="DoorVertical_3"                x="64" y="64" w="64" h="64" pixelPerUnit="64" />
-	<Sprite name="DoorVertical_4"                x="0" y="0" w="64" h="64" pixelPerUnit="64" />
-	<Sprite name="DoorVertical_5"                x="64" y="0" w="64" h="64" pixelPerUnit="64" />
+	<Sprite name="DoorVertical_0"	x="0"	y="128"	w="64"	h="64"	pixelPerUnit="64" />
+	<Sprite name="DoorVertical_1"	x="64"	y="128"	w="64"	h="64"	pixelPerUnit="64" />
+	<Sprite name="DoorVertical_2"	x="0"	y="64"	w="64"	h="64"	pixelPerUnit="64" />
+	<Sprite name="DoorVertical_3"	x="64"	y="64"	w="64"	h="64"	pixelPerUnit="64" />
+	<Sprite name="DoorVertical_4"	x="0"	y="0"	w="64"	h="64"	pixelPerUnit="64" />
+	<Sprite name="DoorVertical_5"	x="64"	y="0"	w="64"	h="64"	pixelPerUnit="64" />
 </Sprites>

--- a/Assets/StreamingAssets/Images/Furniture/DoorVertical.xml.meta
+++ b/Assets/StreamingAssets/Images/Furniture/DoorVertical.xml.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9e09ba01fe4fe9646acc3c57e36d1a0d
+timeCreated: 1472042986
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/StreamingAssets/LUA/Furniture.lua
+++ b/Assets/StreamingAssets/LUA/Furniture.lua
@@ -64,20 +64,54 @@ function IsEnterable_Door( furniture )
 end
 
 function GetSpriteName_Door( furniture )
+	if (furniture.verticalDoor == true) then
+			-- Door is closed
+		if (furniture.Parameters["openness"].ToFloat() < 0.1) then
+			return "DoorVertical_0"
+		end
+
+		if (furniture.Parameters["openness"].ToFloat() < 0.25) then
+			return "DoorVertical_1"
+		end
+
+		if (furniture.Parameters["openness"].ToFloat() < 0.5) then
+			return "DoorVertical_2"
+		end
+
+		if (furniture.Parameters["openness"].ToFloat() < 0.75) then
+			return "DoorVertical_3"
+		end
+
+		if (furniture.Parameters["openness"].ToFloat() < 0.9) then
+			return "DoorVertical_4"
+		end
+		-- Door is a fully open
+		return "DoorVertical_5"
+	end
+
+
 	-- Door is closed
 	if (furniture.Parameters["openness"].ToFloat() < 0.1) then
-		return "Door"
+		return "DoorHorizontal_0"
 	end
-	-- Door is a bit open
+	
+	if (furniture.Parameters["openness"].ToFloat() < 0.25) then
+		return "DoorHorizontal_1"
+	end
+	
 	if (furniture.Parameters["openness"].ToFloat() < 0.5) then
-		return "Door_openness_1"
+		return "DoorHorizontal_2"
 	end
-	-- Door is a lot open
+
+	if (furniture.Parameters["openness"].ToFloat() < 0.75) then
+		return "DoorHorizontal_3"
+	end
+
 	if (furniture.Parameters["openness"].ToFloat() < 0.9) then
-		return "Door_openness_2"
+		return "DoorHorizontal_4"
 	end
 	-- Door is a fully open
-	return "Door_openness_3"
+	return "DoorHorizontal_5"
 end
 
 function GetSpriteName_Airlock( furniture )


### PR DESCRIPTION
This replaces the old door sprites with the new ones created by @longtomjr

It adds a flag to the furniture (probably not the final solution!) that is then set by the `FurnitureSpriteController` instead of rotating the game object.

This is checked by the Lua code in `GetSpriteName_Door` to determine which sprite sheet to use.

`openness` still determines which sprite to use but now has a wider selection.

Includes the XML from #742 also created by @longtomjr 