### PR TITLE
Rewriting Parameter unit test to match implementation & increasing coverage

### DIFF
--- a/Assets/Editor/ParametersEditorTest.cs
+++ b/Assets/Editor/ParametersEditorTest.cs
@@ -112,6 +112,22 @@ public class ParametersEditorTest
     }
 
     [Test]
+    public void ParameterWithValueAndContents()
+    {
+        Parameter param2 = new Parameter("Alice");
+        Assert.That(param2.ToString(), Is.Null);
+
+        param2.SetValue("test");
+        Assert.That(param2.ToString(), Is.EqualTo("test"));
+        Assert.That(param2.ContainsKey("Bob"), Is.False);
+
+        param2.AddParameter(new Parameter("Bob"));
+        Assert.That(param2.ToString(), Is.EqualTo("test"));
+        Assert.That(param2.ContainsKey("Bob"), Is.True);
+        Assert.That(param2["Bob"].GetName(), Is.EqualTo("Bob"));
+    }
+
+    [Test]
     public void ParameterCopyConstructorDoesDeepCopy()
     {
         Parameter param2 = new Parameter(param1);

--- a/Assets/Editor/ParametersEditorTest.cs
+++ b/Assets/Editor/ParametersEditorTest.cs
@@ -85,14 +85,18 @@ public class ParametersEditorTest
         Assert.That(param1["gas_gen"]["N2"]["gas_limit"].ToString(), Is.EqualTo("0.8"));
     }
 
-    // FIXME: This test must be rewritten if lazy evaluation is implemented as per PR #746
     [Test]
-    [ExpectedException(typeof(KeyNotFoundException))]
     public void ParameterAccessingKeyNotDefined()
     {
         Assert.That(param1.ContainsKey("bad_key"), Is.False);
 
+        // accessing it creates a new empty Parameter
         Parameter param2 = param1["bad_key"];
+        Assert.That(param1.ContainsKey("bad_key"), Is.True);
+        Assert.That(param2.ToString(), Is.Null);
+        Assert.That(param2.ToFloat(), Is.EqualTo(0));
+        Assert.That(param2.Keys(), Is.EqualTo(new string[] {}));
+        Assert.That(param2.HasContents(), Is.False);
     }
 
     [Test]


### PR DESCRIPTION
Do as I say, kids, not as I do. #746 broke one of the tests by changing the spec (such as it is) as expected, so I rewrote the test. Also wrote a new test (already passing) checking behavior of Parameters which have a value as well as a sub-parameter.

Question: should Parameters override equality operators? It appears they compare by reference, not value as I would expect... There should be test coverage either way but I've held off because there isn't really a defined behavior yet. What do people want?

I could either put a [WIP] on this if you want to discuss it here or open an Issue and let this be merged for now.