### PR TITLE
Lua runtime exception handling

### DIFF
--- a/Assets/Scripts/Utilities/LuaUtilities.cs
+++ b/Assets/Scripts/Utilities/LuaUtilities.cs
@@ -26,7 +26,17 @@ public class LuaUtilities {
             Debug.ULogChannel("Lua", "'" + functionName + "' is not a LUA function!");
         }
 
-        return luaScript.Call(func, args);
+        try
+        {
+            return luaScript.Call(func, args);
+        }
+        catch (ScriptRuntimeException e)
+        {
+            Debug.LogError( e.DecoratedMessage );
+            Debug.LogError( e.InstructionPtr.ToString() );
+            Debug.LogError( e.CallStack.ToString() );
+            return null;
+        }
     }
     
     static void LoadScript(string script)

--- a/Assets/Scripts/Utilities/LuaUtilities.cs
+++ b/Assets/Scripts/Utilities/LuaUtilities.cs
@@ -33,8 +33,6 @@ public class LuaUtilities {
         catch (ScriptRuntimeException e)
         {
             Debug.LogError( e.DecoratedMessage );
-            Debug.LogError( e.InstructionPtr.ToString() );
-            Debug.LogError( e.CallStack.ToString() );
             return null;
         }
     }


### PR DESCRIPTION
I haven't found a way to replace the unclear "chunk2" parts of these exceptions with Lua filenames, but in any case this includes a line number reference in the Moonsharp runtime errors that is very helpful for debugging.