### PR TITLE
Room deletion

### DIFF
--- a/Assets/Scripts/Models/Room.cs
+++ b/Assets/Scripts/Models/Room.cs
@@ -273,6 +273,16 @@ public class Room : IXmlSerializable
             // though this MAY not be the case any longer (i.e. the wall was 
             // probably deconstructed. So the only thing we have to try is
             // to spawn ONE new room starting from the tile in question.
+
+            // You need to delete the surrounding rooms so a new room can be created
+            // This doesn't work for the gas calculations and needs to be fixed.
+            foreach (Tile t in sourceTile.GetNeighbours())
+            {
+                if (t.Room != null && (onlyIfOutside == false || t.Room.IsOutsideRoom()))
+                {
+                    world.DeleteRoom(t.Room);
+                }
+            }
             ActualFloodFill(sourceTile, null, 0);
         }
     }

--- a/Assets/Scripts/Models/World.cs
+++ b/Assets/Scripts/Models/World.cs
@@ -111,6 +111,7 @@ public class World : IXmlSerializable
     public void AddRoom(Room r)
     {
         rooms.Add(r);
+        Debug.ULogChannel("Rooms","creating room:" + r.ID);
     }
 
     public int CountFurnitureType(string objectType)
@@ -121,12 +122,12 @@ public class World : IXmlSerializable
 
     public void DeleteRoom(Room r)
     {
-        if (r == GetOutsideRoom())
+        if (r.IsOutsideRoom())
         {
             Debug.LogError("Tried to delete the outside room.");
             return;
         }
-
+        Debug.ULogChannel("Rooms","Deleting room:" + r.ID);
         // Remove this room from our rooms list.
         rooms.Remove(r);
 


### PR DESCRIPTION
There was a bug in the furniture deconstruction code that when a wall was deconstructed the surrounding walls where never deleted.

This just deletes the rooms before doing the flood fill however this won't preserve the gas calculations. 