### PR TITLE
Added check against null Object

### DIFF
--- a/Assets/Scripts/Models/Character.cs
+++ b/Assets/Scripts/Models/Character.cs
@@ -67,13 +67,13 @@ public class Character : IXmlSerializable, ISelectable, IContextActionProvider
         }
     }
     Need[] needs;
-    
+
     /// <summary>
     /// The tile the Character is considered to still be standing in.
     /// </summary>
     public Tile CurrTile
     {
-        get 
+        get
         {
             return _currTile;
         }
@@ -98,8 +98,8 @@ public class Character : IXmlSerializable, ISelectable, IContextActionProvider
     /// </summary>
     private Tile DestTile
     {
-        get 
-        { 
+        get
+        {
             return _destTile;
         }
 
@@ -209,7 +209,7 @@ public class Character : IXmlSerializable, ISelectable, IContextActionProvider
         characterColor = color;
 		LoadNeeds();
     }
-    
+
     private void GetNewJob()
     {
         float needPercent = 0;
@@ -256,7 +256,7 @@ public class Character : IXmlSerializable, ISelectable, IContextActionProvider
 
         // Get our destination from the job
         DestTile = myJob.tile;
-        
+
         // If the dest tile does not have neighbours that are walkable it's very likable that they can't be walked to
         if (DestTile.GetNeighbours().Any((tile) => { return tile.MovementCost > 0; }) == false)
         {
@@ -302,7 +302,7 @@ public class Character : IXmlSerializable, ISelectable, IContextActionProvider
     private void Update_DoJob(float deltaTime)
     {
         // Check if I already have a job.
-        if (myJob == null) 
+        if (myJob == null)
         {
             GetNewJob();
 
@@ -317,7 +317,7 @@ public class Character : IXmlSerializable, ISelectable, IContextActionProvider
 
         // Make sure all materials are in place.
         if (CheckForJobMaterials())
-        { 
+        {
             // If we get here, then the job has all the material that it needs.
             // Lets make sure that our destination tile is the job site tile.
             DestTile = JobTile;
@@ -497,7 +497,7 @@ public class Character : IXmlSerializable, ISelectable, IContextActionProvider
     /// Fulfillable inventory requirements for job.
     /// </summary>
     /// <returns>A list of (string) objectTypes for job inventory requirements that can be met. Returns null if the job requires materials which do not exist on the map.</returns>
-    private List<string> FulfillableInventoryRequirements(Job job) 
+    private List<string> FulfillableInventoryRequirements(Job job)
     {
         List<string> fulfillableInventoryRequirements = new List<string>();
 
@@ -532,7 +532,7 @@ public class Character : IXmlSerializable, ISelectable, IContextActionProvider
         return destHasInventory &&
                 !(pathAStar.EndTile().Furniture != null && (myJob.canTakeFromStockpile == false && pathAStar.EndTile().Furniture.IsStockpile() == true));
     }
-    
+
     /// <summary>
     /// This function instructs the character to null its inventory.
     /// However in the fuure it should actually look for a place to dump the materials and then do so.
@@ -655,12 +655,12 @@ public class Character : IXmlSerializable, ISelectable, IContextActionProvider
         else if (NextTile.Y > CurrTile.Y)
         {
             CharFacing = Facing.NORTH;
-        }        
+        }
         else
         {
             CharFacing = Facing.SOUTH;
         }
-        
+
         // At this point we should have a valid nextTile to move to.
 
         // What's the total distance from point A to point B?
@@ -761,8 +761,8 @@ public class Character : IXmlSerializable, ISelectable, IContextActionProvider
         {
             List<string> desired = FulfillableInventoryRequirements(job);
 
-            // Check if the created inventory can fulfill the waiting job
-            if (desired.Contains(inv.objectType))
+            // Check if the created inventory can fulfill the waiting job requirements.
+            if (desired != null && desired.Contains(inv.objectType))
             {
                 // If so, enqueue the job onto the (normal)
                 // job queue.


### PR DESCRIPTION
```
NullReferenceException: Object reference not set to an instance of an object
Character.OnInventoryCreated (Inventory) (at Assets/Scripts/Models/Character.cs:765)
World.OnInventoryCreated (Inventory) (at Assets/Scripts/Models/World.cs:1092)
InventoryManager.PlaceInventory (Tile,Inventory) (at Assets/Scripts/Models/InventoryManager.cs:71)
(wrapper dynamic-method) System.Runtime.CompilerServices.ExecutionScope.lambda_method (System.Runtime.CompilerServices.ExecutionScope,object,object[]) <IL 0x00035, 0x00150>
MoonSharp.Interpreter.Interop.MethodMemberDescriptor.Execute (MoonSharp.Interpreter.Script,object,MoonSharp.Interpreter.ScriptExecutionContext,MoonSharp.Interpreter.CallbackArguments) <IL 0x00049, 0x00231>
MoonSharp.Interpreter.Interop.OverloadedMethodMemberDescriptor.PerformOverloadedCall (MoonSharp.Interpreter.Script,object,MoonSharp.Interpreter.ScriptExecutionContext,MoonSharp.Interpreter.CallbackArguments) <IL 0x001b6, 0x00c14>
MoonSharp.Interpreter.Interop.OverloadedMethodMemberDescriptor/<>c__DisplayClass33_0.<GetCallback>b__0 (MoonSharp.Interpreter.ScriptExecutionContext,MoonSharp.Interpreter.CallbackArguments) <IL 0x00014, 0x00075>
MoonSharp.Interpreter.CallbackFunction.Invoke (MoonSharp.Interpreter.ScriptExecutionContext,System.Collections.Generic.IList`1<MoonSharp.Interpreter.DynValue>,bool) <IL 0x0000e, 0x000dc>
MoonSharp.Interpreter.Execution.VM.Processor.Internal_ExecCall (int,int,MoonSharp.Interpreter.CallbackFunction,MoonSharp.Interpreter.CallbackFunction,bool,string,MoonSharp.Interpreter.DynValue) <IL 0x00188, 0x00aa7>
MoonSharp.Interpreter.Execution.VM.Processor.Processing_Loop (int) <IL 0x002f1, 0x00db2>
MoonSharp.Interpreter.Execution.VM.Processor.Call (MoonSharp.Interpreter.DynValue,MoonSharp.Interpreter.DynValue[]) <IL 0x00077, 0x00388>
MoonSharp.Interpreter.Script.Call (MoonSharp.Interpreter.DynValue,MoonSharp.Interpreter.DynValue[]) <IL 0x000a4, 0x00594>
MoonSharp.Interpreter.Script.Call (MoonSharp.Interpreter.DynValue,object[]) <IL 0x00026, 0x001af>
MoonSharp.Interpreter.Script.Call (object,object[]) <IL 0x00009, 0x0008c>
LuaUtilities.CallFunction (string,object[]) (at Assets/Scripts/Utilities/LuaUtilities.cs:32)
Job.DoWork (single) (at Assets/Scripts/Models/Job.cs:221)
Character.CheckForJobMaterials () (at Assets/Scripts/Models/Character.cs:384)
Character.Update_DoJob (single) (at Assets/Scripts/Models/Character.cs:319)
Character.Update (single) (at Assets/Scripts/Models/Character.cs:722)
World.UpdateCharacters (single) (at Assets/Scripts/Models/World.cs:235)
WorldController.Update () (at Assets/Scripts/Controllers/WorldController.cs:134)
```

This error was introduced in PR #670.
It can be caused when a character takes a job, but no inventory matching a requirement is available. This is due to a missing check against null.
My editor removed the trailing white spaces by itself...
Just use the `?w=1` option.