### PR TITLE
Put JobPriority enum into Job class

### DIFF
--- a/Assets/Scripts/Controllers/BuildModeController.cs
+++ b/Assets/Scripts/Controllers/BuildModeController.cs
@@ -111,7 +111,7 @@ public class BuildModeController
                 else
                 {
                     Debug.ULogErrorChannel("BuildModeController", "There is no furniture job prototype for '" + furnitureType + "'");
-                    j = new Job(t, furnitureType, FurnitureActions.JobComplete_FurnitureBuilding, 0.1f, null, JobPriority.High);
+                    j = new Job(t, furnitureType, FurnitureActions.JobComplete_FurnitureBuilding, 0.1f, null, Job.JobPriority.High);
                     j.JobDescription = "job_build_" + furnitureType + "_desc";
                 }
 

--- a/Assets/Scripts/Models/Character.cs
+++ b/Assets/Scripts/Models/Character.cs
@@ -459,12 +459,12 @@ public class Character : IXmlSerializable, ISelectable, IContextActionProvider
 
         if (needPercent > 50 && needPercent < 100 && need != null)
         {
-            MyJob = new Job(null, need.RestoreNeedFurn.ObjectType, need.CompleteJobNorm, need.RestoreNeedTime, null, JobPriority.High, false, true, false);
+            MyJob = new Job(null, need.RestoreNeedFurn.ObjectType, need.CompleteJobNorm, need.RestoreNeedTime, null, Job.JobPriority.High, false, true, false);
         }
 
         if (needPercent == 100 && need != null && need.CompleteOnFail)
         {
-            MyJob = new Job(CurrTile, null, need.CompleteJobCrit, need.RestoreNeedTime * 10, null, JobPriority.High, false, true, true);
+            MyJob = new Job(CurrTile, null, need.CompleteJobCrit, need.RestoreNeedTime * 10, null, Job.JobPriority.High, false, true, true);
         }
 
         // Get the first job on the queue.
@@ -482,7 +482,7 @@ public class Character : IXmlSerializable, ISelectable, IContextActionProvider
                     null,
                     UnityEngine.Random.Range(0.1f, 0.5f),
                     null,
-                    JobPriority.Low,
+                    Job.JobPriority.Low,
                     false);
                 MyJob.JobDescription = "job_waiting_desc";
             }

--- a/Assets/Scripts/Models/Furniture.cs
+++ b/Assets/Scripts/Models/Furniture.cs
@@ -452,7 +452,7 @@ public class Furniture : IXmlSerializable, ISelectable, IContextActionProvider, 
                     FurnitureActions.JobComplete_FurnitureBuilding,
                     jobTime,
                     invs.ToArray(),
-                    JobPriority.High);
+                    Job.JobPriority.High);
                 j.JobDescription = "job_build_" + ObjectType + "_desc";
                 World.Current.SetFurnitureJobPrototype(j, this);
                 break;

--- a/Assets/Scripts/Models/Job.cs
+++ b/Assets/Scripts/Models/Job.cs
@@ -12,11 +12,6 @@ using System.Linq;
 using MoonSharp.Interpreter;
 using UnityEngine;
 
-public enum JobPriority
-{
-    High, Medium, Low
-}
-
 [MoonSharpUserData]
 public class Job
 {
@@ -56,16 +51,16 @@ public class Job
     // The job has been stopped, either because it's non-repeating or was cancelled.
     private List<string> jobCompletedLua;
 
-    public Job(Tile tile, string jobObjectType, Action<Job> jobComplete, float jobTime, Inventory[] inventoryRequirements, JobPriority jobPriority, bool jobRepeats = false, bool isNeed = false, bool critical = false)
+    public Job(Tile tile, string jobObjectType, Action<Job> jobComplete, float jobTime, Inventory[] inventoryRequirements, Job.JobPriority jobPriority, bool jobRepeats = false, bool need = false, bool critical = false)
     {
         this.tile = tile;
         this.JobObjectType = jobObjectType;
         this.OnJobCompleted += jobComplete;
         this.jobTimeRequired = this.JobTime = jobTime;
         this.jobRepeats = jobRepeats;
-        this.IsNeed = isNeed;
+        this.IsNeed = need;
         this.Critical = critical;
-        this.JobPriority = jobPriority;
+        this.Priority = jobPriority;
         this.JobDescription = "job_error_missing_desc";
 
         jobWorkedLua = new List<string>();
@@ -81,14 +76,14 @@ public class Job
         }
     }
 
-    public Job(Tile tile, TileType jobTileType, Action<Job> jobCompleted, float jobTime, Inventory[] inventoryRequirements, JobPriority jobPriority, bool jobRepeats = false, bool adjacent = false)
+    public Job(Tile tile, TileType jobTileType, Action<Job> jobCompleted, float jobTime, Inventory[] inventoryRequirements, Job.JobPriority jobPriority, bool jobRepeats = false, bool adjacent = false)
     {
         this.tile = tile;
         this.JobTileType = jobTileType;
         this.OnJobCompleted += jobCompleted;
         this.jobTimeRequired = this.JobTime = jobTime;
         this.jobRepeats = jobRepeats;
-        this.JobPriority = jobPriority;
+        this.Priority = jobPriority;
         this.adjacent = adjacent;
         this.JobDescription = "job_error_missing_desc";
 
@@ -112,7 +107,7 @@ public class Job
         this.JobTileType = other.JobTileType;
         this.OnJobCompleted = other.OnJobCompleted;
         this.JobTime = other.JobTime;
-        this.JobPriority = other.JobPriority;
+        this.Priority = other.Priority;
         this.adjacent = other.adjacent;
         this.JobDescription = other.JobDescription;
         this.acceptsAny = other.acceptsAny;
@@ -137,6 +132,11 @@ public class Job
 
     // Gets called each time some work is performed -- maybe update the UI?
     public event Action<Job> OnJobWorked;
+
+    public enum JobPriority
+    {
+        High, Medium, Low
+    }
 
     public string JobDescription { get; set; }
 
@@ -172,7 +172,7 @@ public class Job
         protected set;
     }
 
-    public JobPriority JobPriority
+    public JobPriority Priority
     {
         get;
         protected set;
@@ -360,6 +360,6 @@ public class Job
     public void DropPriority()
     {
         // TODO: This casting to and from enums are a bit wierd. We should decide on ONE priority system.
-        this.JobPriority = (JobPriority)Mathf.Min((int)JobPriority.Low, (int)JobPriority + 1);
+        this.Priority = (Job.JobPriority)Mathf.Min((int)Job.JobPriority.Low, (int)Priority + 1);
     }
 }

--- a/Assets/Scripts/Models/JobQueue.cs
+++ b/Assets/Scripts/Models/JobQueue.cs
@@ -12,11 +12,11 @@ using UnityEngine;
 
 public class JobQueue
 {
-    private SortedList<JobPriority, Job> jobQueue;
+    private SortedList<Job.JobPriority, Job> jobQueue;
 
     public JobQueue()
     {
-        jobQueue = new SortedList<JobPriority, Job>(new DuplicateKeyComparer<JobPriority>(true));
+        jobQueue = new SortedList<Job.JobPriority, Job>(new DuplicateKeyComparer<Job.JobPriority>(true));
     }
 
     public event Action<Job> OnJobCreated;
@@ -43,7 +43,7 @@ public class JobQueue
             return;
         }
 
-        jobQueue.Add(j.JobPriority, j);
+        jobQueue.Add(j.Priority, j);
         Debug.Log("Enqueued job for " + j.JobObjectType ?? string.Empty);
         if (OnJobCreated != null)
         {

--- a/Assets/Scripts/Models/TileType.cs
+++ b/Assets/Scripts/Models/TileType.cs
@@ -227,7 +227,7 @@ public class TileType : IXmlSerializable
                         Tile.ChangeTileTypeJobComplete,
                         jobTime,
                         invs.ToArray(),
-                        JobPriority.High,
+                        Job.JobPriority.High,
                         false,
                         true);
                     j.JobDescription = "job_build_floor_" + this;

--- a/Assets/StreamingAssets/LUA/Furniture.lua
+++ b/Assets/StreamingAssets/LUA/Furniture.lua
@@ -11,11 +11,6 @@ ENTERABILITY_YES = 0
 ENTERABILITY_NO = 1
 ENTERABILITY_SOON = 2
 
--- JobPriority
-JOBPRIORITY_HIGH = 0
-JOBPRIORITY_MEDIUM = 1
-JOBPRIORITY_LOW = 2
-
 -- HOWTO Log:
 -- ModUtils.ULog("Testing ModUtils.ULogChannel")
 -- ModUtils.ULogWarning("Testing ModUtils.ULogWarningChannel")
@@ -229,7 +224,7 @@ function Stockpile_UpdateAction( furniture, deltaTime )
 		nil,
 		0,
 		itemsDesired,
-		JOBPRIORITY_LOW,
+		Job.JobPriority.Low,
 		false
 	)
 	j.JobDescription = "job_stockpile_moving_desc"
@@ -286,7 +281,7 @@ function MiningDroneStation_UpdateAction( furniture, deltaTime )
 		nil,
 		1,
 		nil,
-		JOBPRIORITY_MEDIUM,
+		Job.JobPriority.Medium,
 		true	-- This job repeats until the destination tile is full.
 	)
 
@@ -364,7 +359,7 @@ function MetalSmelter_UpdateAction(furniture, deltaTime)
         nil,
         0.4,
         itemsDesired,
-        JOBPRIORITY_MEDIUM,
+        Job.JobPriority.Medium,
         false
     )
 
@@ -399,7 +394,7 @@ function PowerCellPress_UpdateAction(furniture, deltaTime)
                 nil,
                 1,
                 itemsDesired,
-                JOBPRIORITY_MEDIUM,
+                Job.JobPriority.Medium,
                 false
             )
 
@@ -453,7 +448,7 @@ function CloningPod_UpdateAction(furniture, deltaTime)
         nil,
         10,
         nil,
-        JOBPRIORITY_MEDIUM,
+        Job.JobPriority.Medium,
         false
     )
 
@@ -478,7 +473,7 @@ function PowerGenerator_UpdateAction(furniture, deltatime)
             nil,
             0.5,
             itemsDesired,
-            JOBPRIORITY_HIGH,
+            Job.JobPriority.High,
             false
         )
 
@@ -517,7 +512,7 @@ function LandingPad_Temp_UpdateAction(furniture, deltaTime)
                 nil,
                 0.4,
                 itemsDesired,
-                JOBPRIORITY_MEDIUM,
+                Job.JobPriority.Medium,
                 false
             )
 


### PR DESCRIPTION
I put the JobPriority enum back into the Job class to make it accessible from Lua without having to define global replacements for them in the Lua files.
For this, I had to rename the JobPriority property to Priority.

**_I do think that this is an acceptable name for the property._**
**_If you think otherwise, then please explain why and maybe how to solve it differently._**