### PR TITLE
Allow airlock doors to be pressure locked

### DIFF
--- a/Assets/Scripts/Utilities/ModUtils.cs
+++ b/Assets/Scripts/Utilities/ModUtils.cs
@@ -26,6 +26,11 @@ public static class ModUtils
         return Mathf.FloorToInt(value);
     }
 
+    public static float Round(float value, int digits)
+    {
+        return Round(value, digits);
+    }
+
     public static void Log(object obj) 
     {
         Debug.Log(obj);

--- a/Assets/Scripts/Utilities/ModUtils.cs
+++ b/Assets/Scripts/Utilities/ModUtils.cs
@@ -28,7 +28,7 @@ public static class ModUtils
 
     public static float Round(float value, int digits)
     {
-        return Round(value, digits);
+        return (float)System.Math.Round((double)value, digits);
     }
 
     public static void Log(object obj) 

--- a/Assets/StreamingAssets/Data/Furniture.xml
+++ b/Assets/StreamingAssets/Data/Furniture.xml
@@ -98,12 +98,14 @@
             <Param name="thermal_diffusivity" value="0.00001" />
         </Params>
 
-        <Action event="OnUpdate" functionName="OnUpdate_Door" />
+        <Action event="OnUpdate" functionName="OnUpdate_AirlockDoor" />
         <Action event="OnUpdate" functionName="OnUpdate_Leak_Airlock" />
+        
+        <ContextMenuAction FunctionName="AirlockDoor_Toggle_Pressure_Lock" Text="Toggle Pressure Lock" RequiereCharacterSelected="false"/>
 
         <IsEnterable FunctionName="IsEnterable_Door" />
         <GetSpriteName FunctionName="GetSpriteName_Airlock" />
-
+        
         <LocalizationCode>furn_airlock</LocalizationCode>
         <UnlocalizedDescription>furn_airlock_desc</UnlocalizedDescription>
 

--- a/Assets/StreamingAssets/LUA/Furniture.lua
+++ b/Assets/StreamingAssets/LUA/Furniture.lua
@@ -51,6 +51,43 @@ function OnUpdate_Door( furniture, deltaTime )
 	furniture.UpdateOnChanged(furniture);
 end
 
+
+function OnUpdate_AirlockDoor( furniture, deltaTime )
+    if (furniture.Parameters["pressure_locked"].ToFloat() >= 1.0) then
+        local neighbors = furniture.Tile.GetNeighbours(false)
+        local adjacentRooms = {}
+        local pressureEqual = true;
+        local count = 0
+        for k, tile in pairs(neighbors) do
+            if (tile.Room != nil) then
+                count = count + 1
+                adjacentRooms[count] = tile.Room
+            end
+        end
+        
+        if(adjacentRooms[1].GetTotalGasPressure() == adjacentRooms[2].GetTotalGasPressure()) then
+            OnUpdate_Door(furniture, deltaTime)
+        end
+    else
+        OnUpdate_Door(furniture, deltaTime)
+    end
+end
+        
+    
+function AirlockDoor_Toggle_Pressure_Lock(furniture, character)
+
+    ModUtils.ULog("Toggling Pressure Lock")
+    
+	if (furniture.Parameters["pressure_locked"].ToFloat() == 1) then
+        furniture.Parameters["pressure_locked"].SetValue(0)
+    else
+        furniture.Parameters["pressure_locked"].SetValue(1)
+    end
+    
+    ModUtils.ULog(furniture.Parameters["pressure_locked"].ToFloat())
+end
+
+
 function OnUpdate_Leak_Door( furniture, deltaTime )
 	furniture.Tile.EqualiseGas(deltaTime * 10.0 * (furniture.Parameters["openness"].ToFloat() + 0.1))
 end

--- a/Assets/StreamingAssets/LUA/Furniture.lua
+++ b/Assets/StreamingAssets/LUA/Furniture.lua
@@ -64,8 +64,7 @@ function OnUpdate_AirlockDoor( furniture, deltaTime )
                 adjacentRooms[count] = tile.Room
             end
         end
-        
-        if(adjacentRooms[1].GetTotalGasPressure() == adjacentRooms[2].GetTotalGasPressure()) then
+        if(ModUtils.Round(adjacentRooms[1].GetTotalGasPressure(),3) == ModUtils.Round(adjacentRooms[2].GetTotalGasPressure(),3)) then
             OnUpdate_Door(furniture, deltaTime)
         end
     else


### PR DESCRIPTION
Airlock doors can now be pressure locked (only open when the pressure is equal on both sides, accurate to 3 decimals).

This currently doesn't do much as there is no way to change the pressure in a room other than to open doors, or otherwise put a hole in a wall, but is the first step to allowing airlock doors to be used to make a proper airlock.

Default is for them to not be pressure locked (toggled from context menu) so as to not create any difficulties in using airlock doors before some form of pressure pump is added. For now airlock doors will continue to behave as before, unless the pressure lock is toggled on, then in most cases they just won't open (since there is no way to change the pressure in a room).

To test, a hole can be made in an outside wall, to dump all the atmosphere, then a pressure locked door will be able to open.

Additionally access to System.Math.Round (through ModUtils) was needed to allow rounding to a given decimal place (so as to avoid multiple steps to achieve the same effect. If a Gatekeeper would prefer not to use System.Math, I can change it to use Mathf.Round, and more steps, or Lua's Floor and multiple steps.