### PR TITLE
[small] Add null tile check to SpawnInventory

### DIFF
--- a/Assets/Scripts/Controllers/SpawnInventoryController.cs
+++ b/Assets/Scripts/Controllers/SpawnInventoryController.cs
@@ -39,6 +39,12 @@ public class SpawnInventoryController
 
     public void SpawnInventory(Tile t)
     {
+        // If the user clicks outside the game area t may be null.
+        if (t == null)
+        {
+            return;
+        }
+
         Inventory inventoryChange = new Inventory(InventoryToBuild, 1);
 
         // You can't spawn on occupied tiles


### PR DESCRIPTION
It's possible to generate `NullReferenceException`s by clicking off the map in dev spawn mode. This just fixes that.