### PR TITLE
Fix character-generation overloads

### DIFF
--- a/Assets/Scripts/Models/World.cs
+++ b/Assets/Scripts/Models/World.cs
@@ -165,7 +165,13 @@ public class World : IXmlSerializable
 
     public Character CreateCharacter(Tile t)
     {
-        Character c = new Character(t);
+        return CreateCharacter(t, UnityEngine.Random.ColorHSV());
+    }
+
+    public Character CreateCharacter(Tile t, Color color)
+    {
+        Debug.ULogChannel("World", "CreateCharacter");
+        Character c = new Character(t, color);
 
         // Adds a random name to the Character
         string filePath = System.IO.Path.Combine(Application.streamingAssetsPath, "Data");
@@ -173,21 +179,6 @@ public class World : IXmlSerializable
 
         string[] names = File.ReadAllLines(filePath);
         c.name = names[UnityEngine.Random.Range(0, names.Length - 1)];
-        characters.Add(c);
-
-        if (OnCharacterCreated != null)
-        {
-            OnCharacterCreated(c);
-        }
-
-        return c;
-    }
-
-    public Character CreateCharacter(Tile t, Color color)
-    {
-        Debug.ULogChannel("World", "CreateCharacter");
-        Character c = new Character(t, color); 
-
         characters.Add(c);
 
         if (OnCharacterCreated != null)


### PR DESCRIPTION
Characters now have random colors by default and overloads utilize each other so that there's no code duplication. This also fixes characters that were being generated without a color not having a random name, since that function just calls the other overload with a random color.