### PR TITLE
Implement PathfindingWeights

### DIFF
--- a/Assets/Scripts/Models/Furniture.cs
+++ b/Assets/Scripts/Models/Furniture.cs
@@ -147,11 +147,24 @@ public class Furniture : IXmlSerializable, ISelectable, IContextActionProvider, 
     public event Action<IPowerRelated> PowerValueChanged;
 
     // The effective pathfinding cost of pathing over this furniture
+    public float PathfindingCost
+    {
+        get
+        {
+            return PathfindingWeight * MovementCost;
+        }
+    }
+
     public float PathfindingWeight
     {
         get
         {
-            return pathfindingWeight * MovementCost;
+            return pathfindingWeight;
+        }
+
+        set
+        {
+            pathfindingWeight = value;
         }
     }
 

--- a/Assets/Scripts/Models/Furniture.cs
+++ b/Assets/Scripts/Models/Furniture.cs
@@ -24,6 +24,9 @@ public class Furniture : IXmlSerializable, ISelectable, IContextActionProvider, 
     // Prevent construction too close to the world's edge
     private const int MinEdgeDistance = 5;
 
+    // Base cost of pathfinding over this furniture, movement cost will modify the effective value
+    private float pathfindingWeight = 1f;
+
     // If the job causes some kind of object to be spawned, where will it appear?
     private Vector2 jobSpawnSpotOffset = Vector2.zero;
 
@@ -142,6 +145,15 @@ public class Furniture : IXmlSerializable, ISelectable, IContextActionProvider, 
     public event Action<Furniture> Removed;
 
     public event Action<IPowerRelated> PowerValueChanged;
+
+    // The effective pathfinding cost of pathing over this furniture
+    public float PathfindingWeight
+    {
+        get
+        {
+            return pathfindingWeight * MovementCost;
+        }
+    }
 
     public Color Tint { get; private set; }
 

--- a/Assets/Scripts/Models/Furniture.cs
+++ b/Assets/Scripts/Models/Furniture.cs
@@ -151,32 +151,22 @@ public class Furniture : IXmlSerializable, ISelectable, IContextActionProvider, 
 
     public event Action<IPowerRelated> PowerValueChanged;
 
-    // PathfindingModifier is added to PathfindingCost to get the final amount
+    /// <summary>
+    /// Gets or sets the Furniture's pathfinding modifier which is added into the Tile's final PathfindingCost.
+    /// </summary>
     public float PathfindingModifier
     {
-        get
-        {
-            return pathfindingWeight;
-        }
-
-        set
-        {
-            pathfindingWeight = value;
-        }
+        get { return pathfindingWeight; }
+        set { pathfindingWeight = value; }
     }
 
-    // PathfindingWeight is multiplied by movement cost to get total PathfindingCost
+    /// <summary>
+    /// Gets or sets the Furniture's pathfinding weight which is multiplied into the Tile's final PathfindingCost.
+    /// </summary>
     public float PathfindingWeight
     {
-        get
-        {
-            return pathfindingWeight;
-        }
-
-        set
-        {
-            pathfindingWeight = value;
-        }
+        get { return pathfindingWeight; }
+        set { pathfindingWeight = value; }
     }
 
     public Color Tint { get; private set; }
@@ -440,7 +430,7 @@ public class Furniture : IXmlSerializable, ISelectable, IContextActionProvider, 
             case "Description":
                 reader.Read();
                 description = reader.ReadContentAsString();
-                    break;
+                break;
             case "MovementCost":
                 reader.Read();
                 MovementCost = reader.ReadContentAsFloat();

--- a/Assets/Scripts/Models/Furniture.cs
+++ b/Assets/Scripts/Models/Furniture.cs
@@ -27,6 +27,9 @@ public class Furniture : IXmlSerializable, ISelectable, IContextActionProvider, 
     // Base cost of pathfinding over this furniture, movement cost will modify the effective value
     private float pathfindingWeight = 1f;
 
+    // Additional cost of pathfinding over this furniture, will be added to pathfindingWeight * MovementCost
+    private float pathfindingModifier = 0f;
+
     // If the job causes some kind of object to be spawned, where will it appear?
     private Vector2 jobSpawnSpotOffset = Vector2.zero;
 
@@ -146,15 +149,21 @@ public class Furniture : IXmlSerializable, ISelectable, IContextActionProvider, 
 
     public event Action<IPowerRelated> PowerValueChanged;
 
-    // The effective pathfinding cost of pathing over this furniture
-    public float PathfindingCost
+    // PathfindingModifier is added to PathfindingCost to get the final amount
+    public float PathfindingModifier
     {
         get
         {
-            return PathfindingWeight * MovementCost;
+            return pathfindingWeight;
+        }
+
+        set
+        {
+            pathfindingWeight = value;
         }
     }
 
+    // PathfindingWeight is multiplied by movement cost to get total PathfindingCost
     public float PathfindingWeight
     {
         get

--- a/Assets/Scripts/Models/Furniture.cs
+++ b/Assets/Scripts/Models/Furniture.cs
@@ -100,6 +100,8 @@ public class Furniture : IXmlSerializable, ISelectable, IContextActionProvider, 
         typeTags = new HashSet<string>(other.typeTags);
         description = other.description;
         MovementCost = other.MovementCost;
+        PathfindingModifier = other.PathfindingModifier;
+        PathfindingWeight = other.PathfindingWeight;
         RoomEnclosure = other.RoomEnclosure;
         Width = other.Width;
         Height = other.Height;
@@ -438,10 +440,18 @@ public class Furniture : IXmlSerializable, ISelectable, IContextActionProvider, 
             case "Description":
                 reader.Read();
                 description = reader.ReadContentAsString();
-                break;
+                    break;
             case "MovementCost":
                 reader.Read();
                 MovementCost = reader.ReadContentAsFloat();
+                break;
+            case "PathfindingModifier":
+                reader.Read();
+                PathfindingModifier = reader.ReadContentAsFloat();
+                break;
+            case "PathfindingWeight":
+                reader.Read();
+                PathfindingWeight = reader.ReadContentAsFloat();
                 break;
             case "Width":
                 reader.Read();

--- a/Assets/Scripts/Models/Tile.cs
+++ b/Assets/Scripts/Models/Tile.cs
@@ -76,6 +76,11 @@ public class Tile : IXmlSerializable, ISelectable, IContextActionProvider
     // Furniture is something like a wall, door, or sofa.
     public Furniture Furniture { get; private set; }
 
+    /// <summary>
+    /// The total pathfinding cost of entering this tile.
+    /// The final cost is equal to the Tile's BaseMovementCost * Tile's PathfindingWeight * Furniture's PathfindingWeight * Furniture's MovementCost +
+    /// Tile's PathfindingModifier + Furniture's PathfindingModifier.
+    /// </summary>
     public float PathfindingCost
     {
         get

--- a/Assets/Scripts/Models/Tile.cs
+++ b/Assets/Scripts/Models/Tile.cs
@@ -27,8 +27,11 @@ public class Tile : IXmlSerializable, ISelectable, IContextActionProvider
 {
     private TileType type = TileType.Empty;
 
-    // Base cost of pathfinding over this furniture, movement cost and any furniture will modify the effective value
+    // Base cost of pathfinding over this tile, movement cost and any furniture will modify the effective value
     private float pathfindingWeight = 1f;
+
+    // Additional cost of pathfinding over this tile, will be added to pathfindingWeight * MovementCost
+    private float pathfindingModifier = 0f;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="Tile"/> class.
@@ -83,13 +86,20 @@ public class Tile : IXmlSerializable, ISelectable, IContextActionProvider
     {
         get
         {
+            // If Tile's BaseMovementCost or Furniture's MovementCost = 0 (i.e. impassable) we should always return 0 (stay impassable)
+            if (Type.BaseMovementCost == 0 || (Furniture != null && Furniture.MovementCost == 0))
+            {
+                return 0f;
+            }
+
             if (Furniture != null)
             {
-                return Furniture.PathfindingCost * Type.BaseMovementCost;
+                return (Furniture.PathfindingWeight * Furniture.MovementCost * PathfindingWeight * Type.BaseMovementCost) + 
+                    Furniture.PathfindingModifier + PathfindingModifier;
             }
             else
             {
-                return PathfindingWeight * Type.BaseMovementCost;
+                return (PathfindingWeight * Type.BaseMovementCost) + PathfindingModifier;
             }
         }
     }
@@ -104,6 +114,19 @@ public class Tile : IXmlSerializable, ISelectable, IContextActionProvider
         set
         {
             pathfindingWeight = value;
+        }
+    }
+
+    public float PathfindingModifier
+    {
+        get
+        {
+            return pathfindingModifier;
+        }
+
+        set
+        {
+            pathfindingModifier = value;
         }
     }
 

--- a/Assets/Scripts/Models/Tile.cs
+++ b/Assets/Scripts/Models/Tile.cs
@@ -26,6 +26,8 @@ public enum Enterability
 public class Tile : IXmlSerializable, ISelectable, IContextActionProvider
 {
     private TileType type = TileType.Empty;
+
+    // Base cost of pathfinding over this furniture, movement cost and any furniture will modify the effective value
     private float pathfindingWeight = 1f;
 
     /// <summary>
@@ -83,15 +85,14 @@ public class Tile : IXmlSerializable, ISelectable, IContextActionProvider
         {
             if (Furniture != null)
             {
-                return Furniture.PathfindingWeight * MovementCost;
+                return Furniture.PathfindingWeight * Type.BaseMovementCost;
             }
             else
             {
-                return pathfindingWeight * MovementCost;
+                return pathfindingWeight * Type.BaseMovementCost;
             }
         }
     }
-
 
     // FIXME: This seems like a terrible way to flag if a job is pending
     // on a tile.  This is going to be prone to errors in set/clear.

--- a/Assets/Scripts/Models/Tile.cs
+++ b/Assets/Scripts/Models/Tile.cs
@@ -79,18 +79,31 @@ public class Tile : IXmlSerializable, ISelectable, IContextActionProvider
     // Furniture is something like a wall, door, or sofa.
     public Furniture Furniture { get; private set; }
 
-    public float PathfindingWeight
+    public float PathfindingCost
     {
         get
         {
             if (Furniture != null)
             {
-                return Furniture.PathfindingWeight * Type.BaseMovementCost;
+                return Furniture.PathfindingCost * Type.BaseMovementCost;
             }
             else
             {
-                return pathfindingWeight * Type.BaseMovementCost;
+                return PathfindingWeight * Type.BaseMovementCost;
             }
+        }
+    }
+
+    public float PathfindingWeight
+    {
+        get
+        {
+            return pathfindingWeight;
+        }
+
+        set
+        {
+            pathfindingWeight = value;
         }
     }
 

--- a/Assets/Scripts/Models/Tile.cs
+++ b/Assets/Scripts/Models/Tile.cs
@@ -27,12 +27,6 @@ public class Tile : IXmlSerializable, ISelectable, IContextActionProvider
 {
     private TileType type = TileType.Empty;
 
-    // Base cost of pathfinding over this tile, movement cost and any furniture will modify the effective value
-    private float pathfindingWeight = 1f;
-
-    // Additional cost of pathfinding over this tile, will be added to pathfindingWeight * MovementCost
-    private float pathfindingModifier = 0f;
-
     /// <summary>
     /// Initializes a new instance of the <see cref="Tile"/> class.
     /// </summary>
@@ -94,39 +88,13 @@ public class Tile : IXmlSerializable, ISelectable, IContextActionProvider
 
             if (Furniture != null)
             {
-                return (Furniture.PathfindingWeight * Furniture.MovementCost * PathfindingWeight * Type.BaseMovementCost) + 
-                    Furniture.PathfindingModifier + PathfindingModifier;
+                return (Furniture.PathfindingWeight * Furniture.MovementCost * Type.PathfindingWeight * Type.BaseMovementCost) + 
+                    Furniture.PathfindingModifier + Type.PathfindingModifier;
             }
             else
             {
-                return (PathfindingWeight * Type.BaseMovementCost) + PathfindingModifier;
+                return (Type.PathfindingWeight * Type.BaseMovementCost) + Type.PathfindingModifier;
             }
-        }
-    }
-
-    public float PathfindingWeight
-    {
-        get
-        {
-            return pathfindingWeight;
-        }
-
-        set
-        {
-            pathfindingWeight = value;
-        }
-    }
-
-    public float PathfindingModifier
-    {
-        get
-        {
-            return pathfindingModifier;
-        }
-
-        set
-        {
-            pathfindingModifier = value;
         }
     }
 

--- a/Assets/Scripts/Models/Tile.cs
+++ b/Assets/Scripts/Models/Tile.cs
@@ -26,6 +26,7 @@ public enum Enterability
 public class Tile : IXmlSerializable, ISelectable, IContextActionProvider
 {
     private TileType type = TileType.Empty;
+    private float pathfindingWeight = 1f;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="Tile"/> class.
@@ -75,6 +76,22 @@ public class Tile : IXmlSerializable, ISelectable, IContextActionProvider
 
     // Furniture is something like a wall, door, or sofa.
     public Furniture Furniture { get; private set; }
+
+    public float PathfindingWeight
+    {
+        get
+        {
+            if (Furniture != null)
+            {
+                return Furniture.PathfindingWeight * MovementCost;
+            }
+            else
+            {
+                return pathfindingWeight * MovementCost;
+            }
+        }
+    }
+
 
     // FIXME: This seems like a terrible way to flag if a job is pending
     // on a tile.  This is going to be prone to errors in set/clear.

--- a/Assets/Scripts/Models/TileType.cs
+++ b/Assets/Scripts/Models/TileType.cs
@@ -230,6 +230,14 @@ public class TileType : IXmlSerializable
                     reader.Read();
                     BaseMovementCost = reader.ReadContentAsFloat();
                     break;
+                case "PathfindingModifier":
+                    reader.Read();
+                    PathfindingModifier = reader.ReadContentAsFloat();
+                    break;
+                case "PathfindingWeight":
+                    reader.Read();
+                    PathfindingWeight = reader.ReadContentAsFloat();
+                    break;
                 case "LinksToNeighbours":
                     reader.Read();
                     LinksToNeighbours = reader.ReadContentAsBoolean();

--- a/Assets/Scripts/Models/TileType.cs
+++ b/Assets/Scripts/Models/TileType.cs
@@ -68,30 +68,22 @@ public class TileType : IXmlSerializable
 
     public float BaseMovementCost { get; protected set; }
 
+    /// <summary>
+    /// Gets or sets the TileType's pathfinding weight which is multiplied into the Tile's final PathfindingCost.
+    /// </summary>
     public float PathfindingWeight
     {
-        get
-        {
-            return pathfindingWeight;
-        }
-
-        set
-        {
-            pathfindingWeight = value;
-        }
+        get { return pathfindingWeight; }
+        set { pathfindingWeight = value; }
     }
 
+    /// <summary>
+    /// Gets or sets the TileType's pathfinding modifier which is added into the Tile's final PathfindingCost.
+    /// </summary>
     public float PathfindingModifier
     {
-        get
-        {
-            return pathfindingModifier;
-        }
-
-        set
-        {
-            pathfindingModifier = value;
-        }
+        get { return pathfindingModifier; }
+        set { pathfindingModifier = value; }
     }
 
     // TODO!

--- a/Assets/Scripts/Models/TileType.cs
+++ b/Assets/Scripts/Models/TileType.cs
@@ -68,7 +68,6 @@ public class TileType : IXmlSerializable
 
     public float BaseMovementCost { get; protected set; }
 
-
     public float PathfindingWeight
     {
         get

--- a/Assets/Scripts/Models/TileType.cs
+++ b/Assets/Scripts/Models/TileType.cs
@@ -25,6 +25,12 @@ public class TileType : IXmlSerializable
 
     private static Dictionary<TileType, Job> tileTypeBuildJobPrototypes = new Dictionary<TileType, Job>();
 
+    // Base cost of pathfinding over this tile, movement cost and any furniture will modify the effective value
+    private float pathfindingWeight = 1f;
+
+    // Additional cost of pathfinding over this tile, will be added to pathfindingWeight * MovementCost
+    private float pathfindingModifier = 0f;
+
     // Will this even be needed?
     private TileType(string name, string description, float baseMovementCost)
     {
@@ -61,6 +67,33 @@ public class TileType : IXmlSerializable
     public string Description { get; protected set; }
 
     public float BaseMovementCost { get; protected set; }
+
+
+    public float PathfindingWeight
+    {
+        get
+        {
+            return pathfindingWeight;
+        }
+
+        set
+        {
+            pathfindingWeight = value;
+        }
+    }
+
+    public float PathfindingModifier
+    {
+        get
+        {
+            return pathfindingModifier;
+        }
+
+        set
+        {
+            pathfindingModifier = value;
+        }
+    }
 
     // TODO!
     public bool LinksToNeighbours { get; protected set; }

--- a/Assets/Scripts/Pathfinding/Path_AStar.cs
+++ b/Assets/Scripts/Pathfinding/Path_AStar.cs
@@ -133,9 +133,9 @@ public class Path_AStar
                     continue; // ignore this already completed neighbor
                 }
 
-                float movement_cost_to_neighbor = neighbor.data.MovementCost * Dist_between(current, neighbor);
+                float pathfinding_cost_to_neighbor = neighbor.data.PathfindingCost * Dist_between(current, neighbor);
 
-                float tentative_g_score = g_score[current] + movement_cost_to_neighbor;
+                float tentative_g_score = g_score[current] + pathfinding_cost_to_neighbor;
 
                 if (openSet.Contains(neighbor) && tentative_g_score >= g_score[neighbor])
                 {

--- a/Assets/Scripts/Pathfinding/Path_TileGraph.cs
+++ b/Assets/Scripts/Pathfinding/Path_TileGraph.cs
@@ -71,13 +71,13 @@ public class Path_TileGraph
         if (Mathf.Abs(dX) + Mathf.Abs(dY) == 2)
         {
             // We are diagonal
-            if (World.Current.GetTileAt(curr.X - dX, curr.Y).MovementCost == 0)
+            if (World.Current.GetTileAt(curr.X - dX, curr.Y).PathfindingCost == 0)
             {
                 // East or West is unwalkable, therefore this would be a clipped movement.
                 return true;
             }
 
-            if (World.Current.GetTileAt(curr.X, curr.Y - dY).MovementCost == 0)
+            if (World.Current.GetTileAt(curr.X, curr.Y - dY).PathfindingCost == 0)
             {
                 // North or South is unwalkable, therefore this would be a clipped movement.
                 return true;
@@ -102,11 +102,11 @@ public class Path_TileGraph
         // If neighbour is walkable, create an edge to the relevant node.
         for (int i = 0; i < neighbours.Length; i++)
         {
-            if (neighbours[i] != null && neighbours[i].MovementCost > 0 && IsClippingCorner(t, neighbours[i]) == false)
+            if (neighbours[i] != null && neighbours[i].PathfindingCost > 0 && IsClippingCorner(t, neighbours[i]) == false)
             {
                 // This neighbour exists, is walkable, and doesn't requiring clipping a corner --> so create an edge.
                 Path_Edge<Tile> e = new Path_Edge<Tile>();
-                e.cost = neighbours[i].MovementCost;
+                e.cost = neighbours[i].PathfindingCost;
                 e.node = nodes[neighbours[i]];
 
                 // Add the edge to our temporary (and growable!) list

--- a/Assets/StreamingAssets/Data/Furniture.xml
+++ b/Assets/StreamingAssets/Data/Furniture.xml
@@ -42,7 +42,7 @@
         <MovementCost>1</MovementCost>
         <!-- PathfindingModifer is additive, so a PathfindingModifier of 1 will basically respond to Pathfinding as though it takes 1 extra tile of movement -->
         <!-- Default value of PathfindingModifier is 0 -->
-        <PathfindingModifier>1</PathfindingModifier>
+        <PathfindingModifier>1.5</PathfindingModifier>
         <!-- PathfindingWeight is multiplicative, so a PathfindingWeight of 2 would basically respond to Pathfinding as though it takes double the tiles of movement -->
         <!-- Default value of PathfindingWeight is 1 -->
         <PathfindingWeight>1</PathfindingWeight>

--- a/Assets/StreamingAssets/Data/Furniture.xml
+++ b/Assets/StreamingAssets/Data/Furniture.xml
@@ -40,6 +40,12 @@
         <Description>A door that characters can walk through.</Description>
         <TypeTag>Door</TypeTag>
         <MovementCost>1</MovementCost>
+        <!-- PathfindingModifer is additive, so a PathfindingModifier of 1 will basically respond to Pathfinding as though it takes 1 extra tile of movement -->
+        <!-- Default value of PathfindingModifier is 0 -->
+        <PathfindingModifier>1</PathfindingModifier>
+        <!-- PathfindingWeight is multiplicative, so a PathfindingWeight of 2 would basically respond to Pathfinding as though it takes double the tiles of movement -->
+        <!-- Default value of PathfindingWeight is 1 -->
+        <PathfindingWeight>1</PathfindingWeight>
         <Width>1</Width>
         <Height>1</Height>
         <LinksToNeighbours>false</LinksToNeighbours>

--- a/Assets/StreamingAssets/Data/Furniture.xml
+++ b/Assets/StreamingAssets/Data/Furniture.xml
@@ -83,6 +83,8 @@
         <Description>An Airlock prevents air from leaving the base</Description>
         <TypeTag>Door</TypeTag>
         <MovementCost>1</MovementCost>
+        <PathfindingModifier>3</PathfindingModifier>
+        <PathfindingWeight>1</PathfindingWeight>
         <Width>1</Width>
         <Height>1</Height>
         <LinksToNeighbours>false</LinksToNeighbours>
@@ -137,7 +139,9 @@
         <Name>Oxygen Generator</Name>
         <Description>Create O2 in the room in which it is built.</Description>
         <TypeTag>Generator</TypeTag>
-        <MovementCost>10</MovementCost>
+        <MovementCost>2</MovementCost>
+        <PathfindingModifier>0</PathfindingModifier>
+        <PathfindingWeight>2</PathfindingWeight>
         <Width>2</Width>
         <Height>2</Height>
         <Power>-1</Power>
@@ -171,6 +175,8 @@
         <Description>Creates raw materials when worked by a character.</Description>
         <TypeTag>Workstation</TypeTag>
         <MovementCost>1</MovementCost>
+        <PathfindingModifier>0</PathfindingModifier>
+        <PathfindingWeight>2</PathfindingWeight>
         <Width>3</Width>
         <Height>3</Height>
 
@@ -197,7 +203,9 @@
     <Furniture objectType="Power Generator">
         <Name>Power Generator</Name>
         <TypeTag>Generator</TypeTag>
-        <MovementCost>10</MovementCost>
+        <MovementCost>2</MovementCost>
+        <PathfindingModifier>0</PathfindingModifier>
+        <PathfindingWeight>2</PathfindingWeight>
         <Width>2</Width>
         <Height>2</Height>
         <Power>5</Power>
@@ -220,7 +228,9 @@
     <Furniture objectType="Cloning Pod">
         <Name>Cloning Pod</Name>
         <Description>Creates an additional worker, then is destroyed.</Description>
-        <MovementCost>50</MovementCost>
+        <MovementCost>2</MovementCost>
+        <PathfindingModifier>0</PathfindingModifier>
+        <PathfindingWeight>2</PathfindingWeight>
         <Width>2</Width>
         <Height>2</Height>
 
@@ -248,6 +258,8 @@
         <Description>Smelts your raw iron into metal.</Description>
         <TypeTag>Processor</TypeTag>
         <MovementCost>1</MovementCost>
+        <PathfindingModifier>1.5</PathfindingModifier>
+        <PathfindingWeight>2</PathfindingWeight>
         <Width>3</Width>
         <Height>3</Height>
 
@@ -272,7 +284,9 @@
         <Name>Heater</Name>
         <Description>Raises temperature in the room.</Description>
         <BaseType>Temperature</BaseType>
-        <MovementCost>10</MovementCost>
+        <MovementCost>2</MovementCost>
+        <PathfindingModifier>0</PathfindingModifier>
+        <PathfindingWeight>2</PathfindingWeight>
         <Width>1</Width>
         <Height>1</Height>
         <Power>4</Power>
@@ -298,6 +312,8 @@
         <Name>Power Cell Press</Name>
         <Description>A press that converts steel plate and something into power cells.</Description>
         <MovementCost>1</MovementCost>
+        <PathfindingModifier>1.5</PathfindingModifier>
+        <PathfindingWeight>2</PathfindingWeight>
         <Width>2</Width>
         <Height>2</Height>
 
@@ -320,7 +336,9 @@
         <Name>Small Landing Pad</Name>
         <Description>A landing pad for small spaceboats to land.</Description>
         <TypeTag>OutdoorOnly</TypeTag>
-        <MovementCost>5</MovementCost>
+        <MovementCost>2</MovementCost>
+        <PathfindingModifier>0</PathfindingModifier>
+        <PathfindingWeight>2</PathfindingWeight>
         <Width>3</Width>
         <Height>3</Height>
 
@@ -357,7 +375,9 @@
     <Furniture objectType="compressor_oxygen">
         <Name>Oxygen Compressor</Name>
         <Description>Stores and releases oxygen as needed</Description>
-        <MovementCost>5</MovementCost>
+        <MovementCost>2</MovementCost>
+        <PathfindingModifier>0</PathfindingModifier>
+        <PathfindingWeight>2</PathfindingWeight>
         <Width>2</Width>
         <Height>2</Height>
 
@@ -384,7 +404,9 @@
         <Name>Solar Panel</Name>
         <TypeTag>Generator</TypeTag>
         <TypeTag>OutdoorOnly</TypeTag>
-        <MovementCost>10</MovementCost>
+        <MovementCost>2</MovementCost>
+        <PathfindingModifier>1.5</PathfindingModifier>
+        <PathfindingWeight>2</PathfindingWeight>
         <Width>2</Width>
         <Height>3</Height>
         <Power>3</Power>


### PR DESCRIPTION
This is an extremely basic Pathfinding Weight for Tiles (which calls Furniture for it's pathfinding weight if it has furniture). At the moment the only thing used is movementCost, modifiers to the final weight (Accessed through the property PathfindingWeight on Tile), are set at 1. Pathfinding can get the total PathfindingCost (PathfindingWeight * movementCost) from the PathfindingCost Property.

The purpose is to get an extremely simple thing in place that allows those working on pathfinding to make use of a weight that can be further modified from movementCost, that is small enough to allow it to easily be merged. This will allow them to make use of it as soon as possible, and any further changes to how weight is calculated will be handled separately and should minimize conflicts with pathfinding PRs. PathfindingWeight (the multiplier to movementCost) can be modified through the property.

The system has been hooked into the current Pathfinding implementation, with no changes to behavior (specific weight for furnitures and tiles still need implemented, but this will allow future Pathfinding changes to not have to worry about what changes may be made to pathfinding weights)

At a minimum, in the future this will allow Tiles and Furnitures to have a pathfindingWeight read from xml, that will allow a separate modifier (so some tiles can be less desirable without being slower moving, such as a fire, or a door).

Further changes will depend on how costly they are calculation-wise when accessed at a high rate by the pathfinding system.