### PR TITLE
[Small]Cleaned up lingering Debug-calls. 

### DIFF
--- a/Assets/Scripts/Models/Prototypes/XmlPrototypes.cs
+++ b/Assets/Scripts/Models/Prototypes/XmlPrototypes.cs
@@ -78,12 +78,12 @@ public class XmlPrototypes<T> : BasePrototypes<T>
             }
             else
             {
-                Debug.LogError("The furniture prototype definition file doesn't have any '" + elementTag + "' elements.");
+                Debug.ULogErrorChannel("XmlPrototypes", "The furniture prototype definition file doesn't have any '" + elementTag + "' elements.");
             }
         }
         else
         {
-            Debug.LogError("Did not find a '" + listTag + "' element in the prototype definition file.");
+            Debug.ULogErrorChannel("XmlPrototypes", "Did not find a '" + listTag + "' element in the prototype definition file.");
         }
     }
 
@@ -102,6 +102,7 @@ public class XmlPrototypes<T> : BasePrototypes<T>
     /// <param name="type">The prototype type.</param>
     protected void LogPrototypeError(Exception e, string type)
     {
+        // Leaving this for Unitys console because UberLogger doesn't show multiline messages correctly.
         Debug.LogError("Error reading furniture prototype for: " + type + Environment.NewLine + "Exception: " + e.Message + Environment.NewLine + "StackTrace: " + e.StackTrace);
     }
 }

--- a/Assets/Scripts/Utilities/Settings.cs
+++ b/Assets/Scripts/Utilities/Settings.cs
@@ -245,7 +245,7 @@ public static class Settings
         XmlDocument xDoc = new XmlDocument();
         xDoc.LoadXml(furnitureXmlText);
         Debug.ULogChannel("Settings", "Loaded settings");
-        Debug.Log(xDoc.InnerText); // Uber Logger doesn't handle multilines.
+        Debug.ULogChannel("Settings", xDoc.InnerText); 
 
         // Get the Settings node. Its children are the individual settings.
         XmlNode settingsNode = xDoc.GetElementsByTagName("Settings").Item(0);


### PR DESCRIPTION
`Settings.cs` fail StyleCop, needs rule change. StyleCop message: 
SA1305 : CSharp.Naming : The variable name 'xDoc' begins with a prefix that looks like Hungarian notation. Remove the prefix or add it to the list of allowed prefixes.	
	
