### PR TITLE
[Small] Fixed Furniture and Job context menu

### DIFF
--- a/Assets/Scripts/Models/Furniture.cs
+++ b/Assets/Scripts/Models/Furniture.cs
@@ -706,17 +706,23 @@ public class Furniture : IXmlSerializable, ISelectable, IContextActionProvider, 
             RequireCharacterSelected = false,
             Action = (ca, c) => Deconstruct()
         };
-        if (jobs.Count > 0 && !jobs[0].IsBeingWorked)
+        if (jobs.Count > 0)
         {
-            yield return new ContextMenuAction
+            for (int i = 0; i < jobs.Count; i++)
             {
-                Text = "Prioritize " + Name,
-                RequireCharacterSelected = true,
-                Action = (ca, c) => { c.PrioritizeJob(jobs[0]); }
-            };
+                if (!jobs[i].IsBeingWorked)
+                {
+                    yield return new ContextMenuAction
+                    {
+                        Text = "Prioritize " + Name,
+                        RequireCharacterSelected = true,
+                        Action = (ca, c) => { c.PrioritizeJob(jobs[0]); }
+                    };
+                }
+            }
         }
 
-        foreach (var contextMenuLuaAction in contextMenuLuaActions)
+        foreach (ContextMenuLuaAction contextMenuLuaAction in contextMenuLuaActions)
         {
             yield return new ContextMenuAction
             {

--- a/Assets/Scripts/Models/Tile.cs
+++ b/Assets/Scripts/Models/Tile.cs
@@ -397,7 +397,7 @@ public class Tile : IXmlSerializable, ISelectable, IContextActionProvider
             {
                 yield return new ContextMenuAction
                 {
-                    Text = "Prioritize Job",
+                    Text = "Prioritize " + PendingBuildJob.GetName(),
                     RequireCharacterSelected = true,
                     Action = (cm, c) => { c.PrioritizeJob(PendingBuildJob); }
                 };


### PR DESCRIPTION
I have fixed the context menu in Furniture.cs where i had only shown the first job in the index(i know it was ugly and not good practice), now it will properly show all jobs that can manually prioritized by a selected character. Also in Tile.cs, for its context menu, i had hard coded the name of the job because at the time there was no good way to get the name. But now that jobs are selectable, i have changed it to show the name of the object that will be prioritized. 

Also in Furniture.cs, there was a foreach loop in the GetContextMenuActions() that used a 'var', i have removed the var.

NOTE: No in game change except for a pending build job showing its name in the context menu when a character is selected.