### PR TITLE
Fix repetitive logic in ConstructionMenu

### DIFF
--- a/Assets/Scripts/UI/InGameUI/ConstructionMenu.cs
+++ b/Assets/Scripts/UI/InGameUI/ConstructionMenu.cs
@@ -21,6 +21,13 @@ public class ConstructionMenu : MonoBehaviour
     public Button buttonDeconstruction;
 
     private BuildModeController bmc;
+    private GameObject[] furnitureSubs {
+        get { 
+            
+            // add every submenu here
+            return new GameObject[] {furnitureMenu, floorMenu};
+        }
+    }
 
     public void OnClickDeconstruct()
     {
@@ -30,13 +37,13 @@ public class ConstructionMenu : MonoBehaviour
 
     public void OnClickFloors()
     {
-        furnitureMenu.SetActive(false);
+        DeactivateSubsExcept(floorMenu);
         ToggleMenu(floorMenu);
     }
 
     public void OnClickFurniture()
     {
-        floorMenu.SetActive(false);
+        DeactivateSubsExcept(furnitureMenu);
         ToggleMenu(furnitureMenu);
     }
 
@@ -53,6 +60,18 @@ public class ConstructionMenu : MonoBehaviour
         menu.SetActive(!menu.activeSelf);
     }
 
+    public void DeactivateSubsExcept(GameObject menu)
+    {
+        foreach (GameObject g in furnitureSubs)
+        {
+            if (g == menu)
+            {
+                continue;
+            }
+            g.SetActive(false);
+        }
+    }
+
     private void Start()
     {
         bmc = WorldController.Instance.buildModeController;
@@ -62,12 +81,12 @@ public class ConstructionMenu : MonoBehaviour
         furnitureMenu = cm.furnitureMenu;
         floorMenu = cm.floorMenu;
 
+        // Add liseners here.
         buttonDeconstruction.onClick.AddListener(delegate
         {
             OnClickDeconstruct();
         });
 
-        // Add liseners here.
         buttonFloors.onClick.AddListener(delegate
         {
             OnClickFloors();

--- a/Assets/Scripts/UI/InGameUI/ConstructionMenu.cs
+++ b/Assets/Scripts/UI/InGameUI/ConstructionMenu.cs
@@ -69,12 +69,10 @@ public class ConstructionMenu : MonoBehaviour
     {
         foreach (GameObject g in FurnitureSubs)
         {
-            if (g == menu)
+            if (g != menu)
             {
-                continue;
+                g.SetActive(false);
             }
-
-            g.SetActive(false);
         }
     }
 

--- a/Assets/Scripts/UI/InGameUI/ConstructionMenu.cs
+++ b/Assets/Scripts/UI/InGameUI/ConstructionMenu.cs
@@ -22,15 +22,22 @@ public class ConstructionMenu : MonoBehaviour
 
     private BuildModeController bmc;
 
-    private GameObject[] FurnitureSubs 
+    private GameObject[] furnitureSubs;
+
+    private GameObject[] FurnitureSubs
     {
-        get 
+        get
         {
-            return new GameObject[] 
+            if (furnitureSubs == null)
             {
-                // add every furniture submenu here
-                furnitureMenu, floorMenu
-            };
+                furnitureSubs = new GameObject[]
+                {
+                    // add every furniture submenu here
+                    furnitureMenu, floorMenu
+                };
+            }
+
+            return furnitureSubs;
         }
     }
 

--- a/Assets/Scripts/UI/InGameUI/ConstructionMenu.cs
+++ b/Assets/Scripts/UI/InGameUI/ConstructionMenu.cs
@@ -74,11 +74,11 @@ public class ConstructionMenu : MonoBehaviour
 
     public void DeactivateSubsExcept(GameObject menu)
     {
-        foreach (GameObject g in FurnitureSubs)
+        foreach (GameObject subMenu in FurnitureSubs)
         {
-            if (g != menu)
+            if (subMenu != menu)
             {
-                g.SetActive(false);
+                subMenu.SetActive(false);
             }
         }
     }

--- a/Assets/Scripts/UI/InGameUI/ConstructionMenu.cs
+++ b/Assets/Scripts/UI/InGameUI/ConstructionMenu.cs
@@ -21,11 +21,16 @@ public class ConstructionMenu : MonoBehaviour
     public Button buttonDeconstruction;
 
     private BuildModeController bmc;
-    private GameObject[] furnitureSubs {
-        get { 
-            
-            // add every submenu here
-            return new GameObject[] {furnitureMenu, floorMenu};
+
+    private GameObject[] FurnitureSubs 
+    {
+        get 
+        {
+            return new GameObject[] 
+            {
+                // add every furniture submenu here
+                furnitureMenu, floorMenu
+            };
         }
     }
 
@@ -62,12 +67,13 @@ public class ConstructionMenu : MonoBehaviour
 
     public void DeactivateSubsExcept(GameObject menu)
     {
-        foreach (GameObject g in furnitureSubs)
+        foreach (GameObject g in FurnitureSubs)
         {
             if (g == menu)
             {
                 continue;
             }
+
             g.SetActive(false);
         }
     }


### PR DESCRIPTION
#960 noted that their PR doesn't scale well. This aims to fix this by replacing repetitive `menu.SetActive(false)` calls with easier and clearer `DeactivateSubsExcept(selectedMenu)`.

While this changes very little now, a menu with five sub menus logic would be the followin in the current master inside each buttons delegate:
```
floorMenu.SetActive(false);
furnitureMenu.SetActive(false);
powerMenu.SetActive(false);
medicalMenu.SetActive(false);
```
This changes the logic to :
`DeactivateSubsExcept(miscMenu); `