### PR TITLE
Fix metal smelter job construction

### DIFF
--- a/Assets/StreamingAssets/LUA/Furniture.lua
+++ b/Assets/StreamingAssets/LUA/Furniture.lua
@@ -384,7 +384,7 @@ function MetalSmelter_UpdateAction(furniture, deltaTime)
     local itemsDesired = { Inventory.__new("Raw Iron", desiredStackSize, 0) }
     if(spawnSpot.Inventory ~= nil and spawnSpot.Inventory.StackSize < spawnSpot.Inventory.maxStackSize) then
         desiredStackSize = spawnSpot.Inventory.maxStackSize - spawnSpot.Inventory.StackSize
-        itemsDesired.maxStackSize = desiredStackSize
+        itemsDesired[1].maxStackSize = desiredStackSize
     end
     ModUtils.ULog("MetalSmelter: Creating job for " .. desiredStackSize .. " raw iron.")
 


### PR DESCRIPTION
fixes #973 
The lua code didn't properly access desiredItems as a table. The Metal Smelter will now only request enough items to fill it's stack, as originally intended. It also won't consume excess items if a character happens to have too many.