### PR TITLE
Fix param saving/loading

### DIFF
--- a/Assets/Scripts/Models/Furniture.cs
+++ b/Assets/Scripts/Models/Furniture.cs
@@ -83,7 +83,7 @@ public class Furniture : IXmlSerializable, ISelectable, IContextActionProvider
         EventActions = new EventAction();
 
         contextMenuLuaActions = new List<ContextMenuLuaAction>();
-        furnParameters = new Parameter("furnParameters");
+        furnParameters = new Parameter();
         jobs = new List<Job>();
         typeTags = new HashSet<string>();
         funcPositionValidation = DefaultIsValidPosition;

--- a/Assets/Scripts/Models/Furniture.cs
+++ b/Assets/Scripts/Models/Furniture.cs
@@ -560,8 +560,11 @@ public class Furniture : IXmlSerializable, ISelectable, IContextActionProvider
     public void ReadXml(XmlReader reader)
     {
         // X, Y, and objectType have already been set, and we should already
-        // be assigned to a tile.  So just read extra data.
-        ReadXmlParams(reader);
+        // be assigned to a tile.  So just read extra data if we have any.
+        if (!reader.IsEmptyElement)
+        {
+            ReadXmlParams(reader);
+        }
     }
 
     public void ReadXmlParams(XmlReader reader)

--- a/Assets/Scripts/Models/Parameter.cs
+++ b/Assets/Scripts/Models/Parameter.cs
@@ -109,6 +109,7 @@ public class Parameter
         {
             subReader.ReadToDescendant("Params");
         }
+
         subReader.Read();
 
         do
@@ -136,11 +137,11 @@ public class Parameter
                     paramGroup[k] = Parameter.ReadXml(subReader);
                 }
             }
-        } while (subReader.ReadToNextSibling("Param"));
+        }
+        while (subReader.ReadToNextSibling("Param"));
 
         subReader.Close();
         return paramGroup;
-
     }
 
     public override string ToString() 
@@ -241,6 +242,7 @@ public class Parameter
             writer.WriteStartElement("Param");
             writer.WriteAttributeString("name", name);
         }
+
         if (value != null)
         {
             writer.WriteAttributeString("value", value);

--- a/Assets/Scripts/Models/Parameter.cs
+++ b/Assets/Scripts/Models/Parameter.cs
@@ -25,15 +25,11 @@ public class Parameter
     // If this Parameter contains other Parameters, contents will contain the actual parameters
     private Dictionary<string, Parameter> contents;
 
-    // Tracks if value has been explicitly set
-    private bool uninitializedValue = true;
-
     public Parameter(string name, string value) 
     {
         this.name = name;
         this.value = value;
         contents = new Dictionary<string, Parameter>();
-        uninitializedValue = false;
     }
 
     // Constructor with object parameter allows it to easily create a Parameter with any object that has a string representation (primarily for use if that string
@@ -43,13 +39,18 @@ public class Parameter
         this.name = name;
         this.value = value.ToString();
         contents = new Dictionary<string, Parameter>();
-        uninitializedValue = false;
     }
 
     // Parameter with no value assumes it is being used for Parameter with contents, and initialized the dictionary
     public Parameter(string name) 
     {
         this.name = name;
+        contents = new Dictionary<string, Parameter>();
+    }
+
+    // Constructor for top-level Parameter (e.g. furnParameters in Furniture.css
+    public Parameter() 
+    {
         contents = new Dictionary<string, Parameter>();
     }
 
@@ -151,7 +152,7 @@ public class Parameter
 
     public string ToString(string defaultValue) 
     {
-        if (uninitializedValue)
+        if (value == null)
         {
             return defaultValue;
         }
@@ -175,7 +176,7 @@ public class Parameter
 
     public float ToFloat(float defaultValue) 
     {
-        if (uninitializedValue)
+        if (value == null)
         {
             return defaultValue;
         }
@@ -186,20 +187,17 @@ public class Parameter
     public void SetValue(string value) 
     {
         this.value = value;
-        uninitializedValue = false;
     }
 
     public void SetValue(object value)
     {
         this.value = value.ToString();
-        uninitializedValue = false;
     }
 
     // Change value by a float, primarily here to approximate old parameter system usage
     public void ChangeFloatValue(float value)
     {
         this.value = string.Empty + (ToFloat() + value);
-        uninitializedValue = false;
     }
 
     public string GetName()


### PR DESCRIPTION
This is a redo of PR #819 .

It fixes how Parameters are saved and loaded, and changes the save format of Parameters match how they are written in the furniture prototypes, allowing the same Loading code to handle both.

This fixes a bug where the parameters of furniture (and any other object that uses Parameters) weren't properly loaded on Load Game, causing most furniture that uses Parameters to not work on Load.