### PR TITLE
Build From Command Line (for CI)

### DIFF
--- a/Assets/Editor/BuildGame.cs
+++ b/Assets/Editor/BuildGame.cs
@@ -1,0 +1,63 @@
+﻿#region License
+// ====================================================
+// Project Porcupine Copyright(C) 2016 Team Porcupine
+// This program comes with ABSOLUTELY NO WARRANTY; This is free software, 
+// and you are welcome to redistribute it under certain conditions; See 
+// file LICENSE, which is part of this source code package, for details.
+// ====================================================
+#endregion
+using System.Collections;
+using System.Linq;
+using UnityEditor;
+using UnityEngine;
+
+public class BuildGame
+{
+    private const string BuildName = "ProjectPorcupine";
+
+    public static void All()
+    {
+        OSX();
+        Windows();
+        Linux();
+    }
+
+    public static void Windows() 
+    {
+        Windows32();
+        Windows64();
+    }
+
+    public static void Windows32()
+    {
+        BuildPipeline.BuildPlayer(GetScenes(), "Builds/" + BuildName + "_Win32", BuildTarget.StandaloneWindows, BuildOptions.None);
+    }
+
+    public static void Windows64() 
+    {
+        BuildPipeline.BuildPlayer(GetScenes(), "Builds/" + BuildName + "_Win64", BuildTarget.StandaloneWindows64, BuildOptions.None);
+    }
+
+    public static void OSX()
+    {
+        BuildPipeline.BuildPlayer(GetScenes(), "Builds/" + BuildName + "_OSX", BuildTarget.StandaloneOSXUniversal, BuildOptions.None);
+    }
+
+    public static void Linux()
+    {
+        BuildPipeline.BuildPlayer(GetScenes(), "Builds/" + BuildName + "_Linux", BuildTarget.StandaloneLinuxUniversal, BuildOptions.None);
+    }
+
+    private static string[] GetScenes()
+    {
+        return EditorBuildSettings.scenes.Where(s => s.enabled).Select(s => s.path).ToArray();
+    }
+}
+
+/*
+to build from command line:
+    mac:
+        /Applications/Unity/Unity.app/Contents/MacOS/Unity -quit -batchmode -logfile -projectPath path/to/ProjectPorcupine -executeMethod BuildGame.OSX
+    windows: 
+        "C:\Program Files\Unity\Editor\Unity.exe" -quit -batchmode -logfile -projectPath path/to/ProjectPorcupine -executeMethod BuildGame.Windows
+*/

--- a/Assets/Editor/BuildGame.cs.meta
+++ b/Assets/Editor/BuildGame.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 1c75bee68d87d42b982c18b4a74266a0
+timeCreated: 1472569670
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This PR introduces the first step for continuous integration for #73: creating builds from the command line.
This is done via the following commands:
OSX/Linux/Unix:  `/Applications/Unity/Unity.app/Contents/MacOS/Unity -quit -batchmode -logfile -projectPath path/to/ProjectPorcupine -executeMethod BuildGame.OSX`
Windows:  `"C:\Program Files\Unity\Editor\Unity.exe" -quit -batchmode -logfile -projectPath path/to/ProjectPorcupine -executeMethod BuildGame.Windows`

You can change the build target by changing the method called in `BuildGame`. Currently there are options for Windows 32bit, Windows 64bit, MacOSX universal, Linux universal, and all at the same time.