### PR TITLE
[small] Always check against NullReferenceException when using tile.GetNeighbours!

### DIFF
--- a/Assets/Scripts/Models/Character.cs
+++ b/Assets/Scripts/Models/Character.cs
@@ -513,7 +513,7 @@ public class Character : IXmlSerializable, ISelectable, IContextActionProvider
         // If the dest tile does not have neighbours that are walkable it's very likely that they can't be walked to
         if (DestTile != null)
         {
-            if (DestTile.GetNeighbours().Any((tile) => { return tile.MovementCost > 0; }) == false)
+            if (DestTile.GetNeighbours().Any((tile) => (tile != null && tile.MovementCost > 0)) == false)
             {
                 Debug.ULogChannel("Character", "No neighbouring floor tiles! Abandoning job.");
                 AbandonJob(false);

--- a/Assets/Scripts/Models/Character.cs
+++ b/Assets/Scripts/Models/Character.cs
@@ -290,7 +290,7 @@ public class Character : IXmlSerializable, ISelectable, IContextActionProvider
         DestTile = MyJob.tile;
 
         // If the dest tile does not have neighbours that are walkable it's very likable that they can't be walked to.
-        if (DestTile.GetNeighbours().Any((tile) => { return tile.MovementCost > 0; }) == false)
+        if (DestTile.GetNeighbours().Any((tile) => (tile != null && tile.MovementCost > 0)) == false)
         {
             Debug.ULogChannel("Character", "No neighbouring floor tiles! Abandoning job.");
             AbandonJob(false);

--- a/Assets/Scripts/Models/Room.cs
+++ b/Assets/Scripts/Models/Room.cs
@@ -87,7 +87,7 @@ public class Room : IXmlSerializable
             // Try building new rooms for each of our NESW directions.
             foreach (Tile t in sourceTile.GetNeighbours())
             {
-                if (t.Room != null && (onlyIfOutside == false || t.Room.IsOutsideRoom()))
+                if (t != null && t.Room != null && (onlyIfOutside == false || t.Room.IsOutsideRoom()))
                 {
                     ActualFloodFill(t, oldRoom, sizeOfOldRoom);
                 }
@@ -124,7 +124,7 @@ public class Room : IXmlSerializable
             // This doesn't work for the gas calculations and needs to be fixed.
             foreach (Tile t in sourceTile.GetNeighbours())
             {
-                if (t.Room != null && (onlyIfOutside == false || t.Room.IsOutsideRoom()))
+                if (t != null && t.Room != null && (onlyIfOutside == false || t.Room.IsOutsideRoom()))
                 {
                     world.DeleteRoom(t.Room);
                 }

--- a/Assets/Scripts/Models/Tile.cs
+++ b/Assets/Scripts/Models/Tile.cs
@@ -278,7 +278,7 @@ public class Tile : IXmlSerializable, ISelectable, IContextActionProvider
     /// </summary>
     public bool HasNeighboursOfType(TileType tileType)
     {
-        return GetNeighbours(true).Any(tile => tile.Type == tileType);
+        return GetNeighbours(true).Any(tile => (tile != null && tile.Type == tileType));
     }
 
     public XmlSchema GetSchema()

--- a/Assets/Scripts/Models/Tile.cs
+++ b/Assets/Scripts/Models/Tile.cs
@@ -247,30 +247,21 @@ public class Tile : IXmlSerializable, ISelectable, IContextActionProvider
     /// <param name="diagOkay">Is diagonal movement okay?.</param>
     public Tile[] GetNeighbours(bool diagOkay = false)
     {
-        Tile[] ns = diagOkay == false ? new Tile[4] : new Tile[8];
-
-        Tile tile = World.Current.GetTileAt(X, Y + 1);
-        ns[0] = tile; // Could be null, but that's okay.
-        tile = World.Current.GetTileAt(X + 1, Y);
-        ns[1] = tile; // Could be null, but that's okay.
-        tile = World.Current.GetTileAt(X, Y - 1);
-        ns[2] = tile; // Could be null, but that's okay.
-        tile = World.Current.GetTileAt(X - 1, Y);
-        ns[3] = tile; // Could be null, but that's okay.
+        Tile[] tiles = diagOkay == false ? new Tile[4] : new Tile[8];
+        tiles[0] = World.Current.GetTileAt(X, Y + 1);
+        tiles[1] = World.Current.GetTileAt(X + 1, Y);
+        tiles[2] = World.Current.GetTileAt(X, Y - 1);
+        tiles[3] = World.Current.GetTileAt(X - 1, Y);
 
         if (diagOkay == true)
         {
-            tile = World.Current.GetTileAt(X + 1, Y + 1);
-            ns[4] = tile; // Could be null, but that's okay.
-            tile = World.Current.GetTileAt(X + 1, Y - 1);
-            ns[5] = tile; // Could be null, but that's okay.
-            tile = World.Current.GetTileAt(X - 1, Y - 1);
-            ns[6] = tile; // Could be null, but that's okay.
-            tile = World.Current.GetTileAt(X - 1, Y + 1);
-            ns[7] = tile; // Could be null, but that's okay.
+            tiles[4] = World.Current.GetTileAt(X + 1, Y + 1);
+            tiles[5] = World.Current.GetTileAt(X + 1, Y - 1);
+            tiles[6] = World.Current.GetTileAt(X - 1, Y - 1);
+            tiles[7] = World.Current.GetTileAt(X - 1, Y + 1);
         }
 
-        return ns;
+        return tiles.Where(tile => tile != null).ToArray();
     }
 
     /// <summary>

--- a/Assets/Scripts/Pathfinding/Path_TileGraph.cs
+++ b/Assets/Scripts/Pathfinding/Path_TileGraph.cs
@@ -92,6 +92,11 @@ public class Path_TileGraph
 
     private void GenerateEdgesByTile(Tile t)
     {
+        if (t == null)
+        {
+            return;
+        }
+
         Path_Node<Tile> n = nodes[t];
         List<Path_Edge<Tile>> edges = new List<Path_Edge<Tile>>();
 


### PR DESCRIPTION
(Don't know if this bug has been reported yet.)
To reproduce the bug build floor tiles along the edge of the map. This fixes it.