### PR TITLE
Removed redundant TODOs

### DIFF
--- a/Assets/Scripts/Controllers/FurnitureSpriteController.cs
+++ b/Assets/Scripts/Controllers/FurnitureSpriteController.cs
@@ -95,7 +95,7 @@ public class FurnitureSpriteController : BaseSpriteController<Furniture>
 
     protected override void OnCreated(Furniture furniture)
     {
-        // FIXME: Does not consider multi-tile objects nor rotated objects
+        // FIXME: Does not consider rotated objects
         GameObject furn_go = new GameObject();
 
         // Add our tile/GO pair to the dictionary.

--- a/Assets/Scripts/Controllers/InventorySpriteController.cs
+++ b/Assets/Scripts/Controllers/InventorySpriteController.cs
@@ -50,7 +50,7 @@ public class InventorySpriteController : BaseSpriteController<Inventory>
 
     protected override void OnCreated(Inventory inv)
     {
-        // FIXME: Does not consider multi-tile objects nor rotated objects
+        // FIXME: Does not consider rotated objects
         // This creates a new GameObject and adds it to our scene.
         GameObject inv_go = new GameObject();
 

--- a/Assets/Scripts/Models/Furniture.cs
+++ b/Assets/Scripts/Models/Furniture.cs
@@ -71,10 +71,7 @@ public class Furniture : IXmlSerializable, ISelectable, IContextActionProvider
 
     private bool isOperating;
 
-    // TODO: Implement larger objects
-    // TODO: Implement object rotation
-
-    // Empty constructor is used for serialization
+    /// TODO: Implement object rotation
     public Furniture()
     {
         Tint = Color.white;
@@ -294,7 +291,6 @@ public class Furniture : IXmlSerializable, ISelectable, IContextActionProvider
         Furniture obj = proto.Clone();
         obj.Tile = tile;
 
-        // FIXME: This assumes we are 1x1!
         if (tile.PlaceFurniture(obj) == false)
         {
             // For some reason, we weren't able to place our object in this tile.

--- a/Assets/Scripts/Models/Tile.cs
+++ b/Assets/Scripts/Models/Tile.cs
@@ -139,7 +139,7 @@ public class Tile : IXmlSerializable, ISelectable, IContextActionProvider
 
     public bool UnplaceFurniture()
     {
-        // Just uninstalling.  FIXME:  What if we have a multi-tile furniture?
+        // Just uninstalling.
         if (Furniture == null)
         {
             return false;

--- a/Assets/Scripts/Models/World.cs
+++ b/Assets/Scripts/Models/World.cs
@@ -327,7 +327,6 @@ public class World : IXmlSerializable
 
     public Furniture PlaceFurniture(string objectType, Tile t, bool doRoomFloodFill = true)
     {
-        // TODO: This function assumes 1x1 tiles -- change this later!
         if (PrototypeManager.Furniture.HasPrototype(objectType) == false)
         {
             Debug.ULogErrorChannel("World", "furniturePrototypes doesn't contain a proto for key: " + objectType);


### PR DESCRIPTION
Removed TODO like this:
```
//FIXME:  What if we have a multi-tile furniture?
// TODO: This function assumes 1x1 tiles -- change this later!
```

We support multi-tile object. Or I am wrong?