### PR TITLE
Fixes NullReferenceException in Metal Smelter

### DIFF
--- a/Assets/StreamingAssets/LUA/Furniture.lua
+++ b/Assets/StreamingAssets/LUA/Furniture.lua
@@ -349,7 +349,7 @@ function MetalSmelter_UpdateAction(furniture, deltaTime)
         furniture.Parameters["smelttime"].ChangeFloatValue(deltaTime)
         if(furniture.Parameters["smelttime"].ToFloat() >= furniture.Parameters["smelttime_required"].ToFloat()) then
             furniture.Parameters["smelttime"].SetValue(0)
-            local outputSpot = World.Current.GetTileAt(spawnSpot.X+2, spawnSpot.y, spawnSpot.Zs)
+            local outputSpot = World.Current.GetTileAt(spawnSpot.X+2, spawnSpot.Y, spawnSpot.Z)
 
             if(outputSpot.Inventory == nil) then
                 World.Current.inventoryManager.PlaceInventory(outputSpot, Inventory.__new("Steel Plate", 50, 5))


### PR DESCRIPTION
Fixes 'NullReferenceException: Object reference not set to an instance of an object` . When the metal smelter tries to spawn the steel plates it can't find the location. Variable was misspelled.