### PR TITLE
FilterMode Point for SpriteManager-loaded sprites

### DIFF
--- a/Assets/Scripts/Controllers/SpriteManager.cs
+++ b/Assets/Scripts/Controllers/SpriteManager.cs
@@ -141,6 +141,8 @@ public class SpriteManager : MonoBehaviour
         if (imageTexture.LoadImage(imageBytes))
         {
             // Image was successfully loaded.
+            imageTexture.filterMode = FilterMode.Point;
+
             // So let's see if there's a matching XML file for this image.
             string baseSpriteName = Path.GetFileNameWithoutExtension(filePath);
             string basePath = Path.GetDirectoryName(filePath);
@@ -181,7 +183,7 @@ public class SpriteManager : MonoBehaviour
             // Attempt to load/parse the XML file to get information on the sprite(s)
         }
 
-        // else, the file wasn't actually a image file, so just move on.
+        // Else, the file wasn't actually a image file, so just move on.
     }
 
     private void ReadSpriteFromXml(string spriteCategory, XmlReader reader, Texture2D imageTexture)


### PR DESCRIPTION
Set the FilterMode to Point for textures loaded in SpriteManager to make them look nicer (not washed out) when zoomed in.

PSA: I didn't change the default ppu for files without XML, because I honestly think that we should never have decided to do that, especially when everyone in favour of 32x32 (majority of the Sprite Crew on Discord) was not even there.