### PR TITLE
Fix folding in Travis log

### DIFF
--- a/Scripts/test.sh
+++ b/Scripts/test.sh
@@ -1,13 +1,13 @@
 #! /bin/sh
 
-echo "Attempting Unit Tests"
 echo 'travis_fold:start:compile'
+echo "Attempting Unit Tests"
 /Applications/Unity/Unity.app/Contents/MacOS/Unity -batchmode -runEditorTests -nographics -EditorTestResultFile $(pwd)/EditorTestResults.xml -projectPath $(pwd) -logFile unity.log 
 cat $(pwd)/unity.log
 echo 'travis_fold:end:compile'
 
-echo 'Show Results from Tests'
 echo 'travis_fold:start:tests'
+echo 'Show Results from Tests'
 if [ ! -f $(pwd)/EditorTestResults.xml ]; then
     echo "Results file not found!"
 	exit 1


### PR DESCRIPTION
fixes the order of echos in travis so the log folds on headings rather than the line after

before:
![before](https://cloud.githubusercontent.com/assets/7608114/18232235/66a840da-7299-11e6-912c-859272fc7cbf.PNG)
After:
![after](https://cloud.githubusercontent.com/assets/7608114/18232236/69136d40-7299-11e6-8109-2867dce30863.PNG)

any messages about failures still are shown after the Unit Tests section and will not be folded.
