### PR TITLE
UberLogger can detect that he called from Unit Tests

### DIFF
--- a/Assets/Scripts/Utilities/UnitTestDetector.cs
+++ b/Assets/Scripts/Utilities/UnitTestDetector.cs
@@ -1,0 +1,37 @@
+﻿#region License
+// ====================================================
+// Project Porcupine Copyright(C) 2016 Team Porcupine
+// This program comes with ABSOLUTELY NO WARRANTY; This is free software, 
+// and you are welcome to redistribute it under certain conditions; See 
+// file LICENSE, which is part of this source code package, for details.
+// ====================================================
+#endregion
+using System;
+using System.Reflection;
+
+/// <summary>
+/// Detect if we are running as part of a unit test.
+/// This is DIRTY and should only be used if absolutely necessary 
+/// as its usually a sign of bad design.
+/// </summary>    
+public static class UnitTestDetector
+{
+    private static bool runningFromNUnit;
+
+    static UnitTestDetector()
+    {
+        foreach (Assembly assem in AppDomain.CurrentDomain.GetAssemblies())
+        {
+            if (assem.FullName.ToLowerInvariant().StartsWith("nunit.framework"))
+            {
+                runningFromNUnit = true;
+                break;
+            }
+        }
+    }
+
+    public static bool IsRunningFromUnitTest
+    {
+        get { return runningFromNUnit; }
+    }
+}

--- a/Assets/Scripts/Utilities/UnitTestDetector.cs.meta
+++ b/Assets/Scripts/Utilities/UnitTestDetector.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 61eb1635f250f5942b6c9095cc325713
+timeCreated: 1473009071
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UberLogger/UberLogger.cs
+++ b/Assets/UberLogger/UberLogger.cs
@@ -200,6 +200,11 @@ namespace UberLogger
 
         static Logger()
         {
+            if (UnitTestDetector.IsRunningFromUnitTest)
+            {
+                return;
+            }
+
             // Register with Unity's logging system
 #if UNITY_5
             Application.logMessageReceived += UnityLogHandler;
@@ -420,7 +425,12 @@ namespace UberLogger
         [StackTraceIgnore()]
         static public void Log(string channel, UnityEngine.Object source, LogSeverity severity, object message, params object[] par)
         {
-            lock(Loggers)
+            if (UnitTestDetector.IsRunningFromUnitTest)
+            {
+                return;
+            }
+
+            lock (Loggers)
             {
                 if(!AlreadyLogging)
                 {


### PR DESCRIPTION
Some UnitTest are failing when running them from IDE (VisualStudio) with exception:
```
System.TypeInitializationException: initializer type "UberLogger.Logger" threw an exception.
  ----> System.Security.SecurityException: ECall methods must be packaged in a system module.
   in UberLogger.Logger.Log (String channel, Object source, LogSeverity severity, Object message, Object [] par)
   in Debug.ULogChannel (String channel, String message, Object [] par) in D: \ Development \ GitHubRepository \ ProjectPorcupine \ Assets \ UberLogger \ Debug.cs: line 127
   in ScheduledEventTest <Init> b__2_0 (ScheduledEvent evt) in D:. \ Development \ GitHubRepository \ ProjectPorcupine \ Assets \ Editor \ ScheduledEventTest.cs: line 26
   in Scheduler.ScheduledEvent.Fire () in D: \ Development \ GitHubRepository \ ProjectPorcupine \ Assets \ Scripts \ Scheduler \ ScheduledEvent.cs: line 160
   in Scheduler.ScheduledEvent.Update (Single deltaTime) in D: \ Development \ GitHubRepository \ ProjectPorcupine \ Assets \ Scripts \ Scheduler \ ScheduledEvent.cs: line 145
   in ScheduledEventTest.CooldownEventRunTest () in D: \ Development \ GitHubRepository \ ProjectPorcupine \ Assets \ Editor \ ScheduledEventTest.cs: line 141
--SecurityException
   in UnityEngine.Application.add_logMessageReceived (LogCallback value)
   in UberLogger.Logger..cctor () in D: \ Development \ GitHubRepository \ ProjectPorcupine \ Assets \ UberLogger \ UberLogger.cs: line 205
```
This "fix" will prevent call to `Log` if running from UTest.