### PR TITLE
Fix SchedulerEditorTests using PrototypeManager

### DIFF
--- a/Assets/Scripts/Utilities/LuaUtilities.cs
+++ b/Assets/Scripts/Utilities/LuaUtilities.cs
@@ -68,7 +68,7 @@ public class LuaUtilities
         luaScript.Globals[type.Name] = type;
     }
 
-    private static void LoadScript(string script)
+    public static void LoadScript(string script)
     {
         luaScript.DoString(script);
     }


### PR DESCRIPTION
Fixes issue mentioned by @Grenkin1988 @vogonistic in #998.

It is now possible to use Scheduler without PrototypeManager for unit testing purposes. I did have to make `LuaUtilities.LoadScript` public for this to work. Any objections?

Apologies for slow response... I went offline for the weekend and this happened. :cry: