### PR TITLE
Show compile errors clearly in Travis CI

### DIFF
--- a/Scripts/test.sh
+++ b/Scripts/test.sh
@@ -21,9 +21,9 @@ if [ ! -f $(pwd)/EditorTestResults.xml ]; then
         out=$(grep "CompilerOutput" unity.log)
         if [ "$out" != "" ]; then
 
-            result=$(cat unity.log | awk '/CompilerOutput:/,/EndCompilerOutput/') #sed -n '/CompilerOutput:/,/EndCompilerOutput/p')
             echo 'Build Failed! \nThe compiler generated the following messages:'
-            echo $result
+            echo | awk '/CompilerOutput:/,/EndCompilerOutput/' < unity.log #show lines in between compiler output "tags" including tags 
+
         fi
     fi
     exit 1

--- a/Scripts/test.sh
+++ b/Scripts/test.sh
@@ -21,7 +21,7 @@ if [ ! -f $(pwd)/EditorTestResults.xml ]; then
         out=$(grep "CompilerOutput" unity.log)
         if [ "$out" != "" ]; then
 
-            result=$(cat unity.log | sed -n '/CompilerOutput:/,/EndCompilerOutput/p')
+            result=$(cat unity.log | sed '/CompilerOutput:/,/EndCompilerOutput/p')
             echo 'Build Failed! \nThe compiler generated the following messages:'
             echo $result
         fi

--- a/Scripts/test.sh
+++ b/Scripts/test.sh
@@ -13,7 +13,7 @@ echo 'travis_fold:start:tests'
 if [ ! -f $(pwd)/EditorTestResults.xml ]; then
     echo "Results file not found!"
     echo "travis_fold:end:tests"
-    $endTestsFold = 1
+    $endTestsFold=1
 
     # at this point we know that the build has failed due to compilation errors
     # lets try to parse them out of unity.log and display them
@@ -21,7 +21,7 @@ if [ ! -f $(pwd)/EditorTestResults.xml ]; then
         out=$(grep "CompilerOutput" unity.log)
         if [ "$out" != "" ]; then
 
-            echo 'Build Failed! \nThe compiler generated the following messages:'
+            echo '\nBuild Failed! \nThe compiler generated the following messages:'
             echo | awk '/CompilerOutput:/,/EndCompilerOutput/' < unity.log #show lines in between compiler output "tags" including tags 
 
         fi

--- a/Scripts/test.sh
+++ b/Scripts/test.sh
@@ -1,5 +1,7 @@
 #! /bin/sh
 
+endTestsFold=0 #stores whether the travis_fold:end:tests has been echoed yet
+
 echo "Attempting Unit Tests"
 echo 'travis_fold:start:compile'
 /Applications/Unity/Unity.app/Contents/MacOS/Unity -batchmode -runEditorTests -nographics -EditorTestResultFile $(pwd)/EditorTestResults.xml -projectPath $(pwd) -logFile unity.log 
@@ -10,46 +12,54 @@ echo 'Show Results from Tests'
 echo 'travis_fold:start:tests'
 if [ ! -f $(pwd)/EditorTestResults.xml ]; then
     echo "Results file not found!"
+    echo "travis_fold:end:tests"
+    $endTestsFold = 1
+
     # at this point we know that the build has failed due to compilation errors
     # lets try to parse them out of unity.log and display them
     if [ -f $(pwd)/unity.log ]; then
-        if [ grep "-----CompilerOutput:" unity.log ]; then
-            awk '/"-----CompilerOutput:/,/-----EndCompilerOutput/' compileError.txt
-            cat compileError.txt
+        count=$(grep "CompilerOutput" unity.log)
+        if [ "$count" != "0" ]; then
+
+            result=$(cat unity.log | sed -n '/CompilerOutput:/,/EndCompilerOutput/p')
+            echo 'Build Failed! \nThe compiler generated the following messages:'
+            echo $result
         fi
     fi
-	exit 1
+    exit 1
 fi
 cat $(pwd)/EditorTestResults.xml
-echo 'travis_fold:end:tests'
+if [ "$endTestsFold" == 0 ]; then
+    echo 'travis_fold:end:tests'
+fi
 
 #TERRIBLE error check logic - Please fix ASAP
 errorCount=$(grep "failures" EditorTestResults.xml | awk -F"\"" '{print $8}') #find line with 'failures' and returns characters between quotation mark 8 and 9
 
 if [ "$errorCount" != "0" ]; then
-	echo $errorCount ' unit tests failed!'
-	exit 1
+    echo $errorCount ' unit tests failed!'
+    exit 1
 fi
 
 errorCount=$(grep "failures" EditorTestResults.xml | awk -F"\"" '{print $6}') #now for errors
 
 if [ "$errorCount" != "0" ]; then
-	echo $errorCount ' unit tests threw errors!'
-	exit 1
+    echo $errorCount ' unit tests threw errors!'
+    exit 1
 fi
 
 errorCount=$(grep "failures" EditorTestResults.xml | awk -F"\"" '{print $12}') #inconlusive tests
 
 if [ "$errorCount" != "0" ]; then
-	echo $errorCount ' unit tests were inconlusive!'
-	exit 1
+    echo $errorCount ' unit tests were inconlusive!'
+    exit 1
 fi
 
 
 errorCount=$(grep "failures" EditorTestResults.xml | awk -F"\"" '{print $18}') #finally for invalid tests
 
 if [ "$errorCount" != "0" ]; then
-	echo $errorCount ' unit tests were invalid!'
-	exit 1
+    echo $errorCount ' unit tests were invalid!'
+    exit 1
 fi
 #end of unit test checks. at this point the test have suceeded or exited with an error code.

--- a/Scripts/test.sh
+++ b/Scripts/test.sh
@@ -10,6 +10,14 @@ echo 'Show Results from Tests'
 echo 'travis_fold:start:tests'
 if [ ! -f $(pwd)/EditorTestResults.xml ]; then
     echo "Results file not found!"
+    # at this point we know that the build has failed due to compilation errors
+    # lets try to parse them out of unity.log and display them
+    if [ -f $(pwd)/unity.log ]; then
+        if [ grep "-----CompilerOutput:" unity.log ]; then
+            awk '/"-----CompilerOutput:/,/-----EndCompilerOutput/' compileError.txt
+            cat compileError.txt
+        fi
+    fi
 	exit 1
 fi
 cat $(pwd)/EditorTestResults.xml

--- a/Scripts/test.sh
+++ b/Scripts/test.sh
@@ -21,7 +21,7 @@ if [ ! -f $(pwd)/EditorTestResults.xml ]; then
         out=$(grep "CompilerOutput" unity.log)
         if [ "$out" != "" ]; then
 
-            result=$(cat unity.log | sed '/CompilerOutput:/,/EndCompilerOutput/p')
+            result=$(cat unity.log | awk '/CompilerOutput:/,/EndCompilerOutput/') #sed -n '/CompilerOutput:/,/EndCompilerOutput/p')
             echo 'Build Failed! \nThe compiler generated the following messages:'
             echo $result
         fi

--- a/Scripts/test.sh
+++ b/Scripts/test.sh
@@ -18,8 +18,8 @@ if [ ! -f $(pwd)/EditorTestResults.xml ]; then
     # at this point we know that the build has failed due to compilation errors
     # lets try to parse them out of unity.log and display them
     if [ -f $(pwd)/unity.log ]; then
-        count=$(grep "CompilerOutput" unity.log)
-        if [ "$count" != "0" ]; then
+        out=$(grep "CompilerOutput" unity.log)
+        if [ "$out" != "" ]; then
 
             result=$(cat unity.log | sed -n '/CompilerOutput:/,/EndCompilerOutput/p')
             echo 'Build Failed! \nThe compiler generated the following messages:'


### PR DESCRIPTION
Test.sh now parses unity's log file from a failed build and repeats the console output at the end of the build for easy access to errors. 

Previously the compiler errors from a build were logged, but 300 lines above where the build actually reports failing, making finding errors very difficult.

Sample output of a failing build:
![after](https://cloud.githubusercontent.com/assets/7608114/18234005/16cfea00-72c5-11e6-9e8a-de3e28445d6b.PNG)
