### PR TITLE
Log failed unit tests to Travis CI

### DIFF
--- a/Scripts/test.sh
+++ b/Scripts/test.sh
@@ -40,7 +40,7 @@ if [ "$errorCount" != "0" ]; then
     echo $errorCount ' unit tests failed!'
      
      #show the exact unit test failure
-    echo 'The following unit tests failed:'
+    echo '\nThe following unit tests failed:'
     echo | grep 'success="False"' EditorTestResults.xml | grep 'test-case'
    
     exit 1

--- a/Scripts/test.sh
+++ b/Scripts/test.sh
@@ -38,13 +38,11 @@ errorCount=$(grep "failures" EditorTestResults.xml | awk -F"\"" '{print $8}') #f
 
 if [ "$errorCount" != "0" ]; then
     echo $errorCount ' unit tests failed!'
-     #lets try to show the exact unit test failure
-    failures=$(grep 'success="False"' EditorTestResults.xml | grep 'test-case')
-    if [ "$failures" != "" ]; then
-        echo 'The following unit tests failed:'
-        echo $(failures)
-    fi
-
+     
+     #show the exact unit test failure
+    echo 'The following unit tests failed:'
+    echo | grep 'success="False"' EditorTestResults.xml | grep 'test-case'
+   
     exit 1
 fi
 

--- a/Scripts/test.sh
+++ b/Scripts/test.sh
@@ -38,6 +38,13 @@ errorCount=$(grep "failures" EditorTestResults.xml | awk -F"\"" '{print $8}') #f
 
 if [ "$errorCount" != "0" ]; then
     echo $errorCount ' unit tests failed!'
+     #lets try to show the exact unit test failure
+    failures=$(grep 'success="False"' EditorTestResults.xml | grep 'test-case')
+    if [ "$failures" != "" ]; then
+        echo 'The following unit tests failed:'
+        echo $(failures)
+    fi
+
     exit 1
 fi
 


### PR DESCRIPTION
when a Travis build fails due to a unit test failing, Travis will now log the exact failure at the end of the build log.

here is a sample where two unit test fail:
https://travis-ci.org/bjubes/ProjectPorcupine/builds/157662489
