### PR TITLE
Remove Namespace From Unit Tests

### DIFF
--- a/Assets/Editor/UnitTests/Models/Power/PowerGridTest.cs
+++ b/Assets/Editor/UnitTests/Models/Power/PowerGridTest.cs
@@ -12,7 +12,6 @@ using System.Reflection;
 using NUnit.Framework;
 using ProjectPorcupine.PowerNetwork;
 
-
 public class PowerGridTest
 {
     private Grid grid;

--- a/Assets/Editor/UnitTests/Models/Power/PowerGridTest.cs
+++ b/Assets/Editor/UnitTests/Models/Power/PowerGridTest.cs
@@ -1,4 +1,4 @@
-﻿#region License
+#region License
 // ====================================================
 // Project Porcupine Copyright(C) 2016 Team Porcupine
 // This program comes with ABSOLUTELY NO WARRANTY; This is free software, 
@@ -13,283 +13,283 @@ using NUnit.Framework;
 using ProjectPorcupine.PowerNetwork;
 
 
-    public class PowerGridTest
+public class PowerGridTest
+{
+    private Grid grid;
+    private HashSet<Connection> connections;
+
+    [SetUp]
+    public void Init()
     {
-        private Grid grid;
-        private HashSet<Connection> connections;
-
-        [SetUp]
-        public void Init()
-        {
-            grid = new Grid();
-            Type powerGridType = typeof(Grid);
-            FieldInfo field = powerGridType.GetField("connections", BindingFlags.NonPublic | BindingFlags.Instance);
-            Assert.IsNotNull(field);
-            connections = field.GetValue(grid) as HashSet<Connection>;
-            Assert.IsNotNull(connections);
-        }
-
-        [Test]
-        [ExpectedException(typeof(ArgumentNullException))]
-        public void PlugInArgumentNullException()
-        {
-            grid.PlugIn(null);
-        }
-
-        [Test]
-        public void PlugInTest()
-        {
-            grid.PlugIn(new Connection());
-            Assert.AreEqual(1, connections.Count);
-        }
-
-        [Test]
-        public void IsPluggedInTest()
-        {
-            Connection connection = new Connection();
-            grid.PlugIn(connection);
-            Assert.AreEqual(1, connections.Count);
-            Assert.IsTrue(grid.IsPluggedIn(connection));
-        }
-
-        [Test]
-        public void UnplugTest()
-        {
-            Connection connection = new Connection();
-            grid.PlugIn(connection);
-            Assert.AreEqual(1, connections.Count);
-            grid.Unplug(connection);
-            Assert.AreEqual(0, connections.Count);
-        }
-
-        [Test]
-        public void UpdateEnoughPowerTest()
-        {
-            Connection powerProducer = new Connection { OutputRate = 50.0f };
-            Connection firstPowerConsumer = new Connection { InputRate = 30.0f };
-            grid.PlugIn(powerProducer);
-            grid.PlugIn(firstPowerConsumer);
-            Assert.AreEqual(2, connections.Count);
-            grid.Tick();
-            Assert.IsTrue(grid.IsOperating);
-        }
-
-        [Test]
-        public void UpdateNotEnoughPowerTest()
-        {
-            Connection powerProducer = new Connection { OutputRate = 50.0f };
-            Connection firstPowerConsumer = new Connection { InputRate = 30.0f };
-            Connection secondPowerConsumer = new Connection { InputRate = 30.0f };
-            grid.PlugIn(powerProducer);
-            grid.PlugIn(firstPowerConsumer);
-            grid.PlugIn(secondPowerConsumer);
-            Assert.AreEqual(3, connections.Count);
-            grid.Tick();
-            Assert.IsFalse(grid.IsOperating);
-        }
-
-        [Test]
-        public void ChargeAccumulatorsTest()
-        {
-            Connection powerProducer = new Connection { OutputRate = 50.0f };
-            Connection firstPowerConsumer = new Connection { InputRate = 30.0f };
-            Connection accumulator = new Connection { InputRate = 10.0f, OutputRate = 10.0f, Capacity = 100.0f };
-            grid.PlugIn(powerProducer);
-            grid.PlugIn(firstPowerConsumer);
-            grid.PlugIn(accumulator);
-            Assert.AreEqual(3, connections.Count);
-            grid.Tick();
-            Assert.IsTrue(grid.IsOperating);
-            Assert.IsTrue(accumulator.AccumulatedPower.AreEqual(10.0f));
-            grid.Tick();
-            Assert.IsTrue(grid.IsOperating);
-            Assert.IsTrue(accumulator.AccumulatedPower.AreEqual(20.0f));
-            grid.Tick();
-            Assert.IsTrue(grid.IsOperating);
-            Assert.IsTrue(accumulator.AccumulatedPower.AreEqual(30.0f));
-        }
-
-        [Test]
-        public void DischargeAccumulatorsEnoughPowerTest()
-        {
-            Connection powerProducer = new Connection { OutputRate = 30.0f };
-            Connection firstPowerConsumer = new Connection { InputRate = 30.0f };
-            Connection firstAccumulator = new Connection { InputRate = 10.0f, OutputRate = 10.0f, Capacity = 100.0f };
-            Connection secondAccumulator = new Connection { InputRate = 10.0f, OutputRate = 10.0f, Capacity = 100.0f };
-            Connection thirdAccumulator = new Connection { InputRate = 10.0f, OutputRate = 10.0f, Capacity = 100.0f };
-            grid.PlugIn(powerProducer);
-            grid.PlugIn(firstAccumulator);
-            grid.PlugIn(secondAccumulator);
-            grid.PlugIn(thirdAccumulator);
-            Assert.AreEqual(4, connections.Count);
-
-            grid.Tick();
-            grid.Tick();
-            grid.Tick();
-            Assert.IsTrue(grid.IsOperating);
-            Assert.IsTrue(firstAccumulator.AccumulatedPower.AreEqual(30.0f));
-            Assert.IsTrue(secondAccumulator.AccumulatedPower.AreEqual(30.0f));
-            Assert.IsTrue(thirdAccumulator.AccumulatedPower.AreEqual(30.0f));
-
-            grid.PlugIn(firstPowerConsumer);
-            grid.Tick();
-            Assert.IsTrue(grid.IsOperating);
-            Assert.IsTrue(firstAccumulator.AccumulatedPower.AreEqual(30.0f));
-            Assert.IsTrue(secondAccumulator.AccumulatedPower.AreEqual(30.0f));
-            Assert.IsTrue(thirdAccumulator.AccumulatedPower.AreEqual(30.0f));
-
-            grid.Unplug(powerProducer);
-            grid.Tick();
-            Assert.IsTrue(grid.IsOperating);
-            Assert.IsTrue(firstAccumulator.AccumulatedPower.AreEqual(20.0f));
-            Assert.IsTrue(secondAccumulator.AccumulatedPower.AreEqual(20.0f));
-            Assert.IsTrue(thirdAccumulator.AccumulatedPower.AreEqual(20.0f));
-
-            grid.Tick();
-            grid.Tick();
-            Assert.IsTrue(grid.IsOperating);
-            Assert.IsTrue(firstAccumulator.IsEmpty);
-            Assert.IsTrue(secondAccumulator.IsEmpty);
-            Assert.IsTrue(thirdAccumulator.IsEmpty);
-
-            grid.Tick();
-            Assert.IsFalse(grid.IsOperating);
-        }
-
-        [Test]
-        public void DischargeAccumulatorsNotEnoughPowerTest()
-        {
-            Connection powerProducer = new Connection { OutputRate = 30.0f };
-            Connection firstPowerConsumer = new Connection { InputRate = 30.0f };
-            Connection firstAccumulator = new Connection { InputRate = 10.0f, OutputRate = 10.0f, Capacity = 100.0f };
-            Connection secondAccumulator = new Connection { InputRate = 10.0f, OutputRate = 10.0f, Capacity = 100.0f };
-            grid.PlugIn(powerProducer);
-            grid.PlugIn(firstAccumulator);
-            grid.PlugIn(secondAccumulator);
-            Assert.AreEqual(3, connections.Count);
-
-            grid.Tick();
-            grid.Tick();
-            grid.Tick();
-            Assert.IsTrue(grid.IsOperating);
-            Assert.IsTrue(firstAccumulator.AccumulatedPower.AreEqual(30.0f));
-            Assert.IsTrue(secondAccumulator.AccumulatedPower.AreEqual(30.0f));
-
-            grid.PlugIn(firstPowerConsumer);
-            grid.Tick();
-            Assert.IsTrue(grid.IsOperating);
-            Assert.IsTrue(firstAccumulator.AccumulatedPower.AreEqual(30.0f));
-            Assert.IsTrue(secondAccumulator.AccumulatedPower.AreEqual(30.0f));
-
-            grid.Unplug(powerProducer);
-            grid.Tick();
-            Assert.IsFalse(grid.IsOperating);
-            Assert.IsTrue(firstAccumulator.AccumulatedPower.AreEqual(30.0f));
-            Assert.IsTrue(secondAccumulator.AccumulatedPower.AreEqual(30.0f));
-        }
-
-        [Test]
-        public void ChargeAccumulatorsCapacityTest()
-        {
-            Connection powerProducer = new Connection { OutputRate = 20.0f };
-            Connection accumulator = new Connection { InputRate = 15.0f, OutputRate = 10.0f, Capacity = 40.0f };
-            grid.PlugIn(powerProducer);
-            grid.PlugIn(accumulator);
-            Assert.AreEqual(2, connections.Count);
-            grid.Tick();
-            Assert.IsTrue(grid.IsOperating);
-            Assert.IsTrue(accumulator.AccumulatedPower.AreEqual(15.0f));
-            grid.Tick();
-            Assert.IsTrue(grid.IsOperating);
-            Assert.IsTrue(accumulator.AccumulatedPower.AreEqual(30.0f));
-            grid.Tick();
-            Assert.IsTrue(grid.IsOperating);
-            Assert.IsTrue(accumulator.AccumulatedPower.AreEqual(40.0f));
-            grid.Tick();
-            Assert.IsTrue(grid.IsOperating);
-            Assert.IsTrue(accumulator.AccumulatedPower.AreEqual(40.0f));
-        }
-
-        [Test]
-        public void DischargeAccumulatorsCapacityTest()
-        {
-            Connection powerConsumer = new Connection { InputRate = 4.0f };
-            Connection accumulator = new Connection { InputRate = 10.0f, OutputRate = 10.0f, Capacity = 100.0f, AccumulatedPower = 15.0f };
-            grid.PlugIn(powerConsumer);
-            grid.PlugIn(accumulator);
-            Assert.AreEqual(2, connections.Count);
-
-            grid.Tick();
-            Assert.IsTrue(grid.IsOperating);
-            Assert.IsTrue(accumulator.AccumulatedPower.AreEqual(11.0f));
-
-            grid.Tick();
-            Assert.IsTrue(grid.IsOperating);
-            Assert.IsTrue(accumulator.AccumulatedPower.AreEqual(7.0f));
-
-            grid.Tick();
-            Assert.IsTrue(grid.IsOperating);
-            Assert.IsTrue(accumulator.AccumulatedPower.AreEqual(3.0f));
-
-            grid.Tick();
-            Assert.IsFalse(grid.IsOperating);
-            Assert.IsTrue(accumulator.AccumulatedPower.AreEqual(3.0f));
-        }
-
-        [Test]
-        public void ChargeAccumulatorsInputRateTest()
-        {
-            Connection powerProducer = new Connection { OutputRate = 20.0f };
-            Connection accumulator1 = new Connection { InputRate = 15.0f, OutputRate = 10.0f, Capacity = 40.0f };
-            Connection accumulator2 = new Connection { InputRate = 15.0f, OutputRate = 10.0f, Capacity = 40.0f };
-            grid.PlugIn(powerProducer);
-            grid.PlugIn(accumulator1);
-            grid.PlugIn(accumulator2);
-            Assert.AreEqual(3, connections.Count);
-            grid.Tick();
-            Assert.IsTrue(grid.IsOperating);
-            Assert.IsTrue(accumulator1.AccumulatedPower.AreEqual(15.0f), string.Format("Expected {0} Actual {1}", 15.0f, accumulator1.AccumulatedPower));
-            Assert.IsTrue(accumulator2.AccumulatedPower.AreEqual(5.0f), string.Format("Expected {0} Actual {1}", 5.0f, accumulator2.AccumulatedPower));
-
-            grid.Tick();
-            Assert.IsTrue(grid.IsOperating);
-            Assert.IsTrue(accumulator1.AccumulatedPower.AreEqual(30.0f), string.Format("Expected {0} Actual {1}", 30.0f, accumulator1.AccumulatedPower));
-            Assert.IsTrue(accumulator2.AccumulatedPower.AreEqual(10.0f), string.Format("Expected {0} Actual {1}", 10.0f, accumulator2.AccumulatedPower));
-
-            grid.Tick();
-            Assert.IsTrue(grid.IsOperating);
-            Assert.IsTrue(accumulator1.AccumulatedPower.AreEqual(40.0f), string.Format("Expected {0} Actual {1}", 40.0f, accumulator1.AccumulatedPower));
-            Assert.IsTrue(accumulator2.AccumulatedPower.AreEqual(20.0f), string.Format("Expected {0} Actual {1}", 20.0f, accumulator2.AccumulatedPower));
-
-            grid.Tick();
-            Assert.IsTrue(grid.IsOperating);
-            Assert.IsTrue(accumulator1.AccumulatedPower.AreEqual(40.0f), string.Format("Expected {0} Actual {1}", 40.0f, accumulator1.AccumulatedPower));
-            Assert.IsTrue(accumulator2.AccumulatedPower.AreEqual(35.0f), string.Format("Expected {0} Actual {1}", 35.0f, accumulator2.AccumulatedPower));
-        }
-
-        [Test]
-        public void DischargeAccumulatorsOutputRateTest()
-        {
-            Connection powerConsumer1 = new Connection { InputRate = 5.0f };
-            Connection powerConsumer2 = new Connection { InputRate = 5.0f };
-            Connection powerConsumer3 = new Connection { InputRate = 5.0f };
-            Connection accumulator1 = new Connection { InputRate = 10.0f, OutputRate = 10.0f, Capacity = 100.0f, AccumulatedPower = 10.0f };
-            Connection accumulator2 = new Connection { InputRate = 10.0f, OutputRate = 10.0f, Capacity = 100.0f, AccumulatedPower = 10.0f };
-            grid.PlugIn(powerConsumer1);
-            grid.PlugIn(powerConsumer2);
-            grid.PlugIn(powerConsumer3);
-            grid.PlugIn(accumulator1);
-            grid.PlugIn(accumulator2);
-            Assert.AreEqual(5, connections.Count);
-
-            grid.Tick();
-            Assert.IsTrue(grid.IsOperating);
-            Assert.IsTrue(accumulator1.AccumulatedPower.AreEqual(0.0f), string.Format("Expected {0} Actual {1}", 0.0f, accumulator1.AccumulatedPower));
-            Assert.IsTrue(accumulator2.AccumulatedPower.AreEqual(5.0f), string.Format("Expected {0} Actual {1}", 5.0f, accumulator2.AccumulatedPower));
-
-            grid.Tick();
-            Assert.IsFalse(grid.IsOperating);
-            Assert.IsTrue(accumulator1.AccumulatedPower.AreEqual(0.0f), string.Format("Expected {0} Actual {1}", 0.0f, accumulator1.AccumulatedPower));
-            Assert.IsTrue(accumulator2.AccumulatedPower.AreEqual(5.0f), string.Format("Expected {0} Actual {1}", 5.0f, accumulator2.AccumulatedPower));
-        }
+        grid = new Grid();
+        Type powerGridType = typeof(Grid);
+        FieldInfo field = powerGridType.GetField("connections", BindingFlags.NonPublic | BindingFlags.Instance);
+        Assert.IsNotNull(field);
+        connections = field.GetValue(grid) as HashSet<Connection>;
+        Assert.IsNotNull(connections);
     }
+
+    [Test]
+    [ExpectedException(typeof(ArgumentNullException))]
+    public void PlugInArgumentNullException()
+    {
+        grid.PlugIn(null);
+    }
+
+    [Test]
+    public void PlugInTest()
+    {
+        grid.PlugIn(new Connection());
+        Assert.AreEqual(1, connections.Count);
+    }
+
+    [Test]
+    public void IsPluggedInTest()
+    {
+        Connection connection = new Connection();
+        grid.PlugIn(connection);
+        Assert.AreEqual(1, connections.Count);
+        Assert.IsTrue(grid.IsPluggedIn(connection));
+    }
+
+    [Test]
+    public void UnplugTest()
+    {
+        Connection connection = new Connection();
+        grid.PlugIn(connection);
+        Assert.AreEqual(1, connections.Count);
+        grid.Unplug(connection);
+        Assert.AreEqual(0, connections.Count);
+    }
+
+    [Test]
+    public void UpdateEnoughPowerTest()
+    {
+        Connection powerProducer = new Connection { OutputRate = 50.0f };
+        Connection firstPowerConsumer = new Connection { InputRate = 30.0f };
+        grid.PlugIn(powerProducer);
+        grid.PlugIn(firstPowerConsumer);
+        Assert.AreEqual(2, connections.Count);
+        grid.Tick();
+        Assert.IsTrue(grid.IsOperating);
+    }
+
+    [Test]
+    public void UpdateNotEnoughPowerTest()
+    {
+        Connection powerProducer = new Connection { OutputRate = 50.0f };
+        Connection firstPowerConsumer = new Connection { InputRate = 30.0f };
+        Connection secondPowerConsumer = new Connection { InputRate = 30.0f };
+        grid.PlugIn(powerProducer);
+        grid.PlugIn(firstPowerConsumer);
+        grid.PlugIn(secondPowerConsumer);
+        Assert.AreEqual(3, connections.Count);
+        grid.Tick();
+        Assert.IsFalse(grid.IsOperating);
+    }
+
+    [Test]
+    public void ChargeAccumulatorsTest()
+    {
+        Connection powerProducer = new Connection { OutputRate = 50.0f };
+        Connection firstPowerConsumer = new Connection { InputRate = 30.0f };
+        Connection accumulator = new Connection { InputRate = 10.0f, OutputRate = 10.0f, Capacity = 100.0f };
+        grid.PlugIn(powerProducer);
+        grid.PlugIn(firstPowerConsumer);
+        grid.PlugIn(accumulator);
+        Assert.AreEqual(3, connections.Count);
+        grid.Tick();
+        Assert.IsTrue(grid.IsOperating);
+        Assert.IsTrue(accumulator.AccumulatedPower.AreEqual(10.0f));
+        grid.Tick();
+        Assert.IsTrue(grid.IsOperating);
+        Assert.IsTrue(accumulator.AccumulatedPower.AreEqual(20.0f));
+        grid.Tick();
+        Assert.IsTrue(grid.IsOperating);
+        Assert.IsTrue(accumulator.AccumulatedPower.AreEqual(30.0f));
+    }
+
+    [Test]
+    public void DischargeAccumulatorsEnoughPowerTest()
+    {
+        Connection powerProducer = new Connection { OutputRate = 30.0f };
+        Connection firstPowerConsumer = new Connection { InputRate = 30.0f };
+        Connection firstAccumulator = new Connection { InputRate = 10.0f, OutputRate = 10.0f, Capacity = 100.0f };
+        Connection secondAccumulator = new Connection { InputRate = 10.0f, OutputRate = 10.0f, Capacity = 100.0f };
+        Connection thirdAccumulator = new Connection { InputRate = 10.0f, OutputRate = 10.0f, Capacity = 100.0f };
+        grid.PlugIn(powerProducer);
+        grid.PlugIn(firstAccumulator);
+        grid.PlugIn(secondAccumulator);
+        grid.PlugIn(thirdAccumulator);
+        Assert.AreEqual(4, connections.Count);
+
+        grid.Tick();
+        grid.Tick();
+        grid.Tick();
+        Assert.IsTrue(grid.IsOperating);
+        Assert.IsTrue(firstAccumulator.AccumulatedPower.AreEqual(30.0f));
+        Assert.IsTrue(secondAccumulator.AccumulatedPower.AreEqual(30.0f));
+        Assert.IsTrue(thirdAccumulator.AccumulatedPower.AreEqual(30.0f));
+
+        grid.PlugIn(firstPowerConsumer);
+        grid.Tick();
+        Assert.IsTrue(grid.IsOperating);
+        Assert.IsTrue(firstAccumulator.AccumulatedPower.AreEqual(30.0f));
+        Assert.IsTrue(secondAccumulator.AccumulatedPower.AreEqual(30.0f));
+        Assert.IsTrue(thirdAccumulator.AccumulatedPower.AreEqual(30.0f));
+
+        grid.Unplug(powerProducer);
+        grid.Tick();
+        Assert.IsTrue(grid.IsOperating);
+        Assert.IsTrue(firstAccumulator.AccumulatedPower.AreEqual(20.0f));
+        Assert.IsTrue(secondAccumulator.AccumulatedPower.AreEqual(20.0f));
+        Assert.IsTrue(thirdAccumulator.AccumulatedPower.AreEqual(20.0f));
+
+        grid.Tick();
+        grid.Tick();
+        Assert.IsTrue(grid.IsOperating);
+        Assert.IsTrue(firstAccumulator.IsEmpty);
+        Assert.IsTrue(secondAccumulator.IsEmpty);
+        Assert.IsTrue(thirdAccumulator.IsEmpty);
+
+        grid.Tick();
+        Assert.IsFalse(grid.IsOperating);
+    }
+
+    [Test]
+    public void DischargeAccumulatorsNotEnoughPowerTest()
+    {
+        Connection powerProducer = new Connection { OutputRate = 30.0f };
+        Connection firstPowerConsumer = new Connection { InputRate = 30.0f };
+        Connection firstAccumulator = new Connection { InputRate = 10.0f, OutputRate = 10.0f, Capacity = 100.0f };
+        Connection secondAccumulator = new Connection { InputRate = 10.0f, OutputRate = 10.0f, Capacity = 100.0f };
+        grid.PlugIn(powerProducer);
+        grid.PlugIn(firstAccumulator);
+        grid.PlugIn(secondAccumulator);
+        Assert.AreEqual(3, connections.Count);
+
+        grid.Tick();
+        grid.Tick();
+        grid.Tick();
+        Assert.IsTrue(grid.IsOperating);
+        Assert.IsTrue(firstAccumulator.AccumulatedPower.AreEqual(30.0f));
+        Assert.IsTrue(secondAccumulator.AccumulatedPower.AreEqual(30.0f));
+
+        grid.PlugIn(firstPowerConsumer);
+        grid.Tick();
+        Assert.IsTrue(grid.IsOperating);
+        Assert.IsTrue(firstAccumulator.AccumulatedPower.AreEqual(30.0f));
+        Assert.IsTrue(secondAccumulator.AccumulatedPower.AreEqual(30.0f));
+
+        grid.Unplug(powerProducer);
+        grid.Tick();
+        Assert.IsFalse(grid.IsOperating);
+        Assert.IsTrue(firstAccumulator.AccumulatedPower.AreEqual(30.0f));
+        Assert.IsTrue(secondAccumulator.AccumulatedPower.AreEqual(30.0f));
+    }
+
+    [Test]
+    public void ChargeAccumulatorsCapacityTest()
+    {
+        Connection powerProducer = new Connection { OutputRate = 20.0f };
+        Connection accumulator = new Connection { InputRate = 15.0f, OutputRate = 10.0f, Capacity = 40.0f };
+        grid.PlugIn(powerProducer);
+        grid.PlugIn(accumulator);
+        Assert.AreEqual(2, connections.Count);
+        grid.Tick();
+        Assert.IsTrue(grid.IsOperating);
+        Assert.IsTrue(accumulator.AccumulatedPower.AreEqual(15.0f));
+        grid.Tick();
+        Assert.IsTrue(grid.IsOperating);
+        Assert.IsTrue(accumulator.AccumulatedPower.AreEqual(30.0f));
+        grid.Tick();
+        Assert.IsTrue(grid.IsOperating);
+        Assert.IsTrue(accumulator.AccumulatedPower.AreEqual(40.0f));
+        grid.Tick();
+        Assert.IsTrue(grid.IsOperating);
+        Assert.IsTrue(accumulator.AccumulatedPower.AreEqual(40.0f));
+    }
+
+    [Test]
+    public void DischargeAccumulatorsCapacityTest()
+    {
+        Connection powerConsumer = new Connection { InputRate = 4.0f };
+        Connection accumulator = new Connection { InputRate = 10.0f, OutputRate = 10.0f, Capacity = 100.0f, AccumulatedPower = 15.0f };
+        grid.PlugIn(powerConsumer);
+        grid.PlugIn(accumulator);
+        Assert.AreEqual(2, connections.Count);
+
+        grid.Tick();
+        Assert.IsTrue(grid.IsOperating);
+        Assert.IsTrue(accumulator.AccumulatedPower.AreEqual(11.0f));
+
+        grid.Tick();
+        Assert.IsTrue(grid.IsOperating);
+        Assert.IsTrue(accumulator.AccumulatedPower.AreEqual(7.0f));
+
+        grid.Tick();
+        Assert.IsTrue(grid.IsOperating);
+        Assert.IsTrue(accumulator.AccumulatedPower.AreEqual(3.0f));
+
+        grid.Tick();
+        Assert.IsFalse(grid.IsOperating);
+        Assert.IsTrue(accumulator.AccumulatedPower.AreEqual(3.0f));
+    }
+
+    [Test]
+    public void ChargeAccumulatorsInputRateTest()
+    {
+        Connection powerProducer = new Connection { OutputRate = 20.0f };
+        Connection accumulator1 = new Connection { InputRate = 15.0f, OutputRate = 10.0f, Capacity = 40.0f };
+        Connection accumulator2 = new Connection { InputRate = 15.0f, OutputRate = 10.0f, Capacity = 40.0f };
+        grid.PlugIn(powerProducer);
+        grid.PlugIn(accumulator1);
+        grid.PlugIn(accumulator2);
+        Assert.AreEqual(3, connections.Count);
+        grid.Tick();
+        Assert.IsTrue(grid.IsOperating);
+        Assert.IsTrue(accumulator1.AccumulatedPower.AreEqual(15.0f), string.Format("Expected {0} Actual {1}", 15.0f, accumulator1.AccumulatedPower));
+        Assert.IsTrue(accumulator2.AccumulatedPower.AreEqual(5.0f), string.Format("Expected {0} Actual {1}", 5.0f, accumulator2.AccumulatedPower));
+
+        grid.Tick();
+        Assert.IsTrue(grid.IsOperating);
+        Assert.IsTrue(accumulator1.AccumulatedPower.AreEqual(30.0f), string.Format("Expected {0} Actual {1}", 30.0f, accumulator1.AccumulatedPower));
+        Assert.IsTrue(accumulator2.AccumulatedPower.AreEqual(10.0f), string.Format("Expected {0} Actual {1}", 10.0f, accumulator2.AccumulatedPower));
+
+        grid.Tick();
+        Assert.IsTrue(grid.IsOperating);
+        Assert.IsTrue(accumulator1.AccumulatedPower.AreEqual(40.0f), string.Format("Expected {0} Actual {1}", 40.0f, accumulator1.AccumulatedPower));
+        Assert.IsTrue(accumulator2.AccumulatedPower.AreEqual(20.0f), string.Format("Expected {0} Actual {1}", 20.0f, accumulator2.AccumulatedPower));
+
+        grid.Tick();
+        Assert.IsTrue(grid.IsOperating);
+        Assert.IsTrue(accumulator1.AccumulatedPower.AreEqual(40.0f), string.Format("Expected {0} Actual {1}", 40.0f, accumulator1.AccumulatedPower));
+        Assert.IsTrue(accumulator2.AccumulatedPower.AreEqual(35.0f), string.Format("Expected {0} Actual {1}", 35.0f, accumulator2.AccumulatedPower));
+    }
+
+    [Test]
+    public void DischargeAccumulatorsOutputRateTest()
+    {
+        Connection powerConsumer1 = new Connection { InputRate = 5.0f };
+        Connection powerConsumer2 = new Connection { InputRate = 5.0f };
+        Connection powerConsumer3 = new Connection { InputRate = 5.0f };
+        Connection accumulator1 = new Connection { InputRate = 10.0f, OutputRate = 10.0f, Capacity = 100.0f, AccumulatedPower = 10.0f };
+        Connection accumulator2 = new Connection { InputRate = 10.0f, OutputRate = 10.0f, Capacity = 100.0f, AccumulatedPower = 10.0f };
+        grid.PlugIn(powerConsumer1);
+        grid.PlugIn(powerConsumer2);
+        grid.PlugIn(powerConsumer3);
+        grid.PlugIn(accumulator1);
+        grid.PlugIn(accumulator2);
+        Assert.AreEqual(5, connections.Count);
+
+        grid.Tick();
+        Assert.IsTrue(grid.IsOperating);
+        Assert.IsTrue(accumulator1.AccumulatedPower.AreEqual(0.0f), string.Format("Expected {0} Actual {1}", 0.0f, accumulator1.AccumulatedPower));
+        Assert.IsTrue(accumulator2.AccumulatedPower.AreEqual(5.0f), string.Format("Expected {0} Actual {1}", 5.0f, accumulator2.AccumulatedPower));
+
+        grid.Tick();
+        Assert.IsFalse(grid.IsOperating);
+        Assert.IsTrue(accumulator1.AccumulatedPower.AreEqual(0.0f), string.Format("Expected {0} Actual {1}", 0.0f, accumulator1.AccumulatedPower));
+        Assert.IsTrue(accumulator2.AccumulatedPower.AreEqual(5.0f), string.Format("Expected {0} Actual {1}", 5.0f, accumulator2.AccumulatedPower));
+    }
+}

--- a/Assets/Editor/UnitTests/Models/Power/PowerGridTest.cs
+++ b/Assets/Editor/UnitTests/Models/Power/PowerGridTest.cs
@@ -10,9 +10,9 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 using NUnit.Framework;
+using ProjectPorcupine.PowerNetwork;
 
-namespace ProjectPorcupine.PowerNetwork.Test
-{
+
     public class PowerGridTest
     {
         private Grid grid;
@@ -293,4 +293,3 @@ namespace ProjectPorcupine.PowerNetwork.Test
             Assert.IsTrue(accumulator2.AccumulatedPower.AreEqual(5.0f), string.Format("Expected {0} Actual {1}", 5.0f, accumulator2.AccumulatedPower));
         }
     }
-}

--- a/Assets/Editor/UnitTests/Models/Power/PowerNetworkTest.cs
+++ b/Assets/Editor/UnitTests/Models/Power/PowerNetworkTest.cs
@@ -1,4 +1,4 @@
-﻿#region License
+#region License
 // ====================================================
 // Project Porcupine Copyright(C) 2016 Team Porcupine
 // This program comes with ABSOLUTELY NO WARRANTY; This is free software, 
@@ -13,114 +13,114 @@ using NUnit.Framework;
 using ProjectPorcupine.PowerNetwork;
 
 
-    public class PowerNetworkTest
+public class PowerNetworkTest
+{
+    private PowerNetwork powerNetwork;
+    private HashSet<Grid> powerGrids;
+
+    [SetUp]
+    public void Init()
     {
-        private PowerNetwork powerNetwork;
-        private HashSet<Grid> powerGrids;
-
-        [SetUp]
-        public void Init()
-        {
-            powerNetwork = new PowerNetwork();
-            Type livePowerSystemType = typeof(PowerNetwork);
-            FieldInfo field = livePowerSystemType.GetField("powerGrids", BindingFlags.NonPublic | BindingFlags.Instance);
-            Assert.IsNotNull(field);
-            powerGrids = field.GetValue(powerNetwork) as HashSet<Grid>;
-            Assert.IsNotNull(powerGrids);
-            Assert.AreEqual(0, powerGrids.Count);
-        }
-
-        [Test]
-        [ExpectedException(typeof(ArgumentNullException))]
-        public void PlugInArgumentNullException()
-        {
-            powerNetwork.PlugIn(null);
-        }
-
-        [Test]
-        public void PlugInTest()
-        {
-            Assert.IsTrue(powerNetwork.PlugIn(new Connection()));
-            Assert.AreEqual(1, powerGrids.Count);
-        }
-
-        [Test]
-        public void IsPluggedInTest()
-        {
-            Connection connection = new Connection();
-            Assert.IsTrue(powerNetwork.PlugIn(connection));
-            Assert.AreEqual(1, powerGrids.Count);
-            Grid grid;
-            Assert.IsTrue(powerNetwork.IsPluggedIn(connection, out grid));
-            Assert.IsNotNull(grid);
-        }
-
-        [Test]
-        public void UnplugTest()
-        {
-            Connection connection = new Connection();
-            Assert.IsTrue(powerNetwork.PlugIn(connection));
-            Assert.AreEqual(1, powerGrids.Count);
-            powerNetwork.Unplug(connection);
-            Assert.AreEqual(1, powerGrids.Count);
-
-            powerNetwork.Update(1.0f);
-            Assert.AreEqual(0, powerGrids.Count);
-        }
-
-        [Test]
-        public void UpdateEnoughPowerTest()
-        {
-            Connection powerProducer = new Connection { OutputRate = 50.0f };
-            Connection firstPowerConsumer = new Connection { InputRate = 30.0f };
-            powerNetwork.PlugIn(powerProducer);
-            powerNetwork.PlugIn(firstPowerConsumer);
-            Assert.AreEqual(1, powerGrids.Count);
-
-            powerNetwork.Update(1.0f);
-            Assert.IsTrue(powerNetwork.HasPower(powerProducer));
-            Assert.IsTrue(powerNetwork.HasPower(firstPowerConsumer));
-        }
-
-        [Test]
-        public void UpdateNotEnoughPowerTest()
-        {
-            Connection powerProducer = new Connection { OutputRate = 50.0f };
-            Connection firstPowerConsumer = new Connection { InputRate = 30.0f };
-            Connection secondPowerConsumer = new Connection { InputRate = 30.0f };
-            powerNetwork.PlugIn(powerProducer);
-            powerNetwork.PlugIn(firstPowerConsumer);
-            powerNetwork.PlugIn(secondPowerConsumer);
-            Assert.AreEqual(1, powerGrids.Count);
-
-            powerNetwork.Update(1.0f);
-            Assert.IsFalse(powerNetwork.HasPower(powerProducer));
-            Assert.IsFalse(powerNetwork.HasPower(firstPowerConsumer));
-            Assert.IsFalse(powerNetwork.HasPower(secondPowerConsumer));
-        }
-
-        [Test]
-        public void UpdateIntervalTest()
-        {
-            Connection powerProducer = new Connection { OutputRate = 50.0f };
-            Connection firstPowerConsumer = new Connection { InputRate = 30.0f };
-            powerNetwork.PlugIn(powerProducer);
-            powerNetwork.PlugIn(firstPowerConsumer);
-            Assert.AreEqual(1, powerGrids.Count);
-
-            powerNetwork.Update(0.2f);
-            Assert.IsFalse(powerNetwork.HasPower(powerProducer));
-            Assert.IsFalse(powerNetwork.HasPower(firstPowerConsumer));
-
-            powerNetwork.Update(0.2f);
-            Assert.IsFalse(powerNetwork.HasPower(powerProducer));
-            Assert.IsFalse(powerNetwork.HasPower(firstPowerConsumer));
-
-            powerNetwork.Update(0.2f);
-            powerNetwork.Update(0.2f);
-            powerNetwork.Update(0.2f);
-            Assert.IsTrue(powerNetwork.HasPower(powerProducer));
-            Assert.IsTrue(powerNetwork.HasPower(firstPowerConsumer));
-        }
+        powerNetwork = new PowerNetwork();
+        Type livePowerSystemType = typeof(PowerNetwork);
+        FieldInfo field = livePowerSystemType.GetField("powerGrids", BindingFlags.NonPublic | BindingFlags.Instance);
+        Assert.IsNotNull(field);
+        powerGrids = field.GetValue(powerNetwork) as HashSet<Grid>;
+        Assert.IsNotNull(powerGrids);
+        Assert.AreEqual(0, powerGrids.Count);
     }
+
+    [Test]
+    [ExpectedException(typeof(ArgumentNullException))]
+    public void PlugInArgumentNullException()
+    {
+        powerNetwork.PlugIn(null);
+    }
+
+    [Test]
+    public void PlugInTest()
+    {
+        Assert.IsTrue(powerNetwork.PlugIn(new Connection()));
+        Assert.AreEqual(1, powerGrids.Count);
+    }
+
+    [Test]
+    public void IsPluggedInTest()
+    {
+        Connection connection = new Connection();
+        Assert.IsTrue(powerNetwork.PlugIn(connection));
+        Assert.AreEqual(1, powerGrids.Count);
+        Grid grid;
+        Assert.IsTrue(powerNetwork.IsPluggedIn(connection, out grid));
+        Assert.IsNotNull(grid);
+    }
+
+    [Test]
+    public void UnplugTest()
+    {
+        Connection connection = new Connection();
+        Assert.IsTrue(powerNetwork.PlugIn(connection));
+        Assert.AreEqual(1, powerGrids.Count);
+        powerNetwork.Unplug(connection);
+        Assert.AreEqual(1, powerGrids.Count);
+
+        powerNetwork.Update(1.0f);
+        Assert.AreEqual(0, powerGrids.Count);
+    }
+
+    [Test]
+    public void UpdateEnoughPowerTest()
+    {
+        Connection powerProducer = new Connection { OutputRate = 50.0f };
+        Connection firstPowerConsumer = new Connection { InputRate = 30.0f };
+        powerNetwork.PlugIn(powerProducer);
+        powerNetwork.PlugIn(firstPowerConsumer);
+        Assert.AreEqual(1, powerGrids.Count);
+
+        powerNetwork.Update(1.0f);
+        Assert.IsTrue(powerNetwork.HasPower(powerProducer));
+        Assert.IsTrue(powerNetwork.HasPower(firstPowerConsumer));
+    }
+
+    [Test]
+    public void UpdateNotEnoughPowerTest()
+    {
+        Connection powerProducer = new Connection { OutputRate = 50.0f };
+        Connection firstPowerConsumer = new Connection { InputRate = 30.0f };
+        Connection secondPowerConsumer = new Connection { InputRate = 30.0f };
+        powerNetwork.PlugIn(powerProducer);
+        powerNetwork.PlugIn(firstPowerConsumer);
+        powerNetwork.PlugIn(secondPowerConsumer);
+        Assert.AreEqual(1, powerGrids.Count);
+
+        powerNetwork.Update(1.0f);
+        Assert.IsFalse(powerNetwork.HasPower(powerProducer));
+        Assert.IsFalse(powerNetwork.HasPower(firstPowerConsumer));
+        Assert.IsFalse(powerNetwork.HasPower(secondPowerConsumer));
+    }
+
+    [Test]
+    public void UpdateIntervalTest()
+    {
+        Connection powerProducer = new Connection { OutputRate = 50.0f };
+        Connection firstPowerConsumer = new Connection { InputRate = 30.0f };
+        powerNetwork.PlugIn(powerProducer);
+        powerNetwork.PlugIn(firstPowerConsumer);
+        Assert.AreEqual(1, powerGrids.Count);
+
+        powerNetwork.Update(0.2f);
+        Assert.IsFalse(powerNetwork.HasPower(powerProducer));
+        Assert.IsFalse(powerNetwork.HasPower(firstPowerConsumer));
+
+        powerNetwork.Update(0.2f);
+        Assert.IsFalse(powerNetwork.HasPower(powerProducer));
+        Assert.IsFalse(powerNetwork.HasPower(firstPowerConsumer));
+
+        powerNetwork.Update(0.2f);
+        powerNetwork.Update(0.2f);
+        powerNetwork.Update(0.2f);
+        Assert.IsTrue(powerNetwork.HasPower(powerProducer));
+        Assert.IsTrue(powerNetwork.HasPower(firstPowerConsumer));
+    }
+}
 

--- a/Assets/Editor/UnitTests/Models/Power/PowerNetworkTest.cs
+++ b/Assets/Editor/UnitTests/Models/Power/PowerNetworkTest.cs
@@ -12,7 +12,6 @@ using System.Reflection;
 using NUnit.Framework;
 using ProjectPorcupine.PowerNetwork;
 
-
 public class PowerNetworkTest
 {
     private PowerNetwork powerNetwork;
@@ -123,4 +122,3 @@ public class PowerNetworkTest
         Assert.IsTrue(powerNetwork.HasPower(firstPowerConsumer));
     }
 }
-

--- a/Assets/Editor/UnitTests/Models/Power/PowerNetworkTest.cs
+++ b/Assets/Editor/UnitTests/Models/Power/PowerNetworkTest.cs
@@ -10,9 +10,9 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 using NUnit.Framework;
+using ProjectPorcupine.PowerNetwork;
 
-namespace ProjectPorcupine.PowerNetwork.Test
-{
+
     public class PowerNetworkTest
     {
         private PowerNetwork powerNetwork;
@@ -123,4 +123,4 @@ namespace ProjectPorcupine.PowerNetwork.Test
             Assert.IsTrue(powerNetwork.HasPower(firstPowerConsumer));
         }
     }
-}
+


### PR DESCRIPTION
When unit tests have namespaces the unity editor gets ..weird
![tests](https://cloud.githubusercontent.com/assets/7608114/18257307/4fc666fc-738f-11e6-8c99-590b5c8fcd2b.gif)

This removes the namespaces in the power unit tests.
![after](https://cloud.githubusercontent.com/assets/7608114/18257303/4575c288-738f-11e6-8bdf-992e7314460a.PNG)
^ much better :)

unfortunately, most of the changes git notices are fixing indentation, only 4 lines were actually modified

