### PR TITLE
Removed redundant HasPower() call in Lua

### DIFF
--- a/Assets/StreamingAssets/LUA/Furniture.lua
+++ b/Assets/StreamingAssets/LUA/Furniture.lua
@@ -565,9 +565,6 @@ function Heater_UninstallAction( furniture, deltaTime)
 end
 
 function Heater_UpdateTemperature( furniture, deltaTime)
-    if (furniture.HasPower() == false) then
-        return
-    end
     if (furniture.tile.Room.IsOutsideRoom() == true) then
         return
     end


### PR DESCRIPTION
`Furniture.cs` already has this check in `Update()`it before it calls the Lua `OnUpdate`