### PR TITLE
Fixes #1161 - Jobtime reset after powerloss

### DIFF
--- a/Assets/Scripts/Models/Furniture.cs
+++ b/Assets/Scripts/Models/Furniture.cs
@@ -58,6 +58,8 @@ public class Furniture : IXmlSerializable, ISelectable, IContextActionProvider
 
     private List<Job> jobs;
 
+    private List<Job> jobsQueued;
+
     // This is the generic type of object this is, allowing things to interact with it based on it's generic type
     private HashSet<string> typeTags;
 
@@ -111,6 +113,7 @@ public class Furniture : IXmlSerializable, ISelectable, IContextActionProvider
 
         furnParameters = new Parameter(other.furnParameters);
         jobs = new List<Job>();
+        jobsQueued = new List<Job>();
 
         if (other.EventActions != null)
         {
@@ -343,10 +346,15 @@ public class Furniture : IXmlSerializable, ISelectable, IContextActionProvider
         {
             if (JobCount() > 0)
             {
-                CancelJobs();
+                DequeueJobs();
             }
 
             return;
+        }
+
+        if (jobsQueued.Count > 0)
+        {
+            EnqueueJobs();
         }
 
         // TODO: some weird thing happens
@@ -609,6 +617,26 @@ public class Furniture : IXmlSerializable, ISelectable, IContextActionProvider
         Job[] jobsArray = jobs.ToArray();
         foreach (Job job in jobsArray)
         {
+            job.CancelJob();
+        }
+    }
+
+    public void EnqueueJobs()
+    {
+        Job[] jobsArray = jobsQueued.ToArray();
+        foreach (Job job in jobsArray)
+        {
+            AddJob(job);
+            jobsQueued.Remove(job);
+        }
+    }
+
+    public void DequeueJobs()
+    {
+        Job[] jobsArray = jobs.ToArray();
+        foreach (Job job in jobsArray)
+        {
+            jobsQueued.Add(job);
             job.CancelJob();
         }
     }

--- a/Assets/Scripts/Models/Furniture.cs
+++ b/Assets/Scripts/Models/Furniture.cs
@@ -58,7 +58,7 @@ public class Furniture : IXmlSerializable, ISelectable, IContextActionProvider
 
     private List<Job> jobs;
 
-    private List<Job> jobsQueued;
+    private List<Job> pausedJobs;
 
     // This is the generic type of object this is, allowing things to interact with it based on it's generic type
     private HashSet<string> typeTags;
@@ -113,7 +113,7 @@ public class Furniture : IXmlSerializable, ISelectable, IContextActionProvider
 
         furnParameters = new Parameter(other.furnParameters);
         jobs = new List<Job>();
-        jobsQueued = new List<Job>();
+        pausedJobs = new List<Job>();
 
         if (other.EventActions != null)
         {
@@ -346,15 +346,15 @@ public class Furniture : IXmlSerializable, ISelectable, IContextActionProvider
         {
             if (JobCount() > 0)
             {
-                DequeueJobs();
+                PauseJobs();
             }
 
             return;
         }
 
-        if (jobsQueued.Count > 0)
+        if (pausedJobs.Count > 0)
         {
-            EnqueueJobs();
+            ResumeJobs();
         }
 
         // TODO: some weird thing happens
@@ -621,22 +621,22 @@ public class Furniture : IXmlSerializable, ISelectable, IContextActionProvider
         }
     }
 
-    public void EnqueueJobs()
+    public void ResumeJobs()
     {
-        Job[] jobsArray = jobsQueued.ToArray();
+        Job[] jobsArray = pausedJobs.ToArray();
         foreach (Job job in jobsArray)
         {
             AddJob(job);
-            jobsQueued.Remove(job);
+            pausedJobs.Remove(job);
         }
     }
 
-    public void DequeueJobs()
+    public void PauseJobs()
     {
         Job[] jobsArray = jobs.ToArray();
         foreach (Job job in jobsArray)
         {
-            jobsQueued.Add(job);
+            pausedJobs.Add(job);
             job.CancelJob();
         }
     }

--- a/Assets/Scripts/Models/Furniture.cs
+++ b/Assets/Scripts/Models/Furniture.cs
@@ -621,6 +621,7 @@ public class Furniture : IXmlSerializable, ISelectable, IContextActionProvider
         }
     }
 
+    /// TODO: Refactor this when the new job system is implemented
     public void ResumeJobs()
     {
         Job[] jobsArray = pausedJobs.ToArray();
@@ -631,6 +632,7 @@ public class Furniture : IXmlSerializable, ISelectable, IContextActionProvider
         }
     }
 
+    /// TODO: Refactor this when the new job system is implemented
     public void PauseJobs()
     {
         Job[] jobsArray = jobs.ToArray();


### PR DESCRIPTION
Fixes #1161

When power is lost the jobsTimes would reset because the jobs were canceled. This new method takes the current jobs running and stores them in a new List until the power is restored then the jobs are added back to the normal job queue with any current work done to them saved. 