### PR TITLE
Build Menu - Non-buildable furniture

### DIFF
--- a/Assets/Scripts/UI/FurnitureBuildMenu.cs
+++ b/Assets/Scripts/UI/FurnitureBuildMenu.cs
@@ -24,31 +24,36 @@ public class FurnitureBuildMenu : MonoBehaviour
 
         // For each furniture prototype in our world, create one instance
         // of the button to be clicked!
-        foreach (string s in PrototypeManager.Furniture.Keys)
+        foreach (string furnitureKey in PrototypeManager.Furniture.Keys)
         {
-            GameObject go = (GameObject)Instantiate(buildFurnitureButtonPrefab);
-            go.transform.SetParent(this.transform);
+            if (PrototypeManager.Furniture.Get(furnitureKey).HasTypeTag("Non-buildable"))
+            {
+                continue;
+            }
 
-            Furniture proto = PrototypeManager.Furniture.Get(s);
-            string objectId = s;
+            GameObject gameObject = (GameObject)Instantiate(buildFurnitureButtonPrefab);
+            gameObject.transform.SetParent(this.transform);
 
-            go.name = "Button - Build " + objectId;
+            Furniture proto = PrototypeManager.Furniture.Get(furnitureKey);
+            string objectId = furnitureKey;
 
-            go.transform.GetComponentInChildren<TextLocalizer>().formatValues = new string[] { LocalizationTable.GetLocalization(proto.LocalizationCode) };
+            gameObject.name = "Button - Build " + objectId;
 
-            Button b = go.GetComponent<Button>();
+            gameObject.transform.GetComponentInChildren<TextLocalizer>().formatValues = new string[] { LocalizationTable.GetLocalization(proto.LocalizationCode) };
 
-            b.onClick.AddListener(delegate
+            Button button = gameObject.GetComponent<Button>();
+
+            button.onClick.AddListener(delegate
                 {
                     bmc.SetMode_BuildFurniture(objectId);
                     this.gameObject.SetActive(false);
                 });
 
             // http://stackoverflow.com/questions/1757112/anonymous-c-sharp-delegate-within-a-loop
-            string furn = s;
+            string furniture = furnitureKey;
             LocalizationTable.CBLocalizationFilesChanged += delegate
             {
-                go.transform.GetComponentInChildren<TextLocalizer>().formatValues = new string[] { LocalizationTable.GetLocalization(PrototypeManager.Furniture.Get(furn).LocalizationCode) };
+                gameObject.transform.GetComponentInChildren<TextLocalizer>().formatValues = new string[] { LocalizationTable.GetLocalization(PrototypeManager.Furniture.Get(furniture).LocalizationCode) };
             };
         }
 

--- a/Assets/StreamingAssets/Data/Furniture.xml
+++ b/Assets/StreamingAssets/Data/Furniture.xml
@@ -471,6 +471,7 @@
     <Description>A spot for mining ore</Description>
     <TypeTag>Ore</TypeTag>
     <TypeTag>OutdoorOnly</TypeTag>
+    <TypeTag>Non-buildable</TypeTag>
     <MovementCost>2</MovementCost>
     <PathfindingModifier>1.5</PathfindingModifier>
     <PathfindingWeight>2</PathfindingWeight>


### PR DESCRIPTION
This adds the ability to tag furniture with a `TypeTag` that stops it from showing up in the build menu, which checks before generating a button and moves on to the next furniture if it has the tag.

Currently this is only implemented on the mining points so that the player cannot build them, but will likely be used for most furniture objects created during world gen such as asteroid walls.

For the moment the tag is `Non-buildable` but I am not sure this is ideal and I am open to better suggestions.

I have also redone a bunch of names in the `FurnitureBuildMenu` to hopefully meet standards and to pre-empt any suggestions that they be changed to something else. Please point out if its to much or not correct so I know for the future. :+1: 