### PR TITLE
HeadlineController popup disabled when not visible

### DIFF
--- a/Assets/Scripts/UI/HeadlineController.cs
+++ b/Assets/Scripts/UI/HeadlineController.cs
@@ -20,10 +20,17 @@ public class HeadlineController : MonoBehaviour
     public float dismissTime = 10;
 
     private ScheduledEvent scheduledEvent;
+    private CanvasGroup canvasGroup;
 
     public void Dismiss()
     {
-        GetComponent<CanvasGroup>().alpha = 0;
+        canvasGroup.alpha = 0;
+        canvasGroup.interactable = false;
+    }
+
+    private void Awake()
+    {
+        canvasGroup = GetComponent<CanvasGroup>();
     }
 
     private void Start()
@@ -40,7 +47,9 @@ public class HeadlineController : MonoBehaviour
 
     private void UpdateHeadline(string newHeadline)
     {
-        GetComponent<CanvasGroup>().alpha = 1;
+        canvasGroup.alpha = 1;
+        canvasGroup.interactable = true;
+
         Debug.ULogChannel("Headline", newHeadline);
         textBox.text = newHeadline;
 

--- a/Assets/Scripts/UI/HeadlineController.cs
+++ b/Assets/Scripts/UI/HeadlineController.cs
@@ -26,6 +26,7 @@ public class HeadlineController : MonoBehaviour
     {
         canvasGroup.alpha = 0;
         canvasGroup.interactable = false;
+        canvasGroup.blocksRaycasts = false;
     }
 
     private void Awake()
@@ -49,6 +50,7 @@ public class HeadlineController : MonoBehaviour
     {
         canvasGroup.alpha = 1;
         canvasGroup.interactable = true;
+        canvasGroup.blocksRaycasts = true;
 
         Debug.ULogChannel("Headline", newHeadline);
         textBox.text = newHeadline;


### PR DESCRIPTION
This will prevent button clicks from being processed when the dialog is invisible.  Fix #1171 