### PR TITLE
Headline now fits the text vertically

### DIFF
--- a/Assets/Resources/UI/Headlines.prefab
+++ b/Assets/Resources/UI/Headlines.prefab
@@ -25,6 +25,7 @@ GameObject:
   - 114: {fileID: 114000012257015470}
   - 114: {fileID: 114000010675520848}
   - 225: {fileID: 225000013836945596}
+  - 114: {fileID: 114000013523801554}
   m_Layer: 5
   m_Name: Headlines
   m_TagString: Untagged
@@ -61,6 +62,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   textBox: {fileID: 114000013664433878}
+  dismissTime: 10
 --- !u!114 &114000010675520848
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -160,6 +162,19 @@ MonoBehaviour:
   m_FillAmount: 1
   m_FillClockwise: 1
   m_FillOrigin: 0
+--- !u!114 &114000013523801554
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000010673285602}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1741964061, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_HorizontalFit: 0
+  m_VerticalFit: 2
 --- !u!114 &114000013664433878
 MonoBehaviour:
   m_ObjectHideFlags: 1


### PR DESCRIPTION
Fixes #1174 This will limit the display box for the headline to what is visible.

![capture](https://cloud.githubusercontent.com/assets/5951269/18278343/b7b1db8a-741f-11e6-9e75-41cabb8ba134.PNG)
