### PR TITLE
Fixes bug on load Headlines

### DIFF
--- a/Assets/Scripts/UI/HeadlineController.cs
+++ b/Assets/Scripts/UI/HeadlineController.cs
@@ -24,6 +24,10 @@ public class HeadlineController : MonoBehaviour
 
     public void Dismiss()
     {
+        if (canvasGroup==null)
+        {
+            return;
+        }
         canvasGroup.alpha = 0;
         canvasGroup.interactable = false;
         canvasGroup.blocksRaycasts = false;


### PR DESCRIPTION
Headline scheduling events can get saved, and re-used, even though the UI element is gone. For the time being, checking to see if this appears to be one of those cases, and does nothing to prevent a crash. Fixes #1175 