### PR TITLE
Rework of FurnitureBuildMenu

### DIFF
--- a/Assets/Scripts/UI/DialogBox/Settings/DialogBoxSettings.cs
+++ b/Assets/Scripts/UI/DialogBox/Settings/DialogBoxSettings.cs
@@ -90,6 +90,7 @@ public class DialogBoxSettings : DialogBox
     {
         this.CloseDialog();
         WorldController.Instance.spawnInventoryController.SetUIVisibility(developerModeToggle.isOn);
+        FurnitureBuildMenu.instance.RebuildMenuButtons(developerModeToggle.isOn);
         SaveSetting();
     }
 

--- a/Assets/Scripts/UI/FurnitureBuildMenu.cs
+++ b/Assets/Scripts/UI/FurnitureBuildMenu.cs
@@ -6,58 +6,37 @@
 // file LICENSE, which is part of this source code package, for details.
 // ====================================================
 #endregion
-using System.Linq;
+using System.Collections.Generic;
 using ProjectPorcupine.Localization;
 using UnityEngine;
 using UnityEngine.UI;
 
 public class FurnitureBuildMenu : MonoBehaviour
 {
+    public static FurnitureBuildMenu instance;
     public GameObject buildFurnitureButtonPrefab;
 
+    private List<GameObject> buildMenu;
     private string lastLanguage;
+    private bool showAllFurniture;
 
-    // Use this for initialization
-    private void Start()
+    public void RebuildMenuButtons(bool showAllFurniture)
     {
-        BuildModeController bmc = WorldController.Instance.buildModeController;
-
-        // For each furniture prototype in our world, create one instance
-        // of the button to be clicked!
-        foreach (string furnitureKey in PrototypeManager.Furniture.Keys)
+        foreach (GameObject gameObject in buildMenu)
         {
-            if (PrototypeManager.Furniture.Get(furnitureKey).HasTypeTag("Non-buildable"))
-            {
-                continue;
-            }
-
-            GameObject gameObject = (GameObject)Instantiate(buildFurnitureButtonPrefab);
-            gameObject.transform.SetParent(this.transform);
-
-            Furniture proto = PrototypeManager.Furniture.Get(furnitureKey);
-            string objectId = furnitureKey;
-
-            gameObject.name = "Button - Build " + objectId;
-
-            gameObject.transform.GetComponentInChildren<TextLocalizer>().formatValues = new string[] { LocalizationTable.GetLocalization(proto.LocalizationCode) };
-
-            Button button = gameObject.GetComponent<Button>();
-
-            button.onClick.AddListener(delegate
-                {
-                    bmc.SetMode_BuildFurniture(objectId);
-                    this.gameObject.SetActive(false);
-                });
-
-            // http://stackoverflow.com/questions/1757112/anonymous-c-sharp-delegate-within-a-loop
-            string furniture = furnitureKey;
-            LocalizationTable.CBLocalizationFilesChanged += delegate
-            {
-                gameObject.transform.GetComponentInChildren<TextLocalizer>().formatValues = new string[] { LocalizationTable.GetLocalization(PrototypeManager.Furniture.Get(furniture).LocalizationCode) };
-            };
+            Destroy(gameObject);
         }
 
-        lastLanguage = LocalizationTable.currentLanguage;
+        this.showAllFurniture = showAllFurniture;
+
+        GenerateMenuButtons();
+    }
+
+    private void Start()
+    {
+        instance = this;
+        showAllFurniture = Settings.GetSetting("DialogBoxSettings_developerModeToggle", false);
+        GenerateMenuButtons();        
     }
 
     private void Update()
@@ -73,5 +52,50 @@ public class FurnitureBuildMenu : MonoBehaviour
                 localizers[i].UpdateText(LocalizationTable.GetLocalization(PrototypeManager.Furniture.Get(i).GetName()));
             }
         }
+    }
+
+    private void GenerateMenuButtons()
+    {
+        BuildModeController bmc = WorldController.Instance.buildModeController;
+
+        buildMenu = new List<GameObject>();
+
+        // For each furniture prototype in our world, create one instance
+        // of the button to be clicked!
+        foreach (string furnitureKey in PrototypeManager.Furniture.Keys)
+        {
+            if (PrototypeManager.Furniture.Get(furnitureKey).HasTypeTag("Non-buildable") && showAllFurniture == false)
+            {
+                continue;
+            }
+
+            GameObject gameObject = (GameObject)Instantiate(buildFurnitureButtonPrefab);
+            gameObject.transform.SetParent(this.transform);
+            buildMenu.Add(gameObject);
+
+            Furniture proto = PrototypeManager.Furniture.Get(furnitureKey);
+            string objectId = furnitureKey;
+
+            gameObject.name = "Button - Build " + objectId;
+
+            gameObject.transform.GetComponentInChildren<TextLocalizer>().formatValues = new string[] { LocalizationTable.GetLocalization(proto.LocalizationCode) };
+
+            Button button = gameObject.GetComponent<Button>();
+
+            button.onClick.AddListener(delegate
+            {
+                bmc.SetMode_BuildFurniture(objectId);
+                this.gameObject.SetActive(false);
+            });
+
+            // http://stackoverflow.com/questions/1757112/anonymous-c-sharp-delegate-within-a-loop
+            string furniture = furnitureKey;
+            LocalizationTable.CBLocalizationFilesChanged += delegate
+            {
+                gameObject.transform.GetComponentInChildren<TextLocalizer>().formatValues = new string[] { LocalizationTable.GetLocalization(PrototypeManager.Furniture.Get(furniture).LocalizationCode) };
+            };
+        }
+
+        lastLanguage = LocalizationTable.currentLanguage;
     }
 }

--- a/Assets/Scripts/UI/FurnitureBuildMenu.cs
+++ b/Assets/Scripts/UI/FurnitureBuildMenu.cs
@@ -20,7 +20,7 @@ public class FurnitureBuildMenu : MonoBehaviour
     private string lastLanguage;
     private bool showAllFurniture;
 
-    public void RebuildMenuButtons(bool showAllFurniture)
+    public void RebuildMenuButtons(bool showAllFurniture = false)
     {
         foreach (GameObject gameObject in buildMenu)
         {


### PR DESCRIPTION
Reworked `FurnitureBuildMenu` to allow the furniture list to be rebuilt on the fly, this also allows for Dev mode to make all furniture visible/buildable regardless of Non-buildable flag.

You can call the `RebuildMenuButtons` function to rebuild the list and either tell it to display everything or just rebuild the list.

It should be fairly easy to expand on the checks to make certain buildings become visible when required or vice versa.

Any suggestions for changes welcome! :+1: 