### PR TITLE
Drops the current build item when switching construction menus

### DIFF
--- a/Assets/Scripts/Controllers/MouseController.cs
+++ b/Assets/Scripts/Controllers/MouseController.cs
@@ -151,6 +151,14 @@ public class MouseController
         return false;
     }
 
+    public void ClearMouseMode(bool changeMode = false)
+    {
+        isDragging = false;
+        if (changeMode) {
+            currentMode = MouseMode.SELECT;
+        }
+    }
+
     private void UpdateCurrentFramePosition()
     {
         currFramePosition = Camera.main.ScreenToWorldPoint(Input.mousePosition);
@@ -163,8 +171,7 @@ public class MouseController
         {
             if (currentMode == MouseMode.BUILD)
             {
-                isDragging = false;
-                currentMode = MouseMode.SELECT;
+                ClearMouseMode(true);
             }
             else if (currentMode == MouseMode.SPAWN_INVENTORY)
             {

--- a/Assets/Scripts/UI/InGameUI/ConstructionMenu.cs
+++ b/Assets/Scripts/UI/InGameUI/ConstructionMenu.cs
@@ -62,6 +62,7 @@ public class ConstructionMenu : MonoBehaviour
     // Deactivates any sub menu of the constrution options.
     public void DeactivateSubs()
     {
+        WorldController.Instance.mouseController.ClearMouseMode(true);
         furnitureMenu.SetActive(false);
         floorMenu.SetActive(false);
     }
@@ -74,6 +75,7 @@ public class ConstructionMenu : MonoBehaviour
 
     public void DeactivateSubsExcept(GameObject menu)
     {
+        WorldController.Instance.mouseController.ClearMouseMode(true);
         foreach (GameObject subMenu in FurnitureSubs)
         {
             if (subMenu != menu)

--- a/Assets/Scripts/UI/InGameUI/MenuController.cs
+++ b/Assets/Scripts/UI/InGameUI/MenuController.cs
@@ -41,6 +41,7 @@ public class MenuController : MonoBehaviour
     // Deactivates any sub menu of the constrution options.
     public void DeactivateSubs()
     {
+        WorldController.Instance.mouseController.ClearMouseMode(true);
         furnitureMenu.SetActive(false);
         floorMenu.SetActive(false);
     }


### PR DESCRIPTION
This will drop the item being build when switching menus. As a result of this change, it allows for ease of access to this clearing function, which might make the change in #630 easier.

Fixes #508 