### PR TITLE
Allow disabling saves of ScheduledEvent. Fixes #1180.

### DIFF
--- a/Assets/Editor/SchedulerEditorTest.cs
+++ b/Assets/Editor/SchedulerEditorTest.cs
@@ -263,6 +263,27 @@ public class SchedulerEditorTest
     }
 
     [Test]
+    public void SchedulerWriteXmlDoesNotWriteNoSaveFlaggedEventsTest()
+    {
+        ScheduledEvent evt = new ScheduledEvent(
+            "test",
+            callback,
+            2.0f,
+            false,
+            1);
+        evt.IsSaveable = false;
+        scheduler.RegisterEvent(evt);
+        scheduler.Update(0); // updates the event list
+
+        StringBuilder sb = new StringBuilder();
+        XmlWriter writer = new XmlTextWriter(new StringWriter(sb));
+        scheduler.WriteXml(writer);
+
+        string expectedXml = "<Scheduler />";
+        Assert.That(sb.ToString(), Is.EqualTo(expectedXml));
+    }
+
+    [Test]
     public void SchedulerReadXmlTest()
     {
         // prepare a scheduler instance to serialize

--- a/Assets/Scripts/Scheduler/ScheduledEvent.cs
+++ b/Assets/Scripts/Scheduler/ScheduledEvent.cs
@@ -15,6 +15,10 @@ using MoonSharp.Interpreter;
 
 namespace Scheduler
 {
+    /// <summary>
+    /// The type of function backing a ScheduledEvent.
+    /// Options: CSharp or Lua.
+    /// </summary>
     public enum EventType
     {
         CSharp,
@@ -42,7 +46,7 @@ namespace Scheduler
         /// <param name="onFire">Callback to call when the event fires.</param>
         /// <param name="cooldown">Cooldown in seconds.</param>
         /// <param name="repeatsForever">Whether the event repeats forever (defaults false). If true repeats is ignored.</param>
-        /// <param name="repeats">Number of repeats (default 1). Ignored if repeatsForever=true.</param>
+        /// <param name="repeats">Number of repeats (default 1). Ignored if repeatsForever == true.</param>
         public ScheduledEvent(string name, Action<ScheduledEvent> onFire, float cooldown, bool repeatsForever = false, int repeats = 1)
         {
             this.Name = name;
@@ -55,6 +59,10 @@ namespace Scheduler
             this.IsSaveable = true;
         }
 
+        /// <summary>
+        /// Copy constructor for <see cref="Scheduler.ScheduledEvent"/> objects.
+        /// </summary>
+        /// <param name="other">The event to make a copy of.</param>
         public ScheduledEvent(ScheduledEvent other)
         {
             this.Name = other.Name;
@@ -68,6 +76,17 @@ namespace Scheduler
             this.IsSaveable = other.IsSaveable;
         }
 
+        /// <summary>
+        /// Constructs a <see cref="Scheduler.ScheduledEvent"/> object from a prototype ScheduledEvent.
+        /// If eventPrototype is an EventType.Lua event, the Lua function call is
+        /// looked up based on the eventPrototype.LuaFunctionName attribute and bound
+        /// to a C# callback.
+        /// </summary>
+        /// <param name="eventPrototype">Event prototype.</param>
+        /// <param name="cooldown">Cooldown in seconds.</param>
+        /// <param name="timeToWait">Time to wait until next event firing.</param>
+        /// <param name="repeatsForever">If set to <c>true</c> repeats forever.</param>
+        /// <param name="repeats">Repeats left (only matters if repeatsForever == false).</param>
         public ScheduledEvent(ScheduledEvent eventPrototype, float cooldown, float timeToWait, bool repeatsForever = false, int repeats = 1)
         {
             this.Name = eventPrototype.Name;
@@ -88,6 +107,11 @@ namespace Scheduler
             this.IsSaveable = true;
         }
 
+        /// <summary>
+        /// Construct a <see cref="Scheduler.ScheduledEvent"/> prototype backed by a C# action.
+        /// </summary>
+        /// <param name="name">Name of the prototype.</param>
+        /// <param name="onFire">On fire action.</param>
         public ScheduledEvent(string name, Action<ScheduledEvent> onFire)
         {
             this.Name = name;
@@ -95,6 +119,11 @@ namespace Scheduler
             this.EventType = EventType.CSharp;
         }
 
+        /// <summary>
+        /// Construct a <see cref="Scheduler.ScheduledEvent"/> prototype backed by a Lua function.
+        /// </summary>
+        /// <param name="name">Name of the prototype.</param>
+        /// <param name="luaFuctionName">Lua fuction name.</param>
         public ScheduledEvent(string name, string luaFuctionName)
         {
             this.Name = name;
@@ -104,22 +133,53 @@ namespace Scheduler
 
         private event Action<ScheduledEvent> OnFire;
 
+        /// <summary>
+        /// Gets or sets the name.
+        /// </summary>
         public string Name { get; protected set; }
 
+        /// <summary>
+        /// Gets or sets the type of the event.
+        /// </summary>
         public EventType EventType { get; protected set; }
 
+        /// <summary>
+        /// Gets or sets the name of the lua function.
+        /// Is null if EventType is EventType.CSharp.
+        /// </summary>
         public string LuaFunctionName { get; protected set; }
 
+        /// <summary>
+        /// Gets or sets the number of repeats left.
+        /// This value is ignored if RepeatsForever == true.
+        /// </summary>
         public int RepeatsLeft { get; protected set; }
 
+        /// <summary>
+        /// Gets or sets the cooldown in seconds.
+        /// </summary>
         public float Cooldown { get; protected set; }
 
+        /// <summary>
+        /// Gets or sets the time to wait until the next event firing in seconds.
+        /// </summary>
         public float TimeToWait { get; protected set; }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether this <see cref="Scheduler.ScheduledEvent"/> repeats forever.
+        /// </summary>
         public bool RepeatsForever { get; protected set; }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether this instance is saveable.
+        /// Used by <see cref="Scheduler.Scheduler"/> when serializing itself.
+        /// </summary>
         public bool IsSaveable { get; set; }
 
+        /// <summary>
+        /// Gets a value indicating whether this is the last shot of the <see cref="Scheduler.ScheduledEvent"/>.
+        /// </summary>
+        /// <value><c>true</c> if last shot; otherwise, <c>false</c>.</value>
         public bool LastShot
         {
             get
@@ -128,6 +188,10 @@ namespace Scheduler
             }
         }
 
+        /// <summary>
+        /// Gets a value indicating whether this <see cref="Scheduler.ScheduledEvent"/> is finished.
+        /// </summary>
+        /// <value><c>true</c> if finished; otherwise, <c>false</c>.</value>
         public bool Finished
         {
             get
@@ -152,6 +216,9 @@ namespace Scheduler
             }
         }
 
+        /// <summary>
+        /// Fires the <see cref="Scheduler.ScheduledEvent"/>.
+        /// </summary>
         public void Fire()
         {
             if (Finished)
@@ -168,6 +235,9 @@ namespace Scheduler
             this.RepeatsLeft -= 1;
         }
 
+        /// <summary>
+        /// Stops the <see cref="Scheduler.ScheduledEvent"/>.
+        /// </summary>
         public void Stop()
         {
             RepeatsLeft = 0;
@@ -176,16 +246,34 @@ namespace Scheduler
 
         #region IXmlSerializable implementation
 
+        /// <summary>
+        /// This does absolutely nothing.
+        /// This is required to implement IXmlSerializable.
+        /// </summary>
+        /// <returns>NULL and NULL.</returns>
         public XmlSchema GetSchema()
         {
             return null;
         }
 
+        /// <summary>
+        /// Generates a <see cref="Scheduler.ScheduledEvent"/> from its XML representation. NOT IMPLEMENTED.
+        /// Loading saved <see cref="Scheduler.ScheduledEvent"/>s is handled by <see cref="Scheduler.Scheduler"/>.
+        /// </summary>
         public void ReadXml(XmlReader reader)
         {
             throw new NotImplementedException();
         }
 
+        /// <summary>
+        /// Converts a <see cref="Scheduler.ScheduledEvent"/> into its XML representation.
+        /// Format:
+        /// <Event name="Name" cooldown="Cooldown" timeToWait="TimeToWait" repeatsForever="true" />
+        /// or
+        /// <Event name="Name" cooldown="Cooldown" timeToWait="TimeToWait" repeatsLeft="RepeatsLeft" />
+        /// if RepeatsForever == false.
+        /// </summary>
+        /// <param name="writer">The XmlWriter to output to.</param>
         public void WriteXml(XmlWriter writer)
         {
             writer.WriteStartElement("Event");

--- a/Assets/Scripts/Scheduler/ScheduledEvent.cs
+++ b/Assets/Scripts/Scheduler/ScheduledEvent.cs
@@ -52,6 +52,7 @@ namespace Scheduler
             this.RepeatsForever = repeatsForever;
             this.RepeatsLeft = repeats;
             this.EventType = EventType.CSharp;
+            this.IsSaveable = true;
         }
 
         public ScheduledEvent(ScheduledEvent other)
@@ -64,6 +65,7 @@ namespace Scheduler
             this.RepeatsForever = other.RepeatsForever;
             this.RepeatsLeft = other.RepeatsLeft;
             this.EventType = other.EventType;
+            this.IsSaveable = other.IsSaveable;
         }
 
         public ScheduledEvent(ScheduledEvent eventPrototype, float cooldown, float timeToWait, bool repeatsForever = false, int repeats = 1)
@@ -83,6 +85,7 @@ namespace Scheduler
             this.RepeatsForever = repeatsForever;
             this.RepeatsLeft = repeats;
             this.EventType = eventPrototype.EventType;
+            this.IsSaveable = true;
         }
 
         public ScheduledEvent(string name, Action<ScheduledEvent> onFire)
@@ -114,6 +117,8 @@ namespace Scheduler
         public float TimeToWait { get; protected set; }
 
         public bool RepeatsForever { get; protected set; }
+
+        public bool IsSaveable { get; set; }
 
         public bool LastShot
         {

--- a/Assets/Scripts/Scheduler/Scheduler.cs
+++ b/Assets/Scripts/Scheduler/Scheduler.cs
@@ -28,6 +28,10 @@ namespace Scheduler
         private List<ScheduledEvent> events;
         private List<ScheduledEvent> eventsToAddNextTick;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Scheduler.Scheduler"/> class.
+        /// Note: you probably want to use <see cref="Scheduler.Current"/> to get the singleton instance of the main game scheduler.
+        /// </summary>
         public Scheduler()
         {
             this.events = new List<ScheduledEvent>();
@@ -43,6 +47,10 @@ namespace Scheduler
             LoadScripts();
         }
 
+        /// <summary>
+        /// Get the singleton instance of the main game scheduler.
+        /// If it does not exist yet it is created on demand.
+        /// </summary>
         public static Scheduler Current
         {
             get
@@ -56,8 +64,13 @@ namespace Scheduler
             }
         }
 
+        /// <summary>
+        /// Gets the events currently queued for execution by the scheduler.
+        /// </summary>
+        /// <value>The events.</value>
         public ReadOnlyCollection<ScheduledEvent> Events
         {
+            // FIXME: Currently does not include eventsToAddNextTick!
             get
             {
                 return new ReadOnlyCollection<ScheduledEvent>(events);
@@ -66,13 +79,21 @@ namespace Scheduler
 
         #region LuaHandling
 
+        /// <summary>
+        /// Loads the Lua scripts from StreamingAssets/LUA/Events.lua.
+        /// </summary>
         public static void LoadScripts()
         {
+            // TODO: Use new FunctionsManager??
             string luaFilePath = Path.Combine(Application.streamingAssetsPath, "LUA");
             luaFilePath = Path.Combine(luaFilePath, "Events.lua");
             LuaUtilities.LoadScriptFromFile(luaFilePath);
         }
 
+        /// <summary>
+        /// Loads the Lua scripts from the Events.lua files in mod directories.
+        /// </summary>
+        /// <param name="mods">Mods directories to search for Lua scripts.</param>
         public static void LoadModsScripts(DirectoryInfo[] mods)
         {
             foreach (DirectoryInfo mod in mods)
@@ -121,6 +142,9 @@ namespace Scheduler
             RegisterEvent(evt);
         }
 
+        /// <summary>
+        /// Registers a ScheduledEvent to be tracked by the scheduler.
+        /// </summary>
         public void RegisterEvent(ScheduledEvent evt)
         {
             if (evt != null)
@@ -134,6 +158,9 @@ namespace Scheduler
             }
         }
 
+        /// <summary>
+        /// Determines whether this ScheduledEvent is registered with the scheduler.
+        /// </summary>
         public bool IsRegistered(ScheduledEvent evt)
         {
             return (events != null && events.Contains(evt)) || (eventsToAddNextTick != null && eventsToAddNextTick.Contains(evt));
@@ -142,7 +169,7 @@ namespace Scheduler
         /// <summary>
         /// Deregisters the event.
         /// NOTE: This actually calls Stop() on the event so that it will no longer be run.
-        /// It will be removed on the next call of ClearFinishedEvents().
+        /// It will be removed on the next call of Update().
         /// </summary>
         /// <param name="evt">Event to deregister.</param>
         public void DeregisterEvent(ScheduledEvent evt)
@@ -171,6 +198,10 @@ namespace Scheduler
             return events.Min((e) => e.TimeToWait);
         }
 
+        /// <summary>
+        /// Update the scheduler by the specified deltaTime, running event callbacks as needed.
+        /// </summary>
+        /// <param name="deltaTime">Delta time in seconds.</param>
         public void Update(float deltaTime)
         {
             if ((events == null || events.Count == 0) && (eventsToAddNextTick == null || eventsToAddNextTick.Count == 0))
@@ -193,6 +224,9 @@ namespace Scheduler
             ClearFinishedEvents();
         }
 
+        /// <summary>
+        /// Registers an event prototype with PrototypeManager.
+        /// </summary>
         public void RegisterEventPrototype(string name, ScheduledEvent eventPrototype)
         {
             PrototypeManager.SchedulerEvent.Add(name, eventPrototype);
@@ -200,11 +234,20 @@ namespace Scheduler
 
         #region IXmlSerializable implementation
 
+        /// <summary>
+        /// This does absolutely nothing.
+        /// This is required to implement IXmlSerializable.
+        /// </summary>
+        /// <returns>NULL and NULL.</returns>
         public XmlSchema GetSchema()
         {
             return null;
         }
 
+        /// <summary>
+        /// Generates a Scheduler from its XML representation.
+        /// Clears any previous events in the queue.
+        /// </summary>
         public void ReadXml(XmlReader reader)
         {
             Debug.ULogChannel("Scheduler", "Reading save file...", Events.Count);
@@ -240,6 +283,10 @@ namespace Scheduler
             Debug.ULogChannel("Scheduler", "Save file loaded. Event queue contains {0} events.", Events.Count);
         }
 
+        /// <summary>
+        /// Converts a Scheduler into its XML representation.
+        /// Only serializes events with IsSaveable == true.
+        /// </summary>
         public void WriteXml(XmlWriter writer)
         {
             writer.WriteStartElement("Scheduler");
@@ -271,6 +318,9 @@ namespace Scheduler
             }
         }
 
+        /// <summary>
+        /// Stops all events and clobbers the queue.
+        /// </summary>
         private void CleanUp()
         {
             if (events != null)

--- a/Assets/Scripts/Scheduler/Scheduler.cs
+++ b/Assets/Scripts/Scheduler/Scheduler.cs
@@ -245,6 +245,11 @@ namespace Scheduler
             writer.WriteStartElement("Scheduler");
             foreach (ScheduledEvent evt in Events)
             {
+                if (evt.IsSaveable == false)
+                {
+                    continue;
+                }
+
                 evt.WriteXml(writer);
             }
 

--- a/Assets/Scripts/UI/HeadlineController.cs
+++ b/Assets/Scripts/UI/HeadlineController.cs
@@ -61,6 +61,7 @@ public class HeadlineController : MonoBehaviour
 
         Scheduler.Scheduler.Current.DeregisterEvent(scheduledEvent);
         scheduledEvent = new ScheduledEvent(ToString(), (incomingEvent) => Dismiss(), dismissTime);
+        scheduledEvent.IsSaveable = false;
         Scheduler.Scheduler.Current.RegisterEvent(scheduledEvent);
     }
 }


### PR DESCRIPTION
Fixes #1180 
Adds a `bool ScheduledEvent.IsSaveable` flag which is checked by `Scheduler` before serializing the event.

Also adds documentation comments per #1126. :grinning: 