### PR TITLE
Better Selection Info + Power grid status display on furnitures

### DIFF
--- a/Assets/Scripts/Models/Character.cs
+++ b/Assets/Scripts/Models/Character.cs
@@ -7,6 +7,7 @@
 // ====================================================
 #endregion
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -467,25 +468,23 @@ public class Character : IXmlSerializable, ISelectable, IContextActionProvider
 
     public string GetDescription()
     {
-        StringBuilder description = new StringBuilder();
-        description.AppendLine("A human astronaut.");
+        return "A human astronaut.";
+    }
+
+    public IEnumerable<string> GetAdditionalInfo()
+    {
+        yield return string.Format("HitPoints: 100/100");
+
         foreach (Need n in needs)
         {
-            description.AppendLine(LocalizationTable.GetLocalization(n.localisationID, n.DisplayAmount));
+           yield return LocalizationTable.GetLocalization(n.localisationID, n.DisplayAmount);
         }
 
         foreach (Stat stat in stats.Values)
         {
             // TODO: Localization
-            description.AppendLine(string.Format("{0}: {1}", stat.statType, stat.Value));
+            yield return string.Format("{0}: {1}", stat.statType, stat.Value);
         }
-
-        return description.ToString();
-    }
-
-    public string GetHitPointString()
-    {
-        return "100/100";
     }
 
     public Color GetCharacterColor()

--- a/Assets/Scripts/Models/Furniture.cs
+++ b/Assets/Scripts/Models/Furniture.cs
@@ -976,7 +976,6 @@ public class Furniture : IXmlSerializable, ISelectable, IContextActionProvider
     {
         yield return string.Format("Hitpoint 18 / 18");
 
-
         if (PowerConnection != null)
         {
             bool hasPower = HasPower();

--- a/Assets/Scripts/Models/Furniture.cs
+++ b/Assets/Scripts/Models/Furniture.cs
@@ -980,7 +980,7 @@ public class Furniture : IXmlSerializable, ISelectable, IContextActionProvider
         {
             bool hasPower = HasPower();
 
-            yield return hasPower ? "<color=green>Online</color>" : "<color=red>Offline</color>";
+            yield return string.Format("Power Grid: <color={0}>{1}</color>", hasPower ? "green" : "red", hasPower ? "Online" : "Offline");
 
             if (PowerConnection.IsPowerConsumer)
             {

--- a/Assets/Scripts/Models/Furniture.cs
+++ b/Assets/Scripts/Models/Furniture.cs
@@ -7,6 +7,7 @@
 // ====================================================
 #endregion
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Xml;
 using System.Xml.Schema;
@@ -963,21 +964,40 @@ public class Furniture : IXmlSerializable, ISelectable, IContextActionProvider
     }
 
     /// <summary>
-    /// Returns the HitPoints of the current furniture NOT IMPLEMENTED.
-    /// </summary>
-    /// <returns>String with the HitPoints of the furniture.</returns>
-    public string GetHitPointString()
-    {
-        return "18/18"; // TODO: Add a hitpoint system to...well...everything
-    }
-
-    /// <summary>
     /// Returns the description of the job linked to the furniture. NOT INMPLEMENTED.
     /// </summary>
     /// <returns>Job description of the job linked to the furniture.</returns>
     public string GetJobDescription()
     {
         return string.Empty;
+    }
+
+    public IEnumerable<string> GetAdditionalInfo()
+    {
+        yield return string.Format("Hitpoint 18 / 18");
+
+
+        if (PowerConnection != null)
+        {
+            bool hasPower = HasPower();
+
+            yield return hasPower ? "<color=green>Online</color>" : "<color=red>Offline</color>";
+
+            if (PowerConnection.IsPowerConsumer)
+            {
+                yield return string.Format("Power Input: <color={0}>{1}</color>", hasPower ? "green" : "red", PowerConnection.InputRate);
+            }
+            
+            if (PowerConnection.IsPowerProducer)
+            {
+                yield return string.Format("Power Output: <color={0}>{1}</color>", hasPower ? "green" : "red", PowerConnection.OutputRate);
+            }
+
+            if (PowerConnection.IsPowerAccumulator)
+            {
+                yield return string.Format("Power Accumulated: {0} / {1}", PowerConnection.AccumulatedPower, PowerConnection.Capacity);
+            }
+        }
     }
 
     /// <summary>

--- a/Assets/Scripts/Models/Furniture.cs
+++ b/Assets/Scripts/Models/Furniture.cs
@@ -979,17 +979,18 @@ public class Furniture : IXmlSerializable, ISelectable, IContextActionProvider
         if (PowerConnection != null)
         {
             bool hasPower = HasPower();
+            string powerColor = hasPower ? "green" : "red";
 
-            yield return string.Format("Power Grid: <color={0}>{1}</color>", hasPower ? "green" : "red", hasPower ? "Online" : "Offline");
+            yield return string.Format("Power Grid: <color={0}>{1}</color>", powerColor, hasPower ? "Online" : "Offline");
 
             if (PowerConnection.IsPowerConsumer)
             {
-                yield return string.Format("Power Input: <color={0}>{1}</color>", hasPower ? "green" : "red", PowerConnection.InputRate);
+                yield return string.Format("Power Input: <color={0}>{1}</color>", powerColor, PowerConnection.InputRate);
             }
             
             if (PowerConnection.IsPowerProducer)
             {
-                yield return string.Format("Power Output: <color={0}>{1}</color>", hasPower ? "green" : "red", PowerConnection.OutputRate);
+                yield return string.Format("Power Output: <color={0}>{1}</color>", powerColor, PowerConnection.OutputRate);
             }
 
             if (PowerConnection.IsPowerAccumulator)

--- a/Assets/Scripts/Models/ISelectable.cs
+++ b/Assets/Scripts/Models/ISelectable.cs
@@ -7,6 +7,7 @@
 // ====================================================
 #endregion
 using System.Collections;
+using System.Collections.Generic;
 using UnityEngine;
 
 public interface ISelectable
@@ -16,10 +17,8 @@ public interface ISelectable
     string GetName();
 
     string GetDescription();
-
-    // TODO: Decide whether to allow indestructible thing.
-    // For indestructible things (if any) this is allowed to return blank.
-    string GetHitPointString();
-
+    
     string GetJobDescription();
+
+    IEnumerable<string> GetAdditionalInfo();
 }

--- a/Assets/Scripts/Models/Inventory.cs
+++ b/Assets/Scripts/Models/Inventory.cs
@@ -7,6 +7,7 @@
 // ====================================================
 #endregion
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Xml;
 using System.Xml.Schema;
@@ -116,17 +117,20 @@ public class Inventory : IXmlSerializable, ISelectable, IContextActionProvider
 
     public string GetDescription()
     {
-        return string.Format("StackSize: {0}\nCategory: {1}\nBasePrice: {2:N2}", stackSize, Category, BasePrice);
+        return string.Empty;
     }
-
-    public string GetHitPointString()
-    {
-        return string.Empty;  // Does inventory have hitpoints? How does it get destroyed? Maybe it's just a percentage chance based on damage.
-    }
-
+    
     public string GetJobDescription()
     {
         return string.Empty;
+    }
+
+    public IEnumerable<string> GetAdditionalInfo()
+    {
+        // Does inventory have hitpoints? How does it get destroyed? Maybe it's just a percentage chance based on damage.
+        yield return string.Format("StackSize: {0}", stackSize);
+        yield return string.Format("Category: {0}", BasePrice);
+        yield return string.Format("BasePrice: {0:N2}", BasePrice);
     }
     #endregion
 

--- a/Assets/Scripts/Models/Job.cs
+++ b/Assets/Scripts/Models/Job.cs
@@ -7,6 +7,7 @@
 // ====================================================
 #endregion
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using MoonSharp.Interpreter;
@@ -415,14 +416,14 @@ public class Job : ISelectable
 
         return description;
     }
-
-    public string GetHitPointString()
-    {
-        return string.Empty;
-    }
-
+    
     public string GetJobDescription()
     {
         return GetDescription();
+    }
+
+    public IEnumerable<string> GetAdditionalInfo()
+    {
+        yield break;
     }
 }

--- a/Assets/Scripts/Models/Tile.cs
+++ b/Assets/Scripts/Models/Tile.cs
@@ -7,6 +7,7 @@
 // ====================================================
 #endregion
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Xml;
@@ -394,14 +395,15 @@ public class Tile : IXmlSerializable, ISelectable, IContextActionProvider
         return "tile_" + type.ToString() + "_desc";
     }
 
-    public string GetHitPointString()
-    {
-        return string.Empty; // Do tiles have hitpoints? Can flooring be damaged? Obviously "empty" is indestructible.
-    }
-
     public string GetJobDescription()
     {
         return string.Empty;
+    }
+
+    public IEnumerable<string> GetAdditionalInfo()
+    {
+        // Do tiles have hitpoints? Can flooring be damaged? Obviously "empty" is indestructible.
+        yield break;
     }
 
     #endregion

--- a/Assets/Scripts/UI/SelectionInfoTextField.cs
+++ b/Assets/Scripts/UI/SelectionInfoTextField.cs
@@ -6,7 +6,11 @@
 // file LICENSE, which is part of this source code package, for details.
 // ====================================================
 #endregion
+
+using System;
 using System.Collections;
+using System.Linq;
+using System.Text;
 using ProjectPorcupine.Localization;
 using UnityEngine;
 using UnityEngine.UI;
@@ -42,15 +46,24 @@ public class SelectionInfoTextField : MonoBehaviour
 
         ISelectable actualSelection = mc.mySelection.GetSelectedStuff();
 
+        string additionalInfoText = string.Join(Environment.NewLine, actualSelection.GetAdditionalInfo().ToArray());
+
         if (actualSelection.GetType() == typeof(Character))
         {
             // TODO: Change the hitpoint stuff.
-            txt.text = actualSelection.GetName() + "\n" + actualSelection.GetDescription() + "\n" + actualSelection.GetHitPointString() + "\n" + LocalizationTable.GetLocalization(actualSelection.GetJobDescription());
+            txt.text = 
+                actualSelection.GetName() + "\n" + 
+                actualSelection.GetDescription() + "\n" +
+                LocalizationTable.GetLocalization(actualSelection.GetJobDescription()) + "\n" + 
+                additionalInfoText;
         }
         else
         {
             // TODO: Change the hitpoint stuff.
-            txt.text = LocalizationTable.GetLocalization(actualSelection.GetName()) + "\n" + LocalizationTable.GetLocalization(actualSelection.GetDescription()) + "\n" + actualSelection.GetHitPointString();
+            txt.text = 
+                LocalizationTable.GetLocalization(actualSelection.GetName()) + "\n" + 
+                LocalizationTable.GetLocalization(actualSelection.GetDescription()) + "\n" +
+                additionalInfoText;
         }
     }
 }


### PR DESCRIPTION
Improve the ISelectable to allow multiple string content controller by the class implementing the interface.

Added power info to power related furniture to display the current consumption, production and accumulated power.

(also change the hitpoint, stats & needs to be part of the additional info)

![image](https://cloud.githubusercontent.com/assets/6545998/18331440/4159ee3c-755f-11e6-9104-6bb489824f35.png)
![image](https://cloud.githubusercontent.com/assets/6545998/18331445/4e141f30-755f-11e6-8150-60e119839c06.png)
![image](https://cloud.githubusercontent.com/assets/6545998/18331455/6d1b7f36-755f-11e6-806c-7f9c7acad93c.png)
![image](https://cloud.githubusercontent.com/assets/6545998/18331557/17e45550-7560-11e6-931f-a4a7d7e9239a.png)
