### PR TITLE
[small] Makes the Scheduler class visible to Lua scripts

### DIFF
--- a/Assets/Scripts/Models/Functions/LuaFunctions.cs
+++ b/Assets/Scripts/Models/Functions/LuaFunctions.cs
@@ -32,6 +32,8 @@ public class LuaFunctions
         RegisterGlobal(typeof(World));
         RegisterGlobal(typeof(WorldController));
         RegisterGlobal(typeof(Connection));
+        RegisterGlobal(typeof(Scheduler.Scheduler));
+        RegisterGlobal(typeof(Scheduler.ScheduledEvent));
     }
 
     /// <summary>

--- a/Assets/Scripts/Scheduler/Scheduler.cs
+++ b/Assets/Scripts/Scheduler/Scheduler.cs
@@ -15,6 +15,7 @@ using System.Linq;
 using System.Xml;
 using System.Xml.Schema;
 using System.Xml.Serialization;
+using MoonSharp.Interpreter;
 using UnityEngine;
 
 namespace Scheduler
@@ -22,6 +23,7 @@ namespace Scheduler
     /// <summary>
     /// Generic scheduler class for tracking and dispatching ScheduledEvents.
     /// </summary>
+    [MoonSharpUserData]
     public class Scheduler : IXmlSerializable
     {
         private static Scheduler instance;


### PR DESCRIPTION
Previously there was no way for Lua scripts to access the Scheduler
directly. They could create or modify ScheduledEvent objects but not
actually (de)schedule them! This was a simple oversight on my part. The
intent for Lua access was there from the beginning.

Fixing this was simply a matter of adding a [MoonSharpUserData]
declaration and registering the globals. Now any Lua function run through
LuaFunctions.Call() or CallWithInstance() automatically gets the Scheduler
class and (most importantly) Scheduler.Current in its globals.

On commit all tests and Stylecop were passing.