### PR TITLE
Fix work dialog overlapping other dialogs

### DIFF
--- a/Assets/Scripts/UI/DialogBox/JobList/DialogBoxJobList.cs
+++ b/Assets/Scripts/UI/DialogBox/JobList/DialogBoxJobList.cs
@@ -29,11 +29,6 @@ public class DialogBoxJobList : DialogBox
 
     private int currentWait = 0;
 
-    public override void ShowDialog()
-    {
-        gameObject.SetActive(true);
-    }
-
     public override void CloseDialog()
     {
         // Clear out all the children of our file list

--- a/Assets/Scripts/UI/InGameUI/MenuController.cs
+++ b/Assets/Scripts/UI/InGameUI/MenuController.cs
@@ -1,4 +1,4 @@
-﻿#region License
+#region License
 // ====================================================
 // Project Porcupine Copyright(C) 2016 Team Porcupine
 // This program comes with ABSOLUTELY NO WARRANTY; This is free software, 
@@ -18,7 +18,7 @@ public class MenuController : MonoBehaviour
     // The sub menus of the build menu (furniture, floor..... later - power, security, drones).
     public GameObject furnitureMenu;
     public GameObject floorMenu;
-    
+
     public Button buttonConstructor;
     public Button buttonWorld;
     public Button buttonWork;
@@ -57,9 +57,9 @@ public class MenuController : MonoBehaviour
         if (constructorMenu.activeSelf)
         {
             DeactivateAll();
-        } 
-        else 
-        { 
+        }
+        else
+        {
             DeactivateAll();
             constructorMenu.SetActive(true);
         }
@@ -67,8 +67,11 @@ public class MenuController : MonoBehaviour
 
     public void OnButtonWork()
     {
-        DeactivateAll();
-        dbm.dialogBoxJobList.ShowDialog();
+        if (!WorldController.Instance.IsModal)
+        {
+            DeactivateAll();
+            dbm.dialogBoxJobList.ShowDialog();
+        }
     }
 
     public void OnButtonWorld()


### PR DESCRIPTION
- the work dialog did not check `isModal` before opening
- the work dialog did not set `isModal` when opening.

both caused other dialogs to be open at the same time as work. This PR addresses both issues.