### PR TITLE
Prevent material change at runtime

### DIFF
--- a/Assets/Scripts/UI/Overlay/OverlayMap.cs
+++ b/Assets/Scripts/UI/Overlay/OverlayMap.cs
@@ -546,7 +546,7 @@ public class OverlayMap : MonoBehaviour
         colorMapView.AddComponent<UnityEngine.UI.LayoutElement>();
         colorMapView.GetComponent<UnityEngine.UI.LayoutElement>().minHeight = 30;
         colorMapView.GetComponent<UnityEngine.UI.LayoutElement>().minWidth = 150;
-        Material overlayMaterial = Resources.Load<Material>("Shaders/UI-Unlit-Transparent");
+        Material overlayMaterial = new Material(Resources.Load<Material>("Shaders/UI-Unlit-Transparent"));
         colorMapView.GetComponent<UnityEngine.UI.Image>().material = overlayMaterial;
 
         List<string> options = new List<string> { "None" };


### PR DESCRIPTION
By duplicating the material the file should not be changed at runtime, hopefully preventing changes from being included to the baseline that shouldn't be.