### PR TITLE
Hide OverlayUI Tooltip

### DIFF
--- a/Assets/Scripts/UI/Overlay/OverlayMap.cs
+++ b/Assets/Scripts/UI/Overlay/OverlayMap.cs
@@ -256,6 +256,7 @@ public class OverlayMap : MonoBehaviour
         {
             meshRenderer.enabled = false;
             currentOverlay = name;
+            HideGUI();
             return;
         }
         else if (overlays.ContainsKey(name))
@@ -283,6 +284,8 @@ public class OverlayMap : MonoBehaviour
 
             ColorMapSG = descr.colorMap;
             Bake();
+
+            ShowGUI();
         }
         else
         {
@@ -332,9 +335,13 @@ public class OverlayMap : MonoBehaviour
         // Build GUI.
         CreateGUI();
 
+        SetOverlay("None");
+
+        HideGUI();
+
         // TODO: remove this dummy set size.
         SetSize(100, 100);
-        SetOverlay("None");
+
     }
 
     /// <summary>
@@ -555,5 +562,24 @@ public class OverlayMap : MonoBehaviour
         dropdown.AddOptions(options);
         dropdown.onValueChanged.AddListener(
             (int idx) => { SetOverlay(dropdown.captionText.text); });
+    }
+
+    private void HideGUI()
+    {
+        textView.SetActive(false);
+        colorMapView.SetActive(false);
+        parentPanel.GetComponentInChildren<UnityEngine.UI.Image>().enabled = false;
+    }
+
+    private void ShowGUI()
+    {
+        textView.SetActive(true);
+        parentPanel.GetComponentInChildren<UnityEngine.UI.Image>().enabled = true;
+
+        colorMapView.SetActive(true);
+
+        Material overlayMaterial = new Material(Resources.Load<Material>("Shaders/UI-Unlit-Transparent"));
+        colorMapView.GetComponent<UnityEngine.UI.Image>().material = overlayMaterial;
+        GenerateColorMap();
     }
 }

--- a/Assets/Scripts/UI/Overlay/OverlayMap.cs
+++ b/Assets/Scripts/UI/Overlay/OverlayMap.cs
@@ -256,7 +256,7 @@ public class OverlayMap : MonoBehaviour
         {
             meshRenderer.enabled = false;
             currentOverlay = name;
-            HideGUI();
+            HideGUITooltip();
             return;
         }
         else if (overlays.ContainsKey(name))
@@ -284,8 +284,7 @@ public class OverlayMap : MonoBehaviour
 
             ColorMapSG = descr.colorMap;
             Bake();
-
-            ShowGUI();
+            ShowGUIToolitip();
         }
         else
         {
@@ -335,13 +334,9 @@ public class OverlayMap : MonoBehaviour
         // Build GUI.
         CreateGUI();
 
-        SetOverlay("None");
-
-        HideGUI();
-
         // TODO: remove this dummy set size.
+        SetOverlay("None");
         SetSize(100, 100);
-
     }
 
     /// <summary>
@@ -546,7 +541,6 @@ public class OverlayMap : MonoBehaviour
         textView.GetComponent<UnityEngine.UI.Text>().fontSize = 15;
         textView.GetComponent<UnityEngine.UI.Text>().font = Resources.GetBuiltinResource<Font>("Arial.ttf");
 
-
         colorMapView = new GameObject();
         colorMapView.AddComponent<UnityEngine.UI.Image>();
         colorMapView.transform.SetParent(parentPanel.transform);
@@ -565,14 +559,14 @@ public class OverlayMap : MonoBehaviour
             (int idx) => { SetOverlay(dropdown.captionText.text); });
     }
 
-    private void HideGUI()
+    private void HideGUITooltip()
     {
         textView.SetActive(false);
         colorMapView.SetActive(false);
         parentPanel.GetComponentInChildren<UnityEngine.UI.Image>().enabled = false;
     }
 
-    private void ShowGUI()
+    private void ShowGUIToolitip()
     {
         textView.SetActive(true);
         parentPanel.GetComponentInChildren<UnityEngine.UI.Image>().enabled = true;

--- a/Assets/Scripts/UI/Overlay/OverlayMap.cs
+++ b/Assets/Scripts/UI/Overlay/OverlayMap.cs
@@ -284,7 +284,7 @@ public class OverlayMap : MonoBehaviour
 
             ColorMapSG = descr.colorMap;
             Bake();
-            ShowGUIToolitip();
+            ShowGUITooltip();
         }
         else
         {
@@ -566,7 +566,7 @@ public class OverlayMap : MonoBehaviour
         parentPanel.GetComponentInChildren<UnityEngine.UI.Image>().enabled = false;
     }
 
-    private void ShowGUIToolitip()
+    private void ShowGUITooltip()
     {
         textView.SetActive(true);
         parentPanel.GetComponentInChildren<UnityEngine.UI.Image>().enabled = true;

--- a/Assets/Scripts/UI/Overlay/OverlayMap.cs
+++ b/Assets/Scripts/UI/Overlay/OverlayMap.cs
@@ -543,8 +543,9 @@ public class OverlayMap : MonoBehaviour
         textView.GetComponent<UnityEngine.UI.LayoutElement>().minWidth = 150;
         textView.transform.SetParent(parentPanel.transform);
         textView.GetComponent<UnityEngine.UI.Text>().text = "Currently Selected:";
-        textView.GetComponent<UnityEngine.UI.Text>().resizeTextForBestFit = true;
+        textView.GetComponent<UnityEngine.UI.Text>().fontSize = 15;
         textView.GetComponent<UnityEngine.UI.Text>().font = Resources.GetBuiltinResource<Font>("Arial.ttf");
+
 
         colorMapView = new GameObject();
         colorMapView.AddComponent<UnityEngine.UI.Image>();

--- a/Assets/StreamingAssets/Overlay/overlay_functions.lua
+++ b/Assets/StreamingAssets/Overlay/overlay_functions.lua
@@ -11,7 +11,10 @@ function oxygenValueAt ( tile )
     if room == nil then
 		return 0
 	end
-    return room.GetGasAmount("O2") * 1e3
+	if (room.GetGasAmount("O2") > 0) then
+		return 128
+	end
+    return 0
 end
 
 -- Returns room id or null if room or tile invalid

--- a/Assets/_SCENE_.unity
+++ b/Assets/_SCENE_.unity
@@ -180,7 +180,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 614d1936f989c6949b68336704b91aa8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  GameTickPerSecond: 5
   inventoryUI: {fileID: 191780, guid: d1e1fcd802f51614595cb99879a132a5, type: 2}
   circleCursorPrefab: {fileID: 110048, guid: 782976062f887844ca858482495fcdbd, type: 2}
   IsModal: 0
@@ -1393,7 +1392,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 880d84f7377fd34489cb30281e28c2b5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  leftBottomCorner: {x: -0.5, y: -0.5, z: 1}
   transparency: 0.8
   updateInterval: 5
   pixelsPerTileX: 20
@@ -1634,7 +1632,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9500ef008befed7449f0b38f088a5b1d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  mc: {fileID: 0}
+  dialogBoxJobList: {fileID: 0}
   dialogBoxLoadGame: {fileID: 0}
   dialogBoxSaveGame: {fileID: 0}
   dialogBoxOptions: {fileID: 0}
@@ -1642,6 +1640,7 @@ MonoBehaviour:
   dialogBoxTrade: {fileID: 0}
   dialogBoxAreYouSure: {fileID: 0}
   dialogBoxQuests: {fileID: 0}
+  DialogBoxGO: {fileID: 0}
 --- !u!1 &2038247388
 GameObject:
   m_ObjectHideFlags: 0
@@ -1920,11 +1919,11 @@ RectTransform:
   - {fileID: 305970543}
   m_Father: {fileID: 2038247389}
   m_RootOrder: 1
-  m_AnchorMin: {x: 1, y: 0}
-  m_AnchorMax: {x: 1, y: 0}
-  m_AnchoredPosition: {x: 0, y: 450}
+  m_AnchorMin: {x: 1, y: 0.5}
+  m_AnchorMax: {x: 1, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -50}
   m_SizeDelta: {x: 200, y: 100}
-  m_Pivot: {x: 1, y: 0}
+  m_Pivot: {x: 1, y: -2}
 --- !u!114 &2130921648
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1962,7 +1961,7 @@ MonoBehaviour:
   m_ChildAlignment: 0
   m_Spacing: 0
   m_ChildForceExpandWidth: 1
-  m_ChildForceExpandHeight: 1
+  m_ChildForceExpandHeight: 0
 --- !u!114 &2130921650
 MonoBehaviour:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
Few changes on the overlayUI : 
- Fix a bug with oxygen map (LUA). Only 1 color is displayed if there is some O² in the room. Color change with O² still need to be added.
- Hide the overlayUI Tooltip if no overlay is displayed.

There is a small change in the scene on the dropdown menu : position and avoide streetching it.

![1](https://cloud.githubusercontent.com/assets/3942712/18416809/4d816e3e-781f-11e6-8589-568d16b82d78.png)
![2](https://cloud.githubusercontent.com/assets/3942712/18416810/5c40c230-781f-11e6-89d7-cfab68f28182.png)
