### PR TITLE
[Small] Build Menu. Scrollbar settings.

### DIFF
--- a/Assets/Resources/UI/MenuLeft/ConstructionMenu.prefab
+++ b/Assets/Resources/UI/MenuLeft/ConstructionMenu.prefab
@@ -199,7 +199,7 @@ MonoBehaviour:
   m_Content: {fileID: 224000011952310678}
   m_Horizontal: 0
   m_Vertical: 1
-  m_MovementType: 1
+  m_MovementType: 2
   m_Elasticity: 0.1
   m_Inertia: 1
   m_DecelerationRate: 0.135


### PR DESCRIPTION
A small change in the construction menu scrollbar settings.
The MovementType going from Elastic to Clamped. This stop the bar for trying to go out of range.
