### PR TITLE
Hide Dev menu when opening furniture menu

### DIFF
--- a/Assets/Scripts/UI/InGameUI/MenuLeft.cs
+++ b/Assets/Scripts/UI/InGameUI/MenuLeft.cs
@@ -1,4 +1,4 @@
-﻿#region License
+#region License
 // ====================================================
 // Project Porcupine Copyright(C) 2016 Team Porcupine
 // This program comes with ABSOLUTELY NO WARRANTY; This is free software, 
@@ -35,6 +35,10 @@ public class MenuLeft : MonoBehaviour
 
         menu.SetActive(true);
         CurrentlyOpen = menu;
+        if (CurrentlyOpen.name == "ConstructionMenu")
+        {
+            WorldController.Instance.spawnInventoryController.SetUIVisibility(false);
+        }
     }
 
     public void CloseMenu()
@@ -42,6 +46,11 @@ public class MenuLeft : MonoBehaviour
         if (CurrentlyOpen != null)
         {
             CurrentlyOpen.SetActive(false);
+
+            if (CurrentlyOpen.name == "ConstructionMenu") {
+                WorldController.Instance.spawnInventoryController.SetUIVisibility(Settings.GetSetting("DialogBoxSettings_developerModeToggle", false));
+            }
+
             CurrentlyOpen = null;
         }
     }

--- a/Assets/Scripts/UI/InGameUI/MenuLeft.cs
+++ b/Assets/Scripts/UI/InGameUI/MenuLeft.cs
@@ -47,7 +47,8 @@ public class MenuLeft : MonoBehaviour
         {
             CurrentlyOpen.SetActive(false);
 
-            if (CurrentlyOpen.name == "ConstructionMenu") {
+            if (CurrentlyOpen.name == "ConstructionMenu")
+            {
                 WorldController.Instance.spawnInventoryController.SetUIVisibility(Settings.GetSetting("DialogBoxSettings_developerModeToggle", false));
             }
 

--- a/Assets/Scripts/UI/InGameUI/MenuLeft/ConstructionMenu.cs
+++ b/Assets/Scripts/UI/InGameUI/MenuLeft/ConstructionMenu.cs
@@ -1,4 +1,4 @@
-﻿#region License
+#region License
 // ====================================================
 // Project Porcupine Copyright(C) 2016 Team Porcupine
 // This program comes with ABSOLUTELY NO WARRANTY; This is free software, 
@@ -22,6 +22,9 @@ public class ConstructionMenu : MonoBehaviour
     private string lastLanguage;
 
     private bool showAllFurniture;
+
+    private MenuLeft menuLeft;
+
 
     public void RebuildMenuButtons(bool showAllFurniture = false)
     {
@@ -59,6 +62,9 @@ public class ConstructionMenu : MonoBehaviour
         RenderFurnitureButtons();
 
         lastLanguage = LocalizationTable.currentLanguage;
+
+        menuLeft = this.transform.parent.GetComponent<MenuLeft>();
+
     }
 
     private void RenderFurnitureButtons()
@@ -95,7 +101,7 @@ public class ConstructionMenu : MonoBehaviour
             button.onClick.AddListener(delegate
             {
                 buildModeController.SetMode_BuildFurniture(objectId);
-                this.gameObject.SetActive(false);
+                menuLeft.CloseMenu();
             });
 
             // http://stackoverflow.com/questions/1757112/anonymous-c-sharp-delegate-within-a-loop

--- a/Assets/Scripts/UI/InGameUI/MenuLeft/ConstructionMenu.cs
+++ b/Assets/Scripts/UI/InGameUI/MenuLeft/ConstructionMenu.cs
@@ -25,7 +25,6 @@ public class ConstructionMenu : MonoBehaviour
 
     private MenuLeft menuLeft;
 
-
     public void RebuildMenuButtons(bool showAllFurniture = false)
     {
         foreach (GameObject gameObject in furnitureItems)
@@ -52,9 +51,11 @@ public class ConstructionMenu : MonoBehaviour
 
     private void Start()
     {
+        menuLeft = this.transform.GetComponentInParent<MenuLeft>();
+
         this.transform.FindChild("Close Button").GetComponent<Button>().onClick.AddListener(delegate
         {
-            this.transform.GetComponentInParent<MenuLeft>().CloseMenu();
+            menuLeft.CloseMenu();
         });
 
         RenderDeconstructButton();
@@ -62,9 +63,6 @@ public class ConstructionMenu : MonoBehaviour
         RenderFurnitureButtons();
 
         lastLanguage = LocalizationTable.currentLanguage;
-
-        menuLeft = this.transform.parent.GetComponent<MenuLeft>();
-
     }
 
     private void RenderFurnitureButtons()


### PR DESCRIPTION
when furniture is open, the dev menu is hidden so they don't overlap.

![menu](https://cloud.githubusercontent.com/assets/7608114/18419669/4d1701ac-782e-11e6-892c-e745c26030b8.gif)

**Bug**: for some reason, when not in dev mode, the dev menu reappears after placing furniture.  `Settings.GetSetting("DialogBoxSettings_developerModeToggle", false)` is returning true after turning off dev mode and saving. likely a seperate bug from this PR

Edit: the bug occours on master as well. opened issue #1275 for it.