### PR TITLE
Redo needs

### DIFF
--- a/Assets/Scripts/Models/Character.cs
+++ b/Assets/Scripts/Models/Character.cs
@@ -550,7 +550,7 @@ public class Character : IXmlSerializable, ISelectable, IContextActionProvider
         {
             Need need = needs[i];
             needs[i] = need.Clone();
-            needs[i].character = this;
+            needs[i].Character = this;
         }
     }
 

--- a/Assets/Scripts/Models/EventAction.cs
+++ b/Assets/Scripts/Models/EventAction.cs
@@ -123,7 +123,7 @@ public class EventActions : IXmlSerializable
     /// <param name="actionName">Name of the action being triggered.</param>
     /// <param name="target">Object, passed to LUA function as 1-argument (TODO: make it an object).</param>
     /// <param name="deltaTime">Time since last Trigger of this event.</param>
-    public void Trigger(string actionName, Furniture target, float deltaTime = 0f)
+    public void Trigger<T>(string actionName, T target, float deltaTime = 0f)
     {
         if (!actionsList.ContainsKey(actionName) || actionsList[actionName] == null)
         {
@@ -131,7 +131,7 @@ public class EventActions : IXmlSerializable
         }
         else
         {
-            FunctionsManager.Furniture.CallWithInstance(actionsList[actionName].ToArray(), target, deltaTime);
+            FunctionsManager.Get(target.GetType().ToString()).CallWithInstance(actionsList[actionName].ToArray(), target, deltaTime);
         }
     }
 }

--- a/Assets/Scripts/Models/EventAction.cs
+++ b/Assets/Scripts/Models/EventAction.cs
@@ -134,4 +134,14 @@ public class EventActions : IXmlSerializable
             FunctionsManager.Get(target.GetType().ToString()).CallWithInstance(actionsList[actionName].ToArray(), target, deltaTime);
         }
     }
+
+    /// <summary>
+    /// Determines whether this instance has any events named actionName.
+    /// </summary>
+    /// <returns><c>true</c> if this instance has any events named actionName; otherwise, <c>false</c>.</returns>
+    /// <param name="actionName">Action name.</param>
+    public bool HasEvent(string actionName)
+    {
+        return actionsList.ContainsKey(actionName);
+    }
 }

--- a/Assets/Scripts/Models/EventAction.cs
+++ b/Assets/Scripts/Models/EventAction.cs
@@ -121,7 +121,7 @@ public class EventActions : IXmlSerializable
     /// Fire the event named actionName, resulting in all lua functions being called.
     /// </summary>
     /// <param name="actionName">Name of the action being triggered.</param>
-    /// <param name="target">Object, passed to LUA function as 1-argument (TODO: make it an object).</param>
+    /// <param name="target">Object, passed to LUA function as 1-argument.</param>
     /// <param name="deltaTime">Time since last Trigger of this event.</param>
     public void Trigger<T>(string actionName, T target, float deltaTime = 0f)
     {

--- a/Assets/Scripts/Models/Functions/FunctionsManager.cs
+++ b/Assets/Scripts/Models/Functions/FunctionsManager.cs
@@ -88,7 +88,6 @@ public class FunctionsManager
         {
             return null;
         }
-
         if (actions.ContainsKey(name))
         {
             return actions[name];

--- a/Assets/Scripts/Models/Functions/FunctionsManager.cs
+++ b/Assets/Scripts/Models/Functions/FunctionsManager.cs
@@ -88,6 +88,7 @@ public class FunctionsManager
         {
             return null;
         }
+
         if (actions.ContainsKey(name))
         {
             return actions[name];

--- a/Assets/Scripts/Models/Need.cs
+++ b/Assets/Scripts/Models/Need.cs
@@ -122,21 +122,21 @@ public class Need : IPrototypable
         } 
         else if (Amount > 90f)
         {
-            if (EventActions != null && EventActions.HasEvent("OnSevereNeed"))
+            if (EventActions != null)
             {
                 EventActions.Trigger("OnSevereNeed", this, deltaTime);
             }
         }
         else if (Amount > 75f)
         {
-            if (EventActions != null && EventActions.HasEvent("OnCriticalNeed"))
+            if (EventActions != null)
             {
                 EventActions.Trigger("OnCriticalNeed", this, deltaTime);
             }
         }
         else if (Amount > 50f)
         {
-            if (EventActions != null && EventActions.HasEvent("OnModerateNeed"))
+            if (EventActions != null)
             {
                 EventActions.Trigger("OnModerateNeed", this, deltaTime);
             }

--- a/Assets/Scripts/Models/Need.cs
+++ b/Assets/Scripts/Models/Need.cs
@@ -102,7 +102,6 @@ public class Need : IPrototypable
     {
         if (EventActions != null && EventActions.HasEvent("OnUpdate"))
         {
-            // updateActions(this, deltaTime);
             EventActions.Trigger("OnUpdate", this, deltaTime);
         }
         else 
@@ -114,7 +113,6 @@ public class Need : IPrototypable
         {
             if (EventActions != null && EventActions.HasEvent("OnEmptyNeed"))
             {
-                // updateActions(this, deltaTime);
                 EventActions.Trigger("OnEmptyNeed", this, deltaTime);
             }
             else
@@ -126,7 +124,6 @@ public class Need : IPrototypable
         {
             if (EventActions != null && EventActions.HasEvent("OnSevereNeed"))
             {
-                // updateActions(this, deltaTime);
                 EventActions.Trigger("OnSevereNeed", this, deltaTime);
             }
         }
@@ -134,7 +131,6 @@ public class Need : IPrototypable
         {
             if (EventActions != null && EventActions.HasEvent("OnCriticalNeed"))
             {
-                // updateActions(this, deltaTime);
                 EventActions.Trigger("OnCriticalNeed", this, deltaTime);
             }
         }
@@ -142,7 +138,6 @@ public class Need : IPrototypable
         {
             if (EventActions != null && EventActions.HasEvent("OnModerateNeed"))
             {
-                // updateActions(this, deltaTime);
                 EventActions.Trigger("OnModerateNeed", this, deltaTime);
             }
         }

--- a/Assets/Scripts/Models/Need.cs
+++ b/Assets/Scripts/Models/Need.cs
@@ -43,7 +43,6 @@ public class Need : IPrototypable
         }
     }
 
-
     public Character Character { get; set; }
 
     public string Type { get; private set; }
@@ -101,16 +100,51 @@ public class Need : IPrototypable
     // Update is called once per frame
     public void Update(float deltaTime)
     {
-
-        if (EventActions != null)
+        if (EventActions != null && EventActions.HasEvent("OnUpdate"))
         {
             // updateActions(this, deltaTime);
             EventActions.Trigger("OnUpdate", this, deltaTime);
         }
+        else 
+        {
+            DefaultNeedDecay();
+        }
 
         if (Amount.AreEqual(100))
         {
-            // FIXME: Insert need fail damage code here.
+            if (EventActions != null && EventActions.HasEvent("OnEmptyNeed"))
+            {
+                // updateActions(this, deltaTime);
+                EventActions.Trigger("OnEmptyNeed", this, deltaTime);
+            }
+            else
+            {
+                DefaultEmptyNeed();
+            }
+        } 
+        else if (Amount > 90f)
+        {
+            if (EventActions != null && EventActions.HasEvent("OnSevereNeed"))
+            {
+                // updateActions(this, deltaTime);
+                EventActions.Trigger("OnSevereNeed", this, deltaTime);
+            }
+        }
+        else if (Amount > 75f)
+        {
+            if (EventActions != null && EventActions.HasEvent("OnCriticalNeed"))
+            {
+                // updateActions(this, deltaTime);
+                EventActions.Trigger("OnCriticalNeed", this, deltaTime);
+            }
+        }
+        else if (Amount > 50f)
+        {
+            if (EventActions != null && EventActions.HasEvent("OnModerateNeed"))
+            {
+                // updateActions(this, deltaTime);
+                EventActions.Trigger("OnModerateNeed", this, deltaTime);
+            }
         }
     }
 
@@ -183,5 +217,16 @@ public class Need : IPrototypable
     public Need Clone()
     {
         return new Need(this);
+    }
+
+    public void DefaultNeedDecay()
+    {
+        Amount += this.GrowthRate;
+    }
+
+    public void DefaultEmptyNeed()
+    {
+        // TODO: Default for empty need should probably be taking damage, but shouldn't be implemented until characters are 
+        //       better able to handle getting their oxygen and maybe have real space suits.
     }
 }

--- a/Assets/Scripts/Models/Need.cs
+++ b/Assets/Scripts/Models/Need.cs
@@ -153,7 +153,6 @@ public class Need : IPrototypable
         Type = parentReader.GetAttribute("type");
 
         XmlReader reader = parentReader.ReadSubtree();
-        List<string> luaActions = new List<string>();
 
         while (reader.Read())
         {

--- a/Assets/Scripts/Models/Need.cs
+++ b/Assets/Scripts/Models/Need.cs
@@ -106,7 +106,7 @@ public class Need : IPrototypable
         }
         else 
         {
-            DefaultNeedDecay();
+            DefaultNeedDecay(deltaTime);
         }
 
         if (Amount.AreEqual(100))
@@ -213,9 +213,9 @@ public class Need : IPrototypable
         return new Need(this);
     }
 
-    public void DefaultNeedDecay()
+    public void DefaultNeedDecay(float deltaTime)
     {
-        Amount += this.GrowthRate;
+        Amount += this.GrowthRate  * deltaTime;
     }
 
     public void DefaultEmptyNeed()

--- a/Assets/StreamingAssets/Data/Need.xml
+++ b/Assets/StreamingAssets/Data/Need.xml
@@ -2,14 +2,14 @@
 <Needs>
     <Need type="Oxygen">
         <Name>Oxygen</Name>
-        <GrowthRate>0</GrowthRate>
-        <GrowthInVacuum>0.1</GrowthInVacuum>
+        <GrowthRate>0.3</GrowthRate>
         <RestoreNeedFurnitureType>Oxygen Generator</RestoreNeedFurnitureType>
         <RestoreNeedTime>10</RestoreNeedTime>
         <RestoreNeedAmount>100</RestoreNeedAmount>
         <Damage>20</Damage>
         <CompleteOnFail>false</CompleteOnFail>
         <HighToLow>true</HighToLow>
+        <Action event="OnUpdate" functionName="OnUpdate_Oxygen" />
         <Localization>need_oxygen</Localization>
     </Need>
 

--- a/Assets/StreamingAssets/Data/Need.xml
+++ b/Assets/StreamingAssets/Data/Need.xml
@@ -16,7 +16,10 @@
     <Need type="Sleep">
         <Name>Sleep</Name>
         <RestoreNeedFurnitureType>simple_bed</RestoreNeedFurnitureType>
-        <GrowthRate>0.3</GrowthRate>
+        <!-- A GrowthRate of .15 approximates a "day (16 hours of awake time + 8 hours of sleep time)
+             that is approximately 1000 seconds long. RestoreNeedTime has not yet been adjusted to the
+             same approximation -->
+        <GrowthRate>0.15</GrowthRate>
         <RestoreNeedTime>30</RestoreNeedTime>
         <RestoreNeedAmount>100</RestoreNeedAmount>
         <Localization>need_sleep</Localization>

--- a/Assets/StreamingAssets/LUA/Need.lua
+++ b/Assets/StreamingAssets/LUA/Need.lua
@@ -11,8 +11,6 @@ function OnUpdate_Oxygen( need, deltaTime )
     else
         need.Amount = need.Amount - (need.GrowthRate * deltaTime)
     end
-    
-    return
 end
 
 ModUtils.ULog("Need.lua loaded")

--- a/Assets/StreamingAssets/LUA/Need.lua
+++ b/Assets/StreamingAssets/LUA/Need.lua
@@ -5,6 +5,15 @@
 
 ---------------------------- Need Actions --------------------------------
 
+function OnUpdate_Oxygen( need, deltaTime )
+    need.Amount = need.Amount + (need.GrowthRate * deltaTime)
 
+    if (need.Character != nil and need.Character.CurrTile.GetGasPressure("O2") < 0.15) then
+        need.Amount = need.Amount + ((0.3 - (0.3 * (need.Character.CurrTile.GetGasPressure("O2") * 5))) * deltaTime)
+    end
+    
+    return
+end
 
+ModUtils.ULog("Need.lua loaded")
 return "LUA Script Parsed!"

--- a/Assets/StreamingAssets/LUA/Need.lua
+++ b/Assets/StreamingAssets/LUA/Need.lua
@@ -6,10 +6,10 @@
 ---------------------------- Need Actions --------------------------------
 
 function OnUpdate_Oxygen( need, deltaTime )
-    need.Amount = need.Amount + (need.GrowthRate * deltaTime)
-
     if (need.Character != nil and need.Character.CurrTile.GetGasPressure("O2") < 0.15) then
         need.Amount = need.Amount + ((0.3 - (0.3 * (need.Character.CurrTile.GetGasPressure("O2") * 5))) * deltaTime)
+    else
+        need.Amount = need.Amount - (need.GrowthRate * deltaTime)
     end
     
     return


### PR DESCRIPTION
* Changes Needs to no longer have hardcoded decay specific to Oxygen.
* Needs fires EventActions for updates (for specific decay/regular gain implementation for a need), and for various severity levels of the need. If no OnUpdate EventAction is defined it will use a default Update to decay needs. OnEmptyNeed will also have default, but it currently does nothing as there is not yet good supporting framework, particularly for Oxygen, to have negative actions on an empty need.
* Needs still run from 0 (good) to 100 (bad - empty), as code outside of Need relies on that ordering, and I wanted to minimize files touched outside of Need, until the game could better support Need directly handling what a character does when a need needs fulfilled.

This includes changes to EventActions:
EventActions no longer specifically calls Furniture LUA functions, allows any target Type (that has Lua Functions).