### PR TITLE
Attach the events on World Setup

### DIFF
--- a/Assets/Scripts/Models/World.cs
+++ b/Assets/Scripts/Models/World.cs
@@ -77,8 +77,6 @@ public class World : IXmlSerializable
         // Make one character.
         CreateCharacter(GetTileAt(Width / 2, Height / 2, 0));
 
-        AddEventListeners();
-
         TestRoomGraphGeneration(this);
     }
 
@@ -87,7 +85,6 @@ public class World : IXmlSerializable
     /// </summary>
     public World()
     {
-        AddEventListeners();
     }
 
     /// <summary>
@@ -624,6 +621,8 @@ public class World : IXmlSerializable
         inventoryManager = new InventoryManager();
         PowerNetwork = new ProjectPorcupine.PowerNetwork.PowerNetwork();
         temperature = new Temperature(Width, Height);
+
+        AddEventListeners();
         LoadSkybox();
     }
 


### PR DESCRIPTION
Fixes #1305.

The serialization was creating a new World using the empty constructor and in doing so attaching the events, which triggered but everything in the world was empty. I moved the attachment to SetupWorld.