### PR TITLE
Furniture loss of power event

### DIFF
--- a/Assets/Scripts/Models/Furniture.cs
+++ b/Assets/Scripts/Models/Furniture.cs
@@ -422,10 +422,12 @@ public class Furniture : IXmlSerializable, ISelectable, IPrototypable, IContextA
             {
                 EventActions.Trigger("OnPowerOff", this, deltaTime);                
             }
+
             Jobs.PauseAll();
             prevUpdatePowerOn = false;
             return;
         }
+
         prevUpdatePowerOn = true;
         Jobs.ResumeAll();
 

--- a/Assets/Scripts/Models/Furniture.cs
+++ b/Assets/Scripts/Models/Furniture.cs
@@ -59,6 +59,9 @@ public class Furniture : IXmlSerializable, ISelectable, IPrototypable, IContextA
 
     private bool isOperating;
 
+    // did we have power in the last update?
+    private bool prevUpdatePowerOn;
+
     /// TODO: Implement object rotation
     /// <summary>
     /// Initializes a new instance of the <see cref="Furniture"/> class.
@@ -415,10 +418,15 @@ public class Furniture : IXmlSerializable, ISelectable, IPrototypable, IContextA
     {
         if (PowerConnection != null && PowerConnection.IsPowerConsumer && HasPower() == false)
         {
+            if (prevUpdatePowerOn)
+            {
+                EventActions.Trigger("OnPowerOff", this, deltaTime);                
+            }
             Jobs.PauseAll();
+            prevUpdatePowerOn = false;
             return;
         }
-
+        prevUpdatePowerOn = true;
         Jobs.ResumeAll();
 
         // TODO: some weird thing happens

--- a/Assets/Scripts/Models/State.meta
+++ b/Assets/Scripts/Models/State.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 657cf3fc7cb2c4c0b939c1129c9ccf50
+folderAsset: yes
+timeCreated: 1473204899
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/StreamingAssets/Data/Furniture.xml
+++ b/Assets/StreamingAssets/Data/Furniture.xml
@@ -204,8 +204,8 @@
             </Param>
         </Params>
 
-        <Action event="OnUpdate" functionName="OnUpdate_GasGenerator" />
-        <Action event="OnPowerOff" functionName="OnPowerOff_GasGenerator" />
+        <Action event="OnUpdate" functionName="OxygenGenerator_OnUpdate" />
+        <Action event="OnPowerOff" functionName="OxygenGenerator_OnPowerOff" />
       
         <LocalizationCode>furn_oxygen_generator</LocalizationCode>
         <UnlocalizedDescription>furn_oxygen_generator_desc</UnlocalizedDescription>
@@ -516,8 +516,8 @@
             <Param name="flow_rate" value="0.1" />
         </Params>
 
-        <Action event="OnUpdate" functionName="OnUpdate_OxygenCompressor" />
-        <Action event="OnPowerOff" functionName="OnPowerOff_OxygenCompressor" />
+        <Action event="OnUpdate" functionName="OxygenCompressor_OnUpdate" />
+        <Action event="OnPowerOff" functionName="OxygenCompressor_OnPowerOff" />
       
         <LocalizationCode>furn_oxygen_compressor</LocalizationCode>
         <UnlocalizedDescription>furn_oxygen_compressor_desc</UnlocalizedDescription>

--- a/Assets/StreamingAssets/Data/Furniture.xml
+++ b/Assets/StreamingAssets/Data/Furniture.xml
@@ -183,7 +183,7 @@
           <Animation state="idle" looping="false">
             <Frame name="Oxygen Generator" />
           </Animation>
-          <Animation state="running" fps="2" looping="true">
+          <Animation state="running" fps="8" looping="true">
             <Frame name="Oxygen_Generator_Running1" />
             <Frame name="Oxygen_Generator_Running2" />
             <Frame name="Oxygen_Generator_Running3" />
@@ -205,7 +205,8 @@
         </Params>
 
         <Action event="OnUpdate" functionName="OnUpdate_GasGenerator" />
-
+        <Action event="OnPowerOff" functionName="OnPowerOff_GasGenerator" />
+      
         <LocalizationCode>furn_oxygen_generator</LocalizationCode>
         <UnlocalizedDescription>furn_oxygen_generator_desc</UnlocalizedDescription>
     </Furniture>
@@ -501,8 +502,9 @@
             <Param name="flow_rate" value="0.1" />
         </Params>
 
-        <Action event="OnUpdate" functionName="OxygenCompressor_OnUpdate" />
-
+        <Action event="OnUpdate" functionName="OnUpdate_OxygenCompressor" />
+        <Action event="OnPowerOff" functionName="OnPowerOff_OxygenCompressor" />
+      
         <LocalizationCode>furn_oxygen_compressor</LocalizationCode>
         <UnlocalizedDescription>furn_oxygen_compressor_desc</UnlocalizedDescription>
     </Furniture>

--- a/Assets/StreamingAssets/Data/Furniture.xml
+++ b/Assets/StreamingAssets/Data/Furniture.xml
@@ -179,6 +179,17 @@
 
         <BuildingJob jobTime="0" />
 
+        <Animations>
+          <Animation state="idle" looping="false">
+            <Frame name="Oxygen Generator" />
+          </Animation>
+          <Animation state="running" fps="2" looping="true">
+            <Frame name="Oxygen_Generator_Running1" />
+            <Frame name="Oxygen_Generator_Running2" />
+            <Frame name="Oxygen_Generator_Running3" />
+          </Animation>
+        </Animations>
+      
         <Params>
             <!-- <Param name="gas_name" value="O2" /> -->
             <Param name="gas_limit" value="0.2" />
@@ -239,7 +250,7 @@
         <PowerConnection inputRate="" outputRate="5" capacity=""/>
 
         <Animations>
-            <Animation state="idle" fps="2" looping="false">
+            <Animation state="idle" looping="false">
                 <Frame name="Power-Generator-01" />
             </Animation>
             <Animation state="running" fps="6" looping="true">
@@ -281,7 +292,7 @@
         </DeconstructJob>
 
         <Animations>
-            <Animation state="idle" fps="1" looping="false">
+            <Animation state="idle" looping="false">
                 <Frame name="cloning_pod" />
             </Animation>
             <Animation state="running" fps="1" looping="true">
@@ -466,6 +477,21 @@
 
         <BuildingJob jobTime="2" />
 
+        <Animations>
+          <Animation state="running" valuebased="true">
+            <Frame name="compressor_oxygen" />
+            <Frame name="compressor_oxygen_0" />
+            <Frame name="compressor_oxygen_1" />
+            <Frame name="compressor_oxygen_2" />
+            <Frame name="compressor_oxygen_3" />
+            <Frame name="compressor_oxygen_4" />
+            <Frame name="compressor_oxygen_5" />
+            <Frame name="compressor_oxygen_6" />
+            <Frame name="compressor_oxygen_7" />
+            <Frame name="compressor_oxygen_8" />
+          </Animation>
+        </Animations>
+      
         <Params>
             <!-- <Param name="gas_name" value="O2" /> -->
             <Param name="max_gas_content" value="5" />
@@ -476,7 +502,6 @@
         </Params>
 
         <Action event="OnUpdate" functionName="OxygenCompressor_OnUpdate" />
-        <GetSpriteName FunctionName="OxygenCompressor_GetSpriteName" />
 
         <LocalizationCode>furn_oxygen_compressor</LocalizationCode>
         <UnlocalizedDescription>furn_oxygen_compressor_desc</UnlocalizedDescription>

--- a/Assets/StreamingAssets/LUA/Furniture.lua
+++ b/Assets/StreamingAssets/LUA/Furniture.lua
@@ -17,7 +17,7 @@ ENTERABILITY_SOON = 2
 -- ModUtils.ULogError("Testing ModUtils.ULogErrorChannel") -- Note: pauses the game
 
 -------------------------------- Furniture Actions --------------------------------
-function OnUpdate_GasGenerator( furniture, deltaTime )
+function OxygenGenerator_OnUpdate( furniture, deltaTime )
     if ( furniture.Tile.Room == nil ) then
 		return "Furniture's room was null."
 	end
@@ -34,7 +34,7 @@ function OnUpdate_GasGenerator( furniture, deltaTime )
 	furniture.SetAnimationState("running")
 end
 
-function OnPowerOff_GasGenerator( furniture, deltaTime )
+function OxygenGenerator_OnPowerOff( furniture, deltaTime )
 	furniture.SetAnimationState("idle")
 end
 
@@ -453,7 +453,7 @@ end
 
 -- Should maybe later be integrated with GasGenerator function by
 -- someone who knows how that would work in this case
-function OnUpdate_OxygenCompressor(furniture, deltaTime)
+function OxygenCompressor_OnUpdate(furniture, deltaTime)
     local room = furniture.Tile.Room
     local pressure = room.GetGasPressure("O2")
     local gasAmount = furniture.Parameters["flow_rate"].ToFloat() * deltaTime
@@ -473,11 +473,11 @@ function OnUpdate_OxygenCompressor(furniture, deltaTime)
             furniture.UpdateOnChanged(furniture)
         end
     end
-	furniture.SetAnimationState("running")
-	furniture.SetAnimationProgressValue(furniture.Parameters["gas_content"].ToFloat(), furniture.Parameters["max_gas_content"].ToFloat());
+    furniture.SetAnimationState("running")
+    furniture.SetAnimationProgressValue(furniture.Parameters["gas_content"].ToFloat(), furniture.Parameters["max_gas_content"].ToFloat());
 end
 
-function OnPowerOff_OxygenCompressor(furniture, deltaTime)
+function OxygenCompressor_OnPowerOff(furniture, deltaTime)
     -- lose half of gas, in case of blackout
 	local gasContent = furniture.Parameters["gas_content"].ToFloat()
 	if (gasContent > 0) then

--- a/Assets/StreamingAssets/LUA/Furniture.lua
+++ b/Assets/StreamingAssets/LUA/Furniture.lua
@@ -31,6 +31,7 @@ function OnUpdate_GasGenerator( furniture, deltaTime )
         end
     end
 	return
+	furniture.SetAnimationState("running") --TODO: how do we detect power?
 end
 
 function OnUpdate_Door( furniture, deltaTime )
@@ -467,16 +468,13 @@ function OxygenCompressor_OnUpdate(furniture, deltaTime)
             furniture.UpdateOnChanged(furniture)
         end
     end
-end
-
-function OxygenCompressor_GetSpriteName(furniture)
-    local baseName = furniture.Type
-    local suffix = 0
-    if (furniture.Parameters["gas_content"].ToFloat() > 0) then
-        idxAsFloat = 8 * (furniture.Parameters["gas_content"].ToFloat() / furniture.Parameters["max_gas_content"].ToFloat())
-        suffix = ModUtils.FloorToInt(idxAsFloat)
-    end
-    return baseName .. "_" .. suffix
+	--if (power == true) then
+	--	furniture.SetAnimationState("running")
+	--else
+	--	furniture.SetAnimationState("idle")
+	--end
+	furniture.SetAnimationState("running")
+	furniture.SetAnimationProgressValue(furniture.Parameters["gas_content"].ToFloat(), furniture.Parameters["max_gas_content"].ToFloat());
 end
 
 function SolarPanel_OnUpdate(furniture, deltaTime)

--- a/Assets/StreamingAssets/LUA/Furniture.lua
+++ b/Assets/StreamingAssets/LUA/Furniture.lua
@@ -31,8 +31,13 @@ function OnUpdate_GasGenerator( furniture, deltaTime )
         end
     end
 	return
-	furniture.SetAnimationState("running") --TODO: how do we detect power?
+	furniture.SetAnimationState("running")
 end
+
+function OnPowerOff_GasGenerator( furniture, deltaTime )
+	furniture.SetAnimationState("idle")
+end
+
 
 function OnUpdate_Door( furniture, deltaTime )
 	if (furniture.Parameters["is_opening"].ToFloat() >= 1.0) then
@@ -448,7 +453,7 @@ end
 
 -- Should maybe later be integrated with GasGenerator function by
 -- someone who knows how that would work in this case
-function OxygenCompressor_OnUpdate(furniture, deltaTime)
+function OnUpdate_OxygenCompressor(furniture, deltaTime)
     local room = furniture.Tile.Room
     local pressure = room.GetGasPressure("O2")
     local gasAmount = furniture.Parameters["flow_rate"].ToFloat() * deltaTime
@@ -468,13 +473,18 @@ function OxygenCompressor_OnUpdate(furniture, deltaTime)
             furniture.UpdateOnChanged(furniture)
         end
     end
-	--if (power == true) then
-	--	furniture.SetAnimationState("running")
-	--else
-	--	furniture.SetAnimationState("idle")
-	--end
 	furniture.SetAnimationState("running")
 	furniture.SetAnimationProgressValue(furniture.Parameters["gas_content"].ToFloat(), furniture.Parameters["max_gas_content"].ToFloat());
+end
+
+function OnPowerOff_OxygenCompressor(furniture, deltaTime)
+    -- lose half of gas, in case of blackout
+	local gasContent = furniture.Parameters["gas_content"].ToFloat()
+	if (gasContent > 0) then
+            furniture.Parameters["gas_content"].ChangeFloatValue(-gasContent/2)
+            furniture.UpdateOnChanged(furniture)
+    end
+    furniture.SetAnimationProgressValue(furniture.Parameters["gas_content"].ToFloat(), furniture.Parameters["max_gas_content"].ToFloat());
 end
 
 function SolarPanel_OnUpdate(furniture, deltaTime)


### PR DESCRIPTION
I added a trigger for furniture, when they lose power, as per issue #1312.

I used the new animation system for:

Oxygen generator - now animates, and when power is off it returns to idle state.

Oxygen compressor - This doesn't return to an idle state when turned off, but it leaks half of it's compressed gas. 
I'm not sure if that's the effect it should have, but it's a nice testcase for this event trigger, as we don't always want furniture to return to "idle" when unpowered.

Feedback is appreciated!