### PR TITLE
Fix context actions from lua

### DIFF
--- a/Assets/Scripts/Models/ContextMenu/ContextMenuAction.cs
+++ b/Assets/Scripts/Models/ContextMenu/ContextMenuAction.cs
@@ -16,6 +16,8 @@ public class ContextMenuAction
 
     public string Text { get; set; }
 
+    public string Parameter;
+
     public void OnClick(MouseController mouseController)
     {
         if (Action != null)

--- a/Assets/Scripts/Models/Furniture.cs
+++ b/Assets/Scripts/Models/Furniture.cs
@@ -965,7 +965,9 @@ public class Furniture : IXmlSerializable, ISelectable, IPrototypable, IContextA
                 {
                     Text = contextMenuLuaAction.Text,
                     RequireCharacterSelected = contextMenuLuaAction.RequireCharacterSelected,
+                    // TODO This could be done via a lambda, but it always uses the same space of memory, thus if 2 actions are performed, the same action will be produced for each.
                     Action = InvokeContextMenuLuaAction,
+                    // Note that this is only in place because of the problem with the previous statement.
                     Parameter = contextMenuLuaAction.LuaFunction
                 };
             }

--- a/Assets/Scripts/Models/Furniture.cs
+++ b/Assets/Scripts/Models/Furniture.cs
@@ -961,14 +961,13 @@ public class Furniture : IXmlSerializable, ISelectable, IPrototypable, IContextA
             if (!contextMenuLuaAction.DevModeOnly ||
                 Settings.GetSetting("DialogBoxSettings_developerModeToggle", false))
             {
+                // TODO The Action could be done via a lambda, but it always uses the same space of memory, thus if 2 actions are performed, the same action will be produced for each.
                 yield return new ContextMenuAction
                 {
                     Text = contextMenuLuaAction.Text,
                     RequireCharacterSelected = contextMenuLuaAction.RequireCharacterSelected,
-                    // TODO This could be done via a lambda, but it always uses the same space of memory, thus if 2 actions are performed, the same action will be produced for each.
                     Action = InvokeContextMenuLuaAction,
-                    // Note that this is only in place because of the problem with the previous statement.
-                    Parameter = contextMenuLuaAction.LuaFunction
+                    Parameter = contextMenuLuaAction.LuaFunction    // Note that this is only in place because of the problem with the previous statement.
                 };
             }
         }

--- a/Assets/Scripts/Models/Furniture.cs
+++ b/Assets/Scripts/Models/Furniture.cs
@@ -617,7 +617,7 @@ public class Furniture : IXmlSerializable, ISelectable, IPrototypable, IContextA
                     {
                         LuaFunction = reader.GetAttribute("FunctionName"),
                         Text = reader.GetAttribute("Text"),
-                        RequiereCharacterSelected = bool.Parse(reader.GetAttribute("RequiereCharacterSelected")),
+                        RequireCharacterSelected = bool.Parse(reader.GetAttribute("RequireCharacterSelected")),
                         DevModeOnly = bool.Parse(reader.GetAttribute("DevModeOnly") ?? "false")
                     });
                     break;
@@ -964,8 +964,9 @@ public class Furniture : IXmlSerializable, ISelectable, IPrototypable, IContextA
                 yield return new ContextMenuAction
                 {
                     Text = contextMenuLuaAction.Text,
-                    RequireCharacterSelected = contextMenuLuaAction.RequiereCharacterSelected,
-                    Action = (cma, c) => InvokeContextMenuLuaAction(contextMenuLuaAction.LuaFunction, c)
+                    RequireCharacterSelected = contextMenuLuaAction.RequireCharacterSelected,
+                    Action = InvokeContextMenuLuaAction,
+                    Parameter = contextMenuLuaAction.LuaFunction
                 };
             }
         }
@@ -1051,9 +1052,9 @@ public class Furniture : IXmlSerializable, ISelectable, IPrototypable, IContextA
         function(this, arg);
     }
 
-    private void InvokeContextMenuLuaAction(string luaFunction, Character character)
+    private void InvokeContextMenuLuaAction(ContextMenuAction action, Character character)
     {
-        FunctionsManager.Furniture.Call(luaFunction, this, character);
+        FunctionsManager.Furniture.Call(action.Parameter, this, character);
     }
 
     [MoonSharpVisible(true)]


### PR DESCRIPTION
There is an unusual bug that this fixes that is caused by the "Action" being placed in the same piece of memory for each object yielded. The bottom line is, only the second action was possible. I'm not sure why this is the case, and I tried many means to force the two to occupy different pieces of memory, but I failed. This workaround, however, works well, and it can make it easier to debug such issues in the future.