### PR TITLE
[Small, Fix] Fix Vent Sprite Animation order

### DIFF
--- a/Assets/StreamingAssets/Data/Furniture.xml
+++ b/Assets/StreamingAssets/Data/Furniture.xml
@@ -599,12 +599,12 @@
 
         <Animations>
             <Animation state="horizontal" valuebased="true">
-                <Frame name="vent_EW_Opened" />
                 <Frame name="vent_EW_Closed" />
+                <Frame name="vent_EW_Opened" />
             </Animation>  
             <Animation state="vertical" valuebased="true">
-                <Frame name="vent_NS_Opened" />
-                <Frame name="vent_NS_Closed" />             
+                <Frame name="vent_NS_Closed" />  
+                <Frame name="vent_NS_Opened" />           
             </Animation>                      
         </Animations>
         


### PR DESCRIPTION
I defined the value based animation for the vent in the wrong order, leading to it using the closed sprite for the opened state and vice versa. It however wasn't noticeable due to also having the sprites defined incorrectly in XML.

The Sprite XML should be fixed in #1379, this just fixes the animation state definition.