### PR TITLE
[Tiny] Correct order of animation frames for Vent sprite

### DIFF
--- a/Assets/StreamingAssets/Data/Furniture.xml
+++ b/Assets/StreamingAssets/Data/Furniture.xml
@@ -599,12 +599,12 @@
 
         <Animations>
             <Animation state="horizontal" valuebased="true">
-                <Frame name="vent_EW_Opened" />
                 <Frame name="vent_EW_Closed" />
+                <Frame name="vent_EW_Opened" />
             </Animation>  
             <Animation state="vertical" valuebased="true">
-                <Frame name="vent_NS_Opened" />
                 <Frame name="vent_NS_Closed" />             
+                <Frame name="vent_NS_Opened" />
             </Animation>                      
         </Animations>
         


### PR DESCRIPTION
Fix #1384