### PR TITLE
Adding Utilities to possible Context Menu Actions

### DIFF
--- a/Assets/Scripts/UI/ContextMenu/ContextMenu.cs
+++ b/Assets/Scripts/UI/ContextMenu/ContextMenu.cs
@@ -91,6 +91,14 @@ public class ContextMenu : MonoBehaviour
             providers.Add(tile.Furniture);
         }
 
+        if (tile.Utilities != null)
+        {
+            foreach (Utility utility in tile.Utilities.Values)
+            {
+                providers.Add(utility);
+            }
+        }
+
         if (tile.Characters != null)
         {
             foreach (Character character in tile.Characters)


### PR DESCRIPTION
While working on deconstructing utilities, I found the context menus for utilities weren't wired up. I've addressed that issue with this PR.