### PR TITLE
Add a fast update (every frame)  to furniture to allow smooth animation

### DIFF
--- a/Assets/Scripts/Models/Area/World.cs
+++ b/Assets/Scripts/Models/Area/World.cs
@@ -187,6 +187,12 @@ public class World : IXmlSerializable
     public void TickEveryFrame(float deltaTime)
     {
         CharacterManager.Update(deltaTime);
+
+        // Update Furniture (fast track)
+        foreach (Furniture furniture in furnitures)
+        {
+            furniture.EveryFrameUpdate(deltaTime);
+        }
     }
 
     public void TickFixedFrequency(float deltaTime)
@@ -194,7 +200,7 @@ public class World : IXmlSerializable
         // Update Furniture
         foreach (Furniture f in furnitures)
         {
-            f.Update(deltaTime);
+            f.FixedFrequencyUpdate(deltaTime);
         }
 
         // Progress temperature modelling

--- a/Assets/Scripts/Models/Buildable/Furniture.cs
+++ b/Assets/Scripts/Models/Buildable/Furniture.cs
@@ -71,7 +71,6 @@ public class Furniture : IXmlSerializable, ISelectable, IPrototypable, IContextA
         Tint = Color.white;
         VerticalDoor = false;
         EventActions = new EventActions();
-        FrameActions = new EventActions();
         
         contextMenuLuaActions = new List<ContextMenuLuaAction>();
         Parameters = new Parameter();
@@ -116,11 +115,6 @@ public class Furniture : IXmlSerializable, ISelectable, IPrototypable, IContextA
         if (other.EventActions != null)
         {
             EventActions = other.EventActions.Clone();
-        }
-
-        if (other.FrameActions != null)
-        {
-            FrameActions = other.FrameActions.Clone();
         }
         
         if (other.contextMenuLuaActions != null)
@@ -207,16 +201,7 @@ public class Furniture : IXmlSerializable, ISelectable, IPrototypable, IContextA
     /// </summary>
     /// <value>The event actions that is called on update.</value>
     public EventActions EventActions { get; private set; }
-
-    /// <summary>
-    /// Use lightly
-    /// Gets the FrameAction for the current furniture.
-    /// These actions are called every frame. They get passed the furniture
-    /// they belong to, plus a deltaTime (which defaults to 0).
-    /// </summary>
-    /// <value>The event actions that is called on update.</value>
-    public EventActions FrameActions { get; private set; }
-
+    
     /// <summary>
     /// Gets the Connection that the furniture has to the power system.
     /// </summary>
@@ -440,11 +425,16 @@ public class Furniture : IXmlSerializable, ISelectable, IPrototypable, IContextA
         return obj;
     }
 
+    /// <summary>
+    /// This function is called to update the furniture animation in lua.
+    /// This will be called every frame and should be used carefully.
+    /// </summary>
+    /// <param name="deltaTime">The time since the last update was called.</param>
     public void EveryFrameUpdate(float deltaTime)
     {
-        if (FrameActions != null)
+        if (EventActions != null)
         {
-            FrameActions.Trigger("OnUpdate", this, deltaTime);
+            EventActions.Trigger("OnFastUpdate", this, deltaTime);
         }
     }
 
@@ -660,11 +650,6 @@ public class Furniture : IXmlSerializable, ISelectable, IPrototypable, IContextA
                     XmlReader subtree = reader.ReadSubtree();
                     EventActions.ReadXml(subtree);
                     subtree.Close();
-                    break;
-                case "FrameAction":
-                    XmlReader frame_subtree = reader.ReadSubtree();
-                    FrameActions.ReadXml(frame_subtree);
-                    frame_subtree.Close();
                     break;
                 case "ContextMenuAction":
                     contextMenuLuaActions.Add(new ContextMenuLuaAction

--- a/Assets/Scripts/Models/Buildable/Furniture.cs
+++ b/Assets/Scripts/Models/Buildable/Furniture.cs
@@ -71,6 +71,7 @@ public class Furniture : IXmlSerializable, ISelectable, IPrototypable, IContextA
         Tint = Color.white;
         VerticalDoor = false;
         EventActions = new EventActions();
+        FrameActions = new EventActions();
         
         contextMenuLuaActions = new List<ContextMenuLuaAction>();
         Parameters = new Parameter();
@@ -115,6 +116,11 @@ public class Furniture : IXmlSerializable, ISelectable, IPrototypable, IContextA
         if (other.EventActions != null)
         {
             EventActions = other.EventActions.Clone();
+        }
+
+        if (other.FrameActions != null)
+        {
+            FrameActions = other.FrameActions.Clone();
         }
         
         if (other.contextMenuLuaActions != null)
@@ -201,6 +207,15 @@ public class Furniture : IXmlSerializable, ISelectable, IPrototypable, IContextA
     /// </summary>
     /// <value>The event actions that is called on update.</value>
     public EventActions EventActions { get; private set; }
+
+    /// <summary>
+    /// Use lightly
+    /// Gets the FrameAction for the current furniture.
+    /// These actions are called every frame. They get passed the furniture
+    /// they belong to, plus a deltaTime (which defaults to 0).
+    /// </summary>
+    /// <value>The event actions that is called on update.</value>
+    public EventActions FrameActions { get; private set; }
 
     /// <summary>
     /// Gets the Connection that the furniture has to the power system.
@@ -425,12 +440,20 @@ public class Furniture : IXmlSerializable, ISelectable, IPrototypable, IContextA
         return obj;
     }
 
+    public void EveryFrameUpdate(float deltaTime)
+    {
+        if (FrameActions != null)
+        {
+            FrameActions.Trigger("OnUpdate", this, deltaTime);
+        }
+    }
+
     /// <summary>
     /// This function is called to update the furniture. This will also trigger EventsActions.
     /// This checks if the furniture is a PowerConsumer, and if it does not have power it cancels its job.
     /// </summary>
     /// <param name="deltaTime">The time since the last update was called.</param>
-    public void Update(float deltaTime)
+    public void FixedFrequencyUpdate(float deltaTime)
     {
         if (PowerConnection != null && PowerConnection.IsPowerConsumer && HasPower() == false)
         {
@@ -637,6 +660,11 @@ public class Furniture : IXmlSerializable, ISelectable, IPrototypable, IContextA
                     XmlReader subtree = reader.ReadSubtree();
                     EventActions.ReadXml(subtree);
                     subtree.Close();
+                    break;
+                case "FrameAction":
+                    XmlReader frame_subtree = reader.ReadSubtree();
+                    FrameActions.ReadXml(frame_subtree);
+                    frame_subtree.Close();
                     break;
                 case "ContextMenuAction":
                     contextMenuLuaActions.Add(new ContextMenuLuaAction

--- a/Assets/Scripts/Models/Events/EventAction.cs
+++ b/Assets/Scripts/Models/Events/EventAction.cs
@@ -48,7 +48,7 @@ public class EventActions : IXmlSerializable
         reader.Read();
         if (reader.Name != "Action")
         {
-            Debug.ULogErrorChannel("EventActions", string.Format("The element is not an Action or a FrameAction, but a \"{0}\"", reader.Name));
+            Debug.ULogErrorChannel("EventActions", string.Format("The element is not an Action, but a \"{0}\"", reader.Name));
         }
 
         string name = reader.GetAttribute("event");

--- a/Assets/Scripts/Models/Events/EventAction.cs
+++ b/Assets/Scripts/Models/Events/EventAction.cs
@@ -46,7 +46,7 @@ public class EventActions : IXmlSerializable
     public void ReadXml(XmlReader reader)
     {
         reader.Read();
-        if (reader.Name != "Action" && reader.Name != "FrameAction")
+        if (reader.Name != "Action")
         {
             Debug.ULogErrorChannel("EventActions", string.Format("The element is not an Action or a FrameAction, but a \"{0}\"", reader.Name));
         }

--- a/Assets/Scripts/Models/Events/EventAction.cs
+++ b/Assets/Scripts/Models/Events/EventAction.cs
@@ -46,9 +46,9 @@ public class EventActions : IXmlSerializable
     public void ReadXml(XmlReader reader)
     {
         reader.Read();
-        if (reader.Name != "Action")
+        if (reader.Name != "Action" && reader.Name != "FrameAction")
         {
-            Debug.ULogErrorChannel("EventActions", string.Format("The element is not an Action, but a \"{0}\"", reader.Name));
+            Debug.ULogErrorChannel("EventActions", string.Format("The element is not an Action or a FrameAction, but a \"{0}\"", reader.Name));
         }
 
         string name = reader.GetAttribute("event");

--- a/Assets/StreamingAssets/Data/Furniture.xml
+++ b/Assets/StreamingAssets/Data/Furniture.xml
@@ -88,7 +88,7 @@
             <Param name="thermal_diffusivity" value="0.0001" />
         </Params>
 
-        <FrameAction event="OnUpdate" functionName="OnUpdate_Door" />
+        <Action event="OnFastUpdate" functionName="OnUpdate_Door" />
         <Action event="OnUpdate" functionName="OnUpdate_Leak_Door" />
 
         <IsEnterable FunctionName="IsEnterable_Door" />
@@ -150,7 +150,7 @@
             <Param name="pressure_locked" value="0" />
         </Params>
 
-        <FrameAction event="OnUpdate" functionName="OnUpdate_AirlockDoor" />
+        <Action event="OnFastUpdate" functionName="OnUpdate_AirlockDoor" />
         <Action event="OnUpdate" functionName="OnUpdate_Leak_Airlock" />
 
         <ContextMenuAction FunctionName="AirlockDoor_Toggle_Pressure_Lock" Text="Toggle Pressure Lock" RequireCharacterSelected="false"/>

--- a/Assets/StreamingAssets/Data/Furniture.xml
+++ b/Assets/StreamingAssets/Data/Furniture.xml
@@ -88,7 +88,7 @@
             <Param name="thermal_diffusivity" value="0.0001" />
         </Params>
 
-        <Action event="OnUpdate" functionName="OnUpdate_Door" />
+        <FrameAction event="OnUpdate" functionName="OnUpdate_Door" />
         <Action event="OnUpdate" functionName="OnUpdate_Leak_Door" />
 
         <IsEnterable FunctionName="IsEnterable_Door" />
@@ -150,7 +150,7 @@
             <Param name="pressure_locked" value="0" />
         </Params>
 
-        <Action event="OnUpdate" functionName="OnUpdate_AirlockDoor" />
+        <FrameAction event="OnUpdate" functionName="OnUpdate_AirlockDoor" />
         <Action event="OnUpdate" functionName="OnUpdate_Leak_Airlock" />
 
         <ContextMenuAction FunctionName="AirlockDoor_Toggle_Pressure_Lock" Text="Toggle Pressure Lock" RequireCharacterSelected="false"/>


### PR DESCRIPTION
Fixes #1383 

Duplicate the EventAction in furniture to add FrameAction

EventAction behavior unchanged
FrameAction will be call every frame, so animation can be smooth

Fix the "door slam open effect"