### PR TITLE
[Hotfix] Disables the prototype reserving the space for now

### DIFF
--- a/Assets/Scripts/Controllers/InputOutput/BuildModeController.cs
+++ b/Assets/Scripts/Controllers/InputOutput/BuildModeController.cs
@@ -148,6 +148,8 @@ public class BuildModeController
                     WorldController.Instance.World.jobQueue.Enqueue(job);
 
                     // Let our workspot tile know it is reserved for us
+                    // FIXME This was commented out because it breaks the validity check when trying to build most furniture. 
+                    // It specifically breaks tile2.IsReservedWorkSpot() in Furniture:DefaultIsValidPosition
                     //World.Current.ReserveTileAsWorkSpot((Furniture)job.buildablePrototype, job.tile);
                 }
             }

--- a/Assets/Scripts/Controllers/InputOutput/BuildModeController.cs
+++ b/Assets/Scripts/Controllers/InputOutput/BuildModeController.cs
@@ -148,7 +148,7 @@ public class BuildModeController
                     WorldController.Instance.World.jobQueue.Enqueue(job);
 
                     // Let our workspot tile know it is reserved for us
-                    World.Current.ReserveTileAsWorkSpot((Furniture)job.buildablePrototype, job.tile);
+                    //World.Current.ReserveTileAsWorkSpot((Furniture)job.buildablePrototype, job.tile);
                 }
             }
         }

--- a/Assets/Scripts/Models/Buildable/Furniture.cs
+++ b/Assets/Scripts/Models/Buildable/Furniture.cs
@@ -1062,6 +1062,7 @@ public class Furniture : IXmlSerializable, ISelectable, IPrototypable, IContextA
                     return false;
                 }
 
+                // FIXME This line breaks the validity checks if the tile is reserved to build this piece of furniture!
                 // Make sure we're not building on another furniture's workspot
                 if (tile2.IsReservedWorkSpot())
                 {


### PR DESCRIPTION
#1352 set up the ability to have build locations that aren't on the main part of the furniture. It seems that this will cause anything that has a build spot on the furniture, or no build spot, to not work. I've commented out this line until we can properly resolve that issue.