### PR TITLE
Reenable pending furniture workspot reservation, unreserve before furniture placement

### DIFF
--- a/Assets/Scripts/Controllers/InputOutput/BuildModeController.cs
+++ b/Assets/Scripts/Controllers/InputOutput/BuildModeController.cs
@@ -148,9 +148,7 @@ public class BuildModeController
                     WorldController.Instance.World.jobQueue.Enqueue(job);
 
                     // Let our workspot tile know it is reserved for us
-                    // FIXME This was commented out because it breaks the validity check when trying to build most furniture. 
-                    // It specifically breaks tile2.IsReservedWorkSpot() in Furniture:DefaultIsValidPosition
-                    //World.Current.ReserveTileAsWorkSpot((Furniture)job.buildablePrototype, job.tile);
+                    World.Current.ReserveTileAsWorkSpot((Furniture)job.buildablePrototype, job.tile);
                 }
             }
         }

--- a/Assets/Scripts/Models/Buildable/Furniture.cs
+++ b/Assets/Scripts/Models/Buildable/Furniture.cs
@@ -1062,7 +1062,6 @@ public class Furniture : IXmlSerializable, ISelectable, IPrototypable, IContextA
                     return false;
                 }
 
-                // FIXME This line breaks the validity checks if the tile is reserved to build this piece of furniture!
                 // Make sure we're not building on another furniture's workspot
                 if (tile2.IsReservedWorkSpot())
                 {

--- a/Assets/Scripts/Models/Functions/FunctionsManager.cs
+++ b/Assets/Scripts/Models/Functions/FunctionsManager.cs
@@ -110,10 +110,11 @@ public class FunctionsManager
     // TODO: Move this function to a better place
     public static void JobComplete_FurnitureBuilding(Job theJob)
     {
-        WorldController.Instance.World.PlaceFurniture(theJob.JobObjectType, theJob.tile);
-
         // Let our workspot tile know it is no longer reserved for us
         WorldController.Instance.World.UnreserveTileAsWorkSpot((Furniture)theJob.buildablePrototype, theJob.tile);
+
+        WorldController.Instance.World.PlaceFurniture(theJob.JobObjectType, theJob.tile);
+
 
         // FIXME: I don't like having to manually and explicitly set
         // flags that prevent conflicts. It's too easy to forget to set/clear them!

--- a/Assets/Scripts/Models/Functions/FunctionsManager.cs
+++ b/Assets/Scripts/Models/Functions/FunctionsManager.cs
@@ -115,7 +115,6 @@ public class FunctionsManager
 
         WorldController.Instance.World.PlaceFurniture(theJob.JobObjectType, theJob.tile);
 
-
         // FIXME: I don't like having to manually and explicitly set
         // flags that prevent conflicts. It's too easy to forget to set/clear them!
         theJob.tile.PendingBuildJob = null;


### PR DESCRIPTION
Reverts #1403 and replaces with a fix to the problem patched by 1403 by unreserving the workspot prior to trying to place the furniture.