### PR TITLE
Fix Lua references to room.GetSize to use room.TileCount

### DIFF
--- a/Assets/Scripts/Models/Functions/LuaFunctions.cs
+++ b/Assets/Scripts/Models/Functions/LuaFunctions.cs
@@ -123,7 +123,7 @@ public class LuaFunctions
                 result = Call(fn, instance);
             }
 
-            if (result.Type == DataType.String)
+            if (result != null && result.Type == DataType.String)
             {
                 Debug.ULogErrorChannel("Lua", result.String);
             }

--- a/Assets/StreamingAssets/LUA/Furniture.lua
+++ b/Assets/StreamingAssets/LUA/Furniture.lua
@@ -442,7 +442,7 @@ function Heater_UpdateTemperature( furniture, deltaTime)
     end
     
     tile = furniture.tile
-    pressure = tile.Room.GetGasPressure() / tile.Room.GetSize()
+    pressure = tile.Room.GetGasPressure() / tile.Room.TileCount
     efficiency = ModUtils.Clamp01(pressure / furniture.Parameters["pressure_threshold"].ToFloat())
     temperatureChangePerSecond = furniture.Parameters["base_heating"].ToFloat() * efficiency
     temperatureChange = temperatureChangePerSecond * deltaTime
@@ -462,14 +462,14 @@ function OxygenCompressor_OnUpdate(furniture, deltaTime)
         -- Expel gas if available
         if (furniture.Parameters["gas_content"].ToFloat() > 0) then
             furniture.Parameters["gas_content"].ChangeFloatValue(-gasAmount)
-            room.ChangeGas("O2", gasAmount / room.GetSize())
+            room.ChangeGas("O2", gasAmount / room.TileCount)
             furniture.UpdateOnChanged(furniture)
         end
     elseif (pressure > furniture.Parameters["take_threshold"].ToFloat()) then
         -- Suck in gas if not full
         if (furniture.Parameters["gas_content"].ToFloat() < furniture.Parameters["max_gas_content"].ToFloat()) then
             furniture.Parameters["gas_content"].ChangeFloatValue(gasAmount)
-            room.ChangeGas("O2", -gasAmount / room.GetSize())
+            room.ChangeGas("O2", -gasAmount / room.TileCount)
             furniture.UpdateOnChanged(furniture)
         end
     end
@@ -670,7 +670,7 @@ function Rtg_UpdateTemperature( furniture, deltaTime)
     end
     
     tile = furniture.tile
-    pressure = tile.Room.GetGasPressure() / tile.Room.GetSize()
+    pressure = tile.Room.GetGasPressure() / tile.Room.TileCount
     efficiency = ModUtils.Clamp01(pressure / furniture.Parameters["pressure_threshold"].ToFloat())
     temperatureChangePerSecond = furniture.Parameters["base_heating"].ToFloat() * efficiency
     temperatureChange = temperatureChangePerSecond * deltaTime


### PR DESCRIPTION
PR #1072 made the change in Room and all C# code, but neglected to check
for Lua references. These wound up giving error (c.f. #1406).

This just changes to references to the new name.

Also added a null check in LuaFunctions::CallWithInstance because the
return value of the Lua call can be null.

Fixes #1406.