### PR TITLE
[Fixes #1405] Fix Room Splitting

### DIFF
--- a/Assets/Scripts/Models/Area/RoomManager.cs
+++ b/Assets/Scripts/Models/Area/RoomManager.cs
@@ -222,7 +222,7 @@ namespace ProjectPorcupine.Rooms
                 // Try building new rooms for each of our NESW directions.
                 foreach (Tile t in sourceTile.GetNeighbours())
                 {
-                    if (t != null && t.Room != null && t.Room.IsOutsideRoom())
+                    if (t != null && t.Room != null)
                     {
                         Room newRoom = ActualFloodFill(t, oldRoom, sizeOfOldRoom);
 


### PR DESCRIPTION
Rooms were only being split if they were the outside room. This removes the check for outside room which is no longer needed.