### PR TITLE
Fix for workshop jobs getting cancelled

### DIFF
--- a/Assets/Scripts/Models/Buildable/FurnitureWorkshop.cs
+++ b/Assets/Scripts/Models/Buildable/FurnitureWorkshop.cs
@@ -259,13 +259,7 @@ public class FurnitureWorkshop
                     furniture.Tile.Y + reqInputItem.SlotPosY,
                     furniture.Tile.Z);
 
-                //// TODO: this is from LUA .. looks like some hack
-                if (inTile.Inventory != null && inTile.Inventory.StackSize == inTile.Inventory.MaxStackSize)
-                {
-                    furniture.Jobs.CancelAll();
-                    return;
-                }
-
+                // create job for desired input resource
                 string desiredInv = reqInputItem.ObjectType;
                 int desiredAmount = PrototypeManager.Inventory.Get(desiredInv).maxStackSize;
                 if (inTile.Inventory != null && inTile.Inventory.Type == reqInputItem.ObjectType &&


### PR DESCRIPTION
Power cell should now get all the materials needed:
![image](https://cloud.githubusercontent.com/assets/12616499/18623406/f45deac0-7e3c-11e6-9eb6-3d9ff275738a.png)
removed old code (evidently not active until recently)
This should fix #1311 and hopefully #975 is now testable again..