### PR TITLE
Furniture progress info and power cell usage

### DIFF
--- a/Assets/Scripts/Models/Buildable/Furniture.cs
+++ b/Assets/Scripts/Models/Buildable/Furniture.cs
@@ -34,6 +34,11 @@ public class Furniture : IXmlSerializable, ISelectable, IPrototypable, IContextA
     /// </summary>
     private string getSpriteNameAction;
 
+    /// <summary>
+    /// This action is called to get the progress info based on the furniture parameters.
+    /// </summary>
+    private string getProgressInfoNameAction;
+
     private List<string> replaceableFurniture = new List<string>();
 
     /// <summary>
@@ -124,6 +129,7 @@ public class Furniture : IXmlSerializable, ISelectable, IPrototypable, IContextA
 
         isEnterableAction = other.isEnterableAction;
         getSpriteNameAction = other.getSpriteNameAction;
+        getProgressInfoNameAction = other.getProgressInfoNameAction;
 
         if (other.PowerConnection != null)
         {
@@ -653,6 +659,9 @@ public class Furniture : IXmlSerializable, ISelectable, IPrototypable, IContextA
                 case "GetSpriteName":
                     getSpriteNameAction = reader.GetAttribute("FunctionName");
                     break;
+                case "GetProgressInfo":
+                    getProgressInfoNameAction = reader.GetAttribute("functionName");
+                    break;
                 case "JobSpotOffset":
                     Jobs.ReadWorkSpotOffset(reader);
                     break;
@@ -881,6 +890,19 @@ public class Furniture : IXmlSerializable, ISelectable, IPrototypable, IContextA
         return string.Empty;
     }
 
+    public string GetProgressInfo()
+    {
+        if (string.IsNullOrEmpty(getProgressInfoNameAction))
+        {
+            return string.Empty;
+        }
+        else
+        {
+            DynValue ret = FunctionsManager.Furniture.Call(getProgressInfoNameAction, this);
+            return ret.String;
+        }
+    }
+
     public IEnumerable<string> GetAdditionalInfo()
     {
         if (IsWorkshop)
@@ -912,6 +934,8 @@ public class Furniture : IXmlSerializable, ISelectable, IPrototypable, IContextA
                 yield return string.Format("Power Accumulated: {0} / {1}", PowerConnection.AccumulatedPower, PowerConnection.Capacity);
             }
         }
+
+        yield return GetProgressInfo();
     }
 
     /// <summary>

--- a/Assets/Scripts/Models/Buildable/FurnitureWorkshop.cs
+++ b/Assets/Scripts/Models/Buildable/FurnitureWorkshop.cs
@@ -259,13 +259,7 @@ public class FurnitureWorkshop
                     furniture.Tile.Y + reqInputItem.SlotPosY,
                     furniture.Tile.Z);
 
-                //// TODO: this is from LUA .. looks like some hack
-                if (inTile.Inventory != null && inTile.Inventory.StackSize == inTile.Inventory.MaxStackSize)
-                {
-                    furniture.Jobs.CancelAll();
-                    return;
-                }
-
+                // create job for desired input resource
                 string desiredInv = reqInputItem.ObjectType;
                 int desiredAmount = PrototypeManager.Inventory.Get(desiredInv).maxStackSize;
                 if (inTile.Inventory != null && inTile.Inventory.Type == reqInputItem.ObjectType &&

--- a/Assets/Scripts/PowerNetwork/Connection.cs
+++ b/Assets/Scripts/PowerNetwork/Connection.cs
@@ -159,7 +159,7 @@ namespace ProjectPorcupine.PowerNetwork
         private bool IsNewThresholdReached(float oldAccumulatedPower)
         {
             int thresholdMovingDirection = oldAccumulatedPower < accumulatedPower ? 1 : -1;
-            int nextThesholdIndex = (currentThresholdIndex + thresholdMovingDirection).Clamp(0, capacityThresholds.Length);
+            int nextThesholdIndex = (currentThresholdIndex + thresholdMovingDirection).Clamp(0, capacityThresholds.Length - 1);
             double nextThreshold = capacityThresholds[nextThesholdIndex];
 
             if ((thresholdMovingDirection > 0 && accumulatedPower >= nextThreshold * Capacity) ||

--- a/Assets/StreamingAssets/Data/Furniture.xml
+++ b/Assets/StreamingAssets/Data/Furniture.xml
@@ -276,9 +276,10 @@
 
         <Params>
             <Param name="burnTime" value="0" />
-            <Param name="burnTimeRequired" value="10" />
+            <Param name="burnTimeRequired" value="30" />
         </Params>
 
+        <GetProgressInfo functionName="PowerGenerator_FuelInfo" />
         <Action event="OnUpdate" functionName="PowerGenerator_UpdateAction" />
 
         <LocalizationCode>furn_power_generator</LocalizationCode>

--- a/Assets/StreamingAssets/LUA/Furniture.lua
+++ b/Assets/StreamingAssets/LUA/Furniture.lua
@@ -385,7 +385,7 @@ end
 function PowerGenerator_UpdateAction(furniture, deltatime)
     if (furniture.Jobs.Count() < 1 and furniture.Parameters["burnTime"].ToFloat() == 0) then
         furniture.PowerConnection.OutputRate = 0
-        local itemsDesired = {Inventory.__new("Uranium", 0, 5)}
+        local itemsDesired = {Inventory.__new("Power Cell", 0, 1)}
 
         local job = Job.__new(
             furniture.Jobs.GetWorkSpotTile(),
@@ -416,6 +416,18 @@ end
 function PowerGenerator_JobComplete(job)
     job.buildable.Parameters["burnTime"].SetValue(job.buildable.Parameters["burnTimeRequired"].ToFloat())
     job.buildable.PowerConnection.OutputRate = 5
+end
+
+function PowerGenerator_FuelInfo(furniture)
+    local curBurn = furniture.Parameters["burnTime"].ToFloat()
+	local maxBurn = furniture.Parameters["burnTimeRequired"].ToFloat()
+
+	local perc = 0
+	if (maxBurn != 0) then
+		perc = curBurn * 100 / maxBurn
+	end
+
+    return "Fuel: " .. string.format("%.1f", perc) .. "%"
 end
 
 function LandingPad_Test_CallTradeShip(furniture, character)


### PR DESCRIPTION
Added new function for furniture to show progress (called with GetAdditionalInfo())
Power generator now uses Power cell as fuel, lasts 30 seconds, shows remaining fuel when selected:
![image](https://cloud.githubusercontent.com/assets/12616499/18627341/b831ac4e-7e5a-11e6-8837-f3717eadde6a.png)
plus tiny bug fix for clamping in Connection.cs (IndexOutOfRangeException: Array index is out of range.)

**Known issue:** Can't force to use just one power cell ? Looks like it takes 4 to make power generator work.. don't know why, don't see problem in settings (also previously even though it required 5 uranium, it took 20 to start the generator.. something funky is there)