### PR TITLE
Add in names from the Localization database

### DIFF
--- a/Scripts/Contributor_Name_List.py
+++ b/Scripts/Contributor_Name_List.py
@@ -26,12 +26,13 @@ def get_jsonparsed_data(url):
     data = response.read().decode("utf-8")
     return json.loads(data)
 
+names=[]
 
+#Main PP repository
 url = 'https://api.github.com/repos/TeamPorcupine/ProjectPorcupine/contributors'
 page=1
-names=[]
 while True:
-	output=get_jsonparsed_data(url+"?page=%i"%page)
+	output=get_jsonparsed_data("%s?page=%i"%(url,page))
 	if len(output)==0:
 		break;
 
@@ -39,7 +40,21 @@ while True:
 		temp=row["login"]
 		names+=[temp[0].upper()+temp[1:]]
 	page+=1
-	
+
+#This is for the localization database. As it isn't in the master branch, we have to do some trickery.
+page=1
+url = 'https://api.github.com/repos/QuiZr/ProjectPorcupineLocalization/commits?sha=Someone_will_come_up_with_a_proper_naming_scheme_later'
+while True:
+	output=get_jsonparsed_data("%s&page=%i"%(url,page))
+	if len(output)==0:
+		break;
+
+	for row in output:
+		temp=row["committer"]["login"]
+		names+=[temp[0].upper()+temp[1:]]
+	page+=1
+
+names=list(set(names))	#This will ensure that only unique values are included
 names.sort()
 for name in names:
 	print (name)


### PR DESCRIPTION
Uses a bit of trickery to make it happen, namely relying on a different API, as the localization repository is effectively housed in a branch.

Fixes #1401 