### PR TITLE
[Fix] Properly deconstruct utilities

### DIFF
--- a/Assets/Scripts/Controllers/InputOutput/BuildModeController.cs
+++ b/Assets/Scripts/Controllers/InputOutput/BuildModeController.cs
@@ -276,6 +276,10 @@ public class BuildModeController
             {
                 tile.PendingBuildJob.CancelJob();
             }
+            else if (tile.Utilities.Count > 0)
+            {
+                tile.Utilities.Last().Value.Deconstruct();
+            }
         }
         else
         {

--- a/Assets/Scripts/Controllers/InputOutput/BuildModeController.cs
+++ b/Assets/Scripts/Controllers/InputOutput/BuildModeController.cs
@@ -277,7 +277,7 @@ public class BuildModeController
             }
             else if (tile.Utilities.Count > 0)
             {
-                tile.Utilities.Last().Value.Deconstruct();
+                tile.Utilities.Last().Value.SetDeconstructJob();
             }
         }
         else

--- a/Assets/Scripts/Models/Buildable/Tile.cs
+++ b/Assets/Scripts/Models/Buildable/Tile.cs
@@ -208,15 +208,16 @@ public class Tile : IXmlSerializable, ISelectable, IContextActionProvider
         return true;
     }
 
-    public bool UnplaceUtility()
+    public bool UnplaceUtility(Utility utility)
     {
         // Just uninstalling.
         if (Utilities == null)
         {
+            Debug.ULogErrorChannel("Tile", "Utilities null when trying to unplace a Utility, this should never happen!");
             return false;
         }
 
-        Utilities = null;
+        Utilities.Remove(utility.Name);
 
         return true;
     }
@@ -225,7 +226,7 @@ public class Tile : IXmlSerializable, ISelectable, IContextActionProvider
     {
         if (objInstance == null)
         {
-            return UnplaceUtility();
+            return false;
         }
 
         if (objInstance.IsValidPosition(this) == false)

--- a/Assets/Scripts/Models/Buildable/Utility.cs
+++ b/Assets/Scripts/Models/Buildable/Utility.cs
@@ -467,18 +467,18 @@ public class Utility : IXmlSerializable, ISelectable, IPrototypable, IContextAct
     /// <summary>
     /// Deconstructs the utility.
     /// </summary>
-    public void Deconstruct(Utility utility)
+    public void Deconstruct()
     {
         int x = Tile.X;
         int y = Tile.Y;
         if (Tile.Utilities != null)
         {
-            utility.Jobs.CancelAll();
+            Jobs.CancelAll();
         }
 
         // We call lua to decostruct
         EventActions.Trigger("OnUninstall", this);
-        Tile.UnplaceUtility();
+        Tile.UnplaceUtility(this);
 
         if (Removed != null)
         {
@@ -499,7 +499,7 @@ public class Utility : IXmlSerializable, ISelectable, IPrototypable, IContextAct
                     {
                         if (neighborUtility.Changed != null)
                         {
-                            neighborUtility.Changed(utility);
+                            neighborUtility.Changed(neighborUtility);
                         }
                     }
                 }
@@ -563,7 +563,7 @@ public class Utility : IXmlSerializable, ISelectable, IPrototypable, IContextAct
         {
             Text = "Deconstruct " + Name,
             RequireCharacterSelected = false,
-            Action = (contextMenuAction, character) => Deconstruct(this)
+            Action = (contextMenuAction, character) => Deconstruct()
         };
         if (Jobs.Count > 0)
         {

--- a/Assets/StreamingAssets/Data/Utility.xml
+++ b/Assets/StreamingAssets/Data/Utility.xml
@@ -6,11 +6,11 @@
     <TypeTag>Power</TypeTag>
 
     <BuildingJob jobTime="1">
-      <Inventory type="Copper Wire" amount="2" />
+      <Inventory type="Copper Plate" amount="2" />
     </BuildingJob>
 
     <DeconstructJob jobTime="1">
-      <Inventory type="Copper Wire" amount="1" />
+      <Inventory type="Copper Plate" amount="1" />
     </DeconstructJob>
     
     <ContextMenuAction FunctionName="UtilityContextTest1" Text="Test Context 1" RequireCharacterSelected="false"/>
@@ -32,6 +32,7 @@
     <DeconstructJob jobTime="1">
       <Inventory type="Steel Plate" amount="1" />
     </DeconstructJob>
+    
     <LocalizationCode>util_water_pipe</LocalizationCode>
     <UnlocalizedDescription>util_water_pipe_desc</UnlocalizedDescription>
   </Utility>

--- a/Assets/StreamingAssets/Data/Utility.xml
+++ b/Assets/StreamingAssets/Data/Utility.xml
@@ -6,11 +6,11 @@
     <TypeTag>Power</TypeTag>
 
     <BuildingJob jobTime="1">
-      <Inventory type="Copper Plate" amount="2" />
+      <Inventory type="Copper Wire" amount="2" />
     </BuildingJob>
 
     <DeconstructJob jobTime="1">
-      <Inventory type="Copper Plate" amount="1" />
+      <Inventory type="Copper Wire" amount="1" />
     </DeconstructJob>
     
     <ContextMenuAction FunctionName="UtilityContextTest1" Text="Test Context 1" RequireCharacterSelected="false"/>


### PR DESCRIPTION
Utilities did not deconstruct previously, both because BMC didn't call deconstruct on utilities, and the utilities deconstruct method didn't handle things properly.

Deconstruction will now first look for a furniture to deconstruct, and then if there is a pending build job, will cancel it (as before) and then deconstruct the last utility built.

This may not be that absolutely best optimal desired behavior (I would like to be able to have things figure out to delete power cables if you've drug deconstruct over power cables, but that would require much more complicated logic, and possibly drastic changes to how the buildModeController performs deconstruction.) but it is functional whereas previously it was not and would completely destroy the utilities hashSet making it impossible for any utilities to be added to the tile or any that were there to do anything.