### PR TITLE
World update frequency for visible/invisible furniture

### DIFF
--- a/Assets/Scripts/Controllers/InputOutput/CameraController.cs
+++ b/Assets/Scripts/Controllers/InputOutput/CameraController.cs
@@ -6,6 +6,7 @@
 // file LICENSE, which is part of this source code package, for details.
 // ====================================================
 #endregion
+using System;
 using UnityEngine;
 
 public class CameraController
@@ -64,6 +65,8 @@ public class CameraController
         TimeManager.Instance.EveryFrameNotModal += (time) => Update();
     }
 
+    public event Action<Bounds> Moved;
+
     public int CurrentLayer
     {
         get
@@ -116,9 +119,9 @@ public class CameraController
             positionTarget = Camera.main.transform.position;
         }
 
-        if (prevPositionTarget != positionTarget)
+        if (prevPositionTarget != positionTarget && Moved != null)
         {
-            WorldController.Instance.World.CameraMoved(GetCameraBounds());            
+            Moved(GetCameraBounds());
         }
 
         prevPositionTarget = positionTarget;

--- a/Assets/Scripts/Controllers/InputOutput/CameraController.cs
+++ b/Assets/Scripts/Controllers/InputOutput/CameraController.cs
@@ -24,6 +24,7 @@ public class CameraController
     private float frameMoveVertical = 0;
 
     private Vector3 positionTarget;
+    private Vector3 prevPositionTarget;
 
     private CameraData cameraData;
 
@@ -114,6 +115,13 @@ public class CameraController
             Camera.main.transform.Translate(pushedAmount);
             positionTarget = Camera.main.transform.position;
         }
+
+        if (prevPositionTarget != positionTarget)
+        {
+            WorldController.Instance.World.CameraMoved(GetCameraBounds());            
+        }
+
+        prevPositionTarget = positionTarget;
     }
 
     public void ChangeZoom(float amount)
@@ -180,6 +188,20 @@ public class CameraController
             zoomTarget = cameraData.zoomLevel;
             Camera.main.orthographicSize = zoomTarget;
         }
+    }
+
+    /// <summary>
+    /// Get the bounds of the main camera.
+    /// </summary>    
+    private Bounds GetCameraBounds()
+    {
+        var x = Camera.main.transform.position.x;
+        var y = Camera.main.transform.position.y;
+        var size = Camera.main.orthographicSize * 2;
+        var width = size * (float)Screen.width / Screen.height;
+        var height = size;
+
+        return new Bounds(new Vector3(x, y, 0), new Vector3(width, height, 0));
     }
 
     private void ApplyPreset(Preset preset)

--- a/Assets/Scripts/Controllers/WorldController.cs
+++ b/Assets/Scripts/Controllers/WorldController.cs
@@ -131,6 +131,7 @@ public class WorldController : MonoBehaviour
         spawnInventoryController.SetUIVisibility(Settings.GetSetting("DialogBoxSettings_developerModeToggle", false));
 
         cameraController.Initialize();
+        cameraController.Moved += this.World.OnCameraMoved;
 
         // Initialising controllers.
         GameObject canvas = GameObject.Find("Canvas");

--- a/Assets/Scripts/Models/Area/World.cs
+++ b/Assets/Scripts/Models/Area/World.cs
@@ -51,9 +51,13 @@ public class World : IXmlSerializable
     // A three-dimensional array to hold our tile data.
     private Tile[,,] tiles;
 
-    // Holds all furnitures with eventactions, and distributes them between visible and invisible
+    // Holds all furnitures with eventactions, and distributes them between visible and invisible.
     private List<Furniture> eventFurnitures;
+
+    // A temporary list of all visible furniture. Gets updated when camera moves.
     private List<Furniture> eventFurnituresVisible;
+
+    // A temporary list of all invisible furniture. Gets updated when camera moves.
     private List<Furniture> eventFurnituresInvisible;
 
     /// <summary>
@@ -144,25 +148,41 @@ public class World : IXmlSerializable
         TimeManager.Instance.FixedFrequencyUnpaused += TickFixedFrequency;
     }
 
+    /// <summary>
+    /// Calls update on characters.
+    /// Also calls "OnFastUpdate" EventActions on visible furniture.
+    /// </summary>
     public void TickEveryFrame(float deltaTime)
     {
         CharacterManager.Update(deltaTime);
 
-        // Update Furniture (fast track)
+        // Update Furniture (fast track) but only if visible to the camera
         foreach (Furniture furniture in eventFurnituresVisible)
         {
             furniture.EveryFrameUpdate(deltaTime);
         }
     }
 
+    /// <summary>
+    /// Fixed update that runs at 5 FPS.
+    /// Calls update on temperature and powernetwork.
+    /// Also calls "OnUpdate" EventActions on all furniture and 
+    /// "OnFastUpdate" EventActions on invisible furniture.
+    /// </summary>
     public void TickFixedFrequency(float deltaTime)
     {
-        // Update Furniture outside of the camera view
-        // TODO: Further optimization could divide furnituresInvisible in multiple lists
+        // TODO: Further optimization could divide eventFurnitures in multiple lists
         //       and update one of the lists each frame
+
+        // Update furniture outside of the camera view
         foreach (Furniture furniture in eventFurnituresInvisible)
         {
             furniture.EveryFrameUpdate(deltaTime);
+        }
+
+        // Update all furniture with EventActions
+        foreach (Furniture furniture in eventFurnitures)
+        {
             furniture.FixedFrequencyUpdate(deltaTime);
         }
 

--- a/Assets/Scripts/Models/Area/World.cs
+++ b/Assets/Scripts/Models/Area/World.cs
@@ -172,7 +172,8 @@ public class World : IXmlSerializable
     public void TickFixedFrequency(float deltaTime)
     {
         // TODO: Further optimization could divide eventFurnitures in multiple lists
-        //       and update one of the lists each frame
+        //       and update one of the lists each frame.
+        //       FixedFrequencyUpdate on invisible furniture could also be even slower.
 
         // Update furniture outside of the camera view
         foreach (Furniture furniture in eventFurnituresInvisible)
@@ -195,8 +196,8 @@ public class World : IXmlSerializable
     /// Notify world that the camera moved, so we can check which entities are visible to the camera.
     /// The invisible enities can be updated less frequent for better performance.
     /// </summary>
-    public void CameraMoved(Bounds cameraBounds)
-    {
+    public void OnCameraMoved(Bounds cameraBounds)
+    {        
         // Expand bounds to include tiles on the edge where the centre isn't inside the bounds
         cameraBounds.Expand(1);
 
@@ -224,13 +225,6 @@ public class World : IXmlSerializable
                 }
             }
         }
-
-        /*
-         Debug.ULogChannel("VisibleFurn","All furn: "+ furnitures.Count.ToString());
-         Debug.ULogChannel("VisibleFurn","EventAction furn: "+ eventFurnitures.Count.ToString());
-         Debug.ULogChannel("VisibleFurn","Visible furn: "+ eventFurnituresVisible.Count.ToString());
-         Debug.ULogChannel("VisibleFurn", "Invisible furn: " + eventFurnituresInvisible.Count.ToString());
-         */
     }
 
     /// <summary>

--- a/Assets/Scripts/Models/Area/World.cs
+++ b/Assets/Scripts/Models/Area/World.cs
@@ -52,9 +52,9 @@ public class World : IXmlSerializable
     private Tile[,,] tiles;
 
     // Holds all furnitures with eventactions, and distributes them between visible and invisible
-    private List<Furniture> furnituresWithEventsAction;
-    private List<Furniture> furnituresVisible;
-    private List<Furniture> furnituresInvisible;
+    private List<Furniture> eventFurnitures;
+    private List<Furniture> eventFurnituresVisible;
+    private List<Furniture> eventFurnituresInvisible;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="World"/> class.
@@ -149,7 +149,7 @@ public class World : IXmlSerializable
         CharacterManager.Update(deltaTime);
 
         // Update Furniture (fast track)
-        foreach (Furniture furniture in furnituresVisible)
+        foreach (Furniture furniture in eventFurnituresVisible)
         {
             furniture.EveryFrameUpdate(deltaTime);
         }
@@ -160,7 +160,7 @@ public class World : IXmlSerializable
         // Update Furniture outside of the camera view
         // TODO: Further optimization could divide furnituresInvisible in multiple lists
         //       and update one of the lists each frame
-        foreach (Furniture furniture in furnituresInvisible)
+        foreach (Furniture furniture in eventFurnituresInvisible)
         {
             furniture.EveryFrameUpdate(deltaTime);
             furniture.FixedFrequencyUpdate(deltaTime);
@@ -180,7 +180,7 @@ public class World : IXmlSerializable
         // Expand bounds to include tiles on the edge where the centre isn't inside the bounds
         cameraBounds.Expand(1);
 
-        foreach (Furniture furn in furnituresWithEventsAction)
+        foreach (Furniture furn in eventFurnitures)
         {
             // Multitile furniture base tile is bottom left - so add width and height 
             Bounds furnitureBounds = new Bounds(
@@ -189,26 +189,28 @@ public class World : IXmlSerializable
 
             if (cameraBounds.Intersects(furnitureBounds))
             {
-                if (furnituresInvisible.Contains(furn))
+                if (eventFurnituresInvisible.Contains(furn))
                 {
-                    furnituresInvisible.Remove(furn);
-                    furnituresVisible.Add(furn);
+                    eventFurnituresInvisible.Remove(furn);
+                    eventFurnituresVisible.Add(furn);
                 }
             }
             else
             {
-                if (furnituresVisible.Contains(furn))
+                if (eventFurnituresVisible.Contains(furn))
                 {
-                    furnituresVisible.Remove(furn);
-                    furnituresInvisible.Add(furn);
+                    eventFurnituresVisible.Remove(furn);
+                    eventFurnituresInvisible.Add(furn);
                 }
             }
         }
 
+        /*
          Debug.ULogChannel("VisibleFurn","All furn: "+ furnitures.Count.ToString());
-         Debug.ULogChannel("VisibleFurn","EventAction furn: "+ furnituresWithEventsAction.Count.ToString());
-         Debug.ULogChannel("VisibleFurn","Visible furn: "+ furnituresVisible.Count.ToString());
-         Debug.ULogChannel("VisibleFurn", "Invisible furn: " + furnituresInvisible.Count.ToString());
+         Debug.ULogChannel("VisibleFurn","EventAction furn: "+ eventFurnitures.Count.ToString());
+         Debug.ULogChannel("VisibleFurn","Visible furn: "+ eventFurnituresVisible.Count.ToString());
+         Debug.ULogChannel("VisibleFurn", "Invisible furn: " + eventFurnituresInvisible.Count.ToString());
+         */
     }
 
     /// <summary>
@@ -261,8 +263,8 @@ public class World : IXmlSerializable
 
         if (furn.EventActions.HasEvents())
         {
-            furnituresWithEventsAction.Add(furn);
-            furnituresVisible.Add(furn);
+            eventFurnitures.Add(furn);
+            eventFurnituresVisible.Add(furn);
         }
         
         // Do we need to recalculate our rooms?
@@ -568,17 +570,18 @@ public class World : IXmlSerializable
     public void OnFurnitureRemoved(Furniture furn)
     {
         furnitures.Remove(furn);
-        if (furnituresWithEventsAction.Contains(furn))
+        if (eventFurnitures.Contains(furn))
         {
-            furnituresWithEventsAction.Remove(furn);
+            eventFurnitures.Remove(furn);
         }
-        if (furnituresInvisible.Contains(furn))
+
+        if (eventFurnituresInvisible.Contains(furn))
         {
-            furnituresInvisible.Remove(furn);            
+            eventFurnituresInvisible.Remove(furn);            
         }
-        else if (furnituresVisible.Contains(furn))
+        else if (eventFurnituresVisible.Contains(furn))
         {
-            furnituresVisible.Remove(furn);
+            eventFurnituresVisible.Remove(furn);
         }
     }
 
@@ -684,9 +687,9 @@ public class World : IXmlSerializable
         CreateWallet();
 
         furnitures = new List<Furniture>();
-        furnituresWithEventsAction = new List<Furniture>();
-        furnituresVisible = new List<Furniture>();
-        furnituresInvisible = new List<Furniture>();
+        eventFurnitures = new List<Furniture>();
+        eventFurnituresVisible = new List<Furniture>();
+        eventFurnituresInvisible = new List<Furniture>();
 
         utilities = new List<Utility>();
         CharacterManager = new CharacterManager();

--- a/Assets/Scripts/Models/Area/World.cs
+++ b/Assets/Scripts/Models/Area/World.cs
@@ -51,14 +51,11 @@ public class World : IXmlSerializable
     // A three-dimensional array to hold our tile data.
     private Tile[,,] tiles;
 
-    // Holds all furnitures with eventactions, and distributes them between visible and invisible.
-    private List<Furniture> eventFurnitures;
-
     // A temporary list of all visible furniture. Gets updated when camera moves.
-    private List<Furniture> eventFurnituresVisible;
+    private List<Furniture> furnituresVisible;
 
     // A temporary list of all invisible furniture. Gets updated when camera moves.
-    private List<Furniture> eventFurnituresInvisible;
+    private List<Furniture> furnituresInvisible;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="World"/> class.
@@ -157,7 +154,7 @@ public class World : IXmlSerializable
         CharacterManager.Update(deltaTime);
 
         // Update Furniture (fast track) but only if visible to the camera
-        foreach (Furniture furniture in eventFurnituresVisible)
+        foreach (Furniture furniture in furnituresVisible)
         {
             furniture.EveryFrameUpdate(deltaTime);
         }
@@ -176,13 +173,13 @@ public class World : IXmlSerializable
         //       FixedFrequencyUpdate on invisible furniture could also be even slower.
 
         // Update furniture outside of the camera view
-        foreach (Furniture furniture in eventFurnituresInvisible)
+        foreach (Furniture furniture in furnituresInvisible)
         {
             furniture.EveryFrameUpdate(deltaTime);
         }
 
         // Update all furniture with EventActions
-        foreach (Furniture furniture in eventFurnitures)
+        foreach (Furniture furniture in furnitures)
         {
             furniture.FixedFrequencyUpdate(deltaTime);
         }
@@ -201,7 +198,7 @@ public class World : IXmlSerializable
         // Expand bounds to include tiles on the edge where the centre isn't inside the bounds
         cameraBounds.Expand(1);
 
-        foreach (Furniture furn in eventFurnitures)
+        foreach (Furniture furn in furnitures)
         {
             // Multitile furniture base tile is bottom left - so add width and height 
             Bounds furnitureBounds = new Bounds(
@@ -210,20 +207,20 @@ public class World : IXmlSerializable
 
             if (cameraBounds.Intersects(furnitureBounds))
             {
-                if (eventFurnituresInvisible.Contains(furn))
+                if (furnituresInvisible.Contains(furn))
                 {
-                    eventFurnituresInvisible.Remove(furn);
-                    eventFurnituresVisible.Add(furn);
+                    furnituresInvisible.Remove(furn);
+                    furnituresVisible.Add(furn);
                 }
             }
             else
             {
-                if (eventFurnituresVisible.Contains(furn))
+                if (furnituresVisible.Contains(furn))
                 {
-                    eventFurnituresVisible.Remove(furn);
-                    eventFurnituresInvisible.Add(furn);
+                    furnituresVisible.Remove(furn);
+                    furnituresInvisible.Add(furn);
                 }
-            }
+            }            
         }
     }
 
@@ -274,12 +271,7 @@ public class World : IXmlSerializable
 
         furn.Removed += OnFurnitureRemoved;
         furnitures.Add(furn);
-
-        if (furn.EventActions.HasEvents())
-        {
-            eventFurnitures.Add(furn);
-            eventFurnituresVisible.Add(furn);
-        }
+        furnituresVisible.Add(furn);
         
         // Do we need to recalculate our rooms?
         if (doRoomFloodFill && furn.RoomEnclosure)
@@ -584,18 +576,14 @@ public class World : IXmlSerializable
     public void OnFurnitureRemoved(Furniture furn)
     {
         furnitures.Remove(furn);
-        if (eventFurnitures.Contains(furn))
-        {
-            eventFurnitures.Remove(furn);
-        }
 
-        if (eventFurnituresInvisible.Contains(furn))
+        if (furnituresInvisible.Contains(furn))
         {
-            eventFurnituresInvisible.Remove(furn);            
+            furnituresInvisible.Remove(furn);            
         }
-        else if (eventFurnituresVisible.Contains(furn))
+        else if (furnituresVisible.Contains(furn))
         {
-            eventFurnituresVisible.Remove(furn);
+            furnituresVisible.Remove(furn);
         }
     }
 
@@ -701,9 +689,8 @@ public class World : IXmlSerializable
         CreateWallet();
 
         furnitures = new List<Furniture>();
-        eventFurnitures = new List<Furniture>();
-        eventFurnituresVisible = new List<Furniture>();
-        eventFurnituresInvisible = new List<Furniture>();
+        furnituresVisible = new List<Furniture>();
+        furnituresInvisible = new List<Furniture>();
 
         utilities = new List<Utility>();
         CharacterManager = new CharacterManager();


### PR DESCRIPTION
This keeps track of visible and invisible furniture, so we can manage update frequency of visible furniture. See #1383.

I'll let this one wait for #1400 to be finished, as they are closely related.
