### PR TITLE
[Small, Fix] Don't assign RoomEnclosing furniture to outside Room

### DIFF
--- a/Assets/Scripts/Models/Area/RoomManager.cs
+++ b/Assets/Scripts/Models/Area/RoomManager.cs
@@ -154,10 +154,6 @@ namespace ProjectPorcupine.Rooms
             // Remove this room from our rooms list.
             rooms.Remove(room);
 
-            // All tiles that belonged to this room should be re-assigned to
-            // the outside.
-            room.ReturnTilesToOutsideRoom();
-
             if (Removed != null)
             {
                 Removed(room);


### PR DESCRIPTION
Currently, in master, any new walls placed have room 0, the outside room, rather than a null room, this causes issues when removing that wall as adjacent rooms won't be joined. Removing the explicit assignment to outside room of any tiles from a removed room doesn't seem to cause any issues, tiles in a room opened to space are still properly assigned to the outside, and new walls will once again have null room.

