### PR TITLE
[Small] Better Room Splitting and Joining

### DIFF
--- a/Assets/Scripts/Models/Area/Room.cs
+++ b/Assets/Scripts/Models/Area/Room.cs
@@ -356,11 +356,11 @@ namespace ProjectPorcupine.Rooms
             }
         }
 
-        public void CopyGasPreasure(Room other, int sizeOfOtherRoom)
+        public void SplitGas(Room other, int sizeOfOtherRoom)
         {
             foreach (string n in other.atmosphericGasses.Keys)
             {
-                this.atmosphericGasses[n] = other.atmosphericGasses[n] / sizeOfOtherRoom * this.TileCount;
+                this.atmosphericGasses[n] = other.atmosphericGasses[n] * TileCount / sizeOfOtherRoom;
             }
         }
 

--- a/Assets/Scripts/Models/Area/RoomManager.cs
+++ b/Assets/Scripts/Models/Area/RoomManager.cs
@@ -401,7 +401,9 @@ namespace ProjectPorcupine.Rooms
             {
                 // In this case we are splitting one room into two or more,
                 // so we can just copy the old gas ratios.
-                newRoom.CopyGasPreasure(oldRoom, sizeOfOldRoom);
+                // 1 is subtracted from size of old room to account for tile being filled by furniture,
+                // this prevents gas from being lost
+                newRoom.SplitGas(oldRoom, sizeOfOldRoom - 1);
             }
 
             // Tell the world that a new room has been formed.

--- a/Assets/Scripts/Models/Area/RoomManager.cs
+++ b/Assets/Scripts/Models/Area/RoomManager.cs
@@ -266,10 +266,9 @@ namespace ProjectPorcupine.Rooms
                 List<Room> oldRooms = new List<Room>();
 
                 // You need to delete the surrounding rooms so a new room can be created
-                // FIXME: This doesn't work for the gas calculations and needs to be fixed.
                 foreach (Tile t in sourceTile.GetNeighbours())
                 {
-                    if (t != null && t.Room != null && t.Room.IsOutsideRoom())
+                    if (t != null && t.Room != null && !t.Room.IsOutsideRoom())
                     {
                         oldRooms.Add(t.Room);
 


### PR DESCRIPTION
This fixes a problem with old rooms not being deleted when rooms are joined (Rooms would stay in RoomManager).

It also fixes a problem when splitting rooms where the gas pressure would be directly copied to the new room, effectively causing a loss of total gasses in the rooms (Gas Pressure now goes up a slight amount when rooms are split, due to more of the space the gas would otherwise be in being occupied by a wall, this matches the behavior where the gas pressure drops when a wall is removed.)

Also renamed CopyGasPreasure to SplitGas, to more accurately reflect what is happening.