### PR TITLE
[Fix] PowerConnection plugged in when cloning

### DIFF
--- a/Assets/Scripts/Models/Buildable/Furniture.cs
+++ b/Assets/Scripts/Models/Buildable/Furniture.cs
@@ -145,7 +145,6 @@ public class Furniture : IXmlSerializable, ISelectable, IPrototypable, IContextA
         if (other.PowerConnection != null)
         {
             PowerConnection = other.PowerConnection.Clone() as Connection;
-            //World.Current.PowerNetwork.PlugIn(PowerConnection);
             PowerConnection.NewThresholdReached += OnNewThresholdReached;
         }
 

--- a/Assets/Scripts/Models/Buildable/Furniture.cs
+++ b/Assets/Scripts/Models/Buildable/Furniture.cs
@@ -145,7 +145,7 @@ public class Furniture : IXmlSerializable, ISelectable, IPrototypable, IContextA
         if (other.PowerConnection != null)
         {
             PowerConnection = other.PowerConnection.Clone() as Connection;
-            World.Current.PowerNetwork.PlugIn(PowerConnection);
+            //World.Current.PowerNetwork.PlugIn(PowerConnection);
             PowerConnection.NewThresholdReached += OnNewThresholdReached;
         }
 
@@ -385,16 +385,10 @@ public class Furniture : IXmlSerializable, ISelectable, IPrototypable, IContextA
         }
 
         // We know our placement destination is valid.
-        Furniture obj = proto.Clone();
-        obj.Tile = tile;
-
-        // need to update reference to furniture and call Initialize (so components can place hooks on events there)
-        foreach (var comp in obj.components)
-        {
-            comp.Initialize(obj);
-        }
-      
-        if (tile.PlaceFurniture(obj) == false)
+        Furniture furnObj = proto.Clone();
+        furnObj.Tile = tile;
+        
+        if (tile.PlaceFurniture(furnObj) == false)
         {
             // For some reason, we weren't able to place our object in this tile.
             // (Probably it was already occupied.)
@@ -403,8 +397,20 @@ public class Furniture : IXmlSerializable, ISelectable, IPrototypable, IContextA
             // (It will be garbage collected.)
             return null;
         }
-        
-        if (obj.LinksToNeighbour != string.Empty)
+
+        // plug-in furniture only when it is placed in world
+        if (furnObj.PowerConnection != null)
+        {
+            World.Current.PowerNetwork.PlugIn(furnObj.PowerConnection);
+        }
+
+        // need to update reference to furniture and call Initialize (so components can place hooks on events there)
+        foreach (var comp in furnObj.components)
+        {
+            comp.Initialize(furnObj);
+        }
+
+        if (furnObj.LinksToNeighbour != string.Empty)
         {
             // This type of furniture links itself to its neighbours,
             // so we should inform our neighbours that they have a new
@@ -426,21 +432,21 @@ public class Furniture : IXmlSerializable, ISelectable, IPrototypable, IContextA
         }
 
         // Let our workspot tile know it is reserved for us
-        World.Current.ReserveTileAsWorkSpot(obj);
+        World.Current.ReserveTileAsWorkSpot(furnObj);
 
         // Call LUA install scripts
-        obj.EventActions.Trigger("OnInstall", obj);
+        furnObj.EventActions.Trigger("OnInstall", furnObj);
 
         // Update thermalDiffusivity using coefficient
         float thermalDiffusivity = Temperature.defaultThermalDiffusivity;
-        if (obj.Parameters.ContainsKey("thermal_diffusivity"))
+        if (furnObj.Parameters.ContainsKey("thermal_diffusivity"))
         {
-            thermalDiffusivity = obj.Parameters["thermal_diffusivity"].ToFloat();
+            thermalDiffusivity = furnObj.Parameters["thermal_diffusivity"].ToFloat();
         }
 
         World.Current.temperature.SetThermalDiffusivity(tile.X, tile.Y, tile.Z, thermalDiffusivity);
 
-        return obj;
+        return furnObj;
     }
 
     #region Update and Animation


### PR DESCRIPTION
Furniture is for some reason cloned when trying to place it in world (MouseController.cs). Cloning of furniture already plugged in the furniture into network - this spawned lots of shadow users => resulted in power shortage.
Overall the furniture cloning is kind of popular in code and needs to be reduced.