### PR TITLE
[Small] Confirm Quit dialog

### DIFF
--- a/Assets/Scripts/UI/DialogBox/Options/DialogBoxOptions.cs
+++ b/Assets/Scripts/UI/DialogBox/Options/DialogBoxOptions.cs
@@ -1,4 +1,4 @@
-﻿#region License
+#region License
 // ====================================================
 // Project Porcupine Copyright(C) 2016 Team Porcupine
 // This program comes with ABSOLUTELY NO WARRANTY; This is free software, 
@@ -41,13 +41,34 @@ public class DialogBoxOptions : DialogBox
     // Quit the app whether in editor or a build version.
     public void OnButtonQuitGame()
     {
-        // Maybe ask the user if he want to save or is sure they want to quit??
+        StartCoroutine(ConfirmQuitDialog());
+    }
+
+    private IEnumerator ConfirmQuitDialog()
+    {
+        dialogManager.dialogBoxPromptOrInfo.SetPrompt("prompt_confirm_quit");
+        dialogManager.dialogBoxPromptOrInfo.SetButtons(DialogBoxResult.Yes, DialogBoxResult.No);
+
+        dialogManager.dialogBoxPromptOrInfo.Closed = () =>
+        {
+            if (dialogManager.dialogBoxPromptOrInfo.Result == DialogBoxResult.Yes)
+            {
+                // Quit the game
 #if UNITY_EDITOR
-        // Allows you to quit in the editor.
-        UnityEditor.EditorApplication.isPlaying = false;
+                // Allows you to quit in the editor.
+                UnityEditor.EditorApplication.isPlaying = false;
 #else
         Application.Quit();
 #endif
+            }
+        };
+
+        dialogManager.dialogBoxPromptOrInfo.ShowDialog();
+
+        while (dialogManager.dialogBoxPromptOrInfo.gameObject.activeSelf)
+        {
+            yield return null;
+        }
     }
 
     private IEnumerator CheckIfSaveGameBefore(string prompt)

--- a/Assets/StreamingAssets/Localization/en_US.lang
+++ b/Assets/StreamingAssets/Localization/en_US.lang
@@ -99,3 +99,4 @@ prompt_save_before_creating_new_world=Would you like to save the game before cre
 prompt_save_before_loading_new_game=Would you like to save before loading another game?
 prompt_overwrite_existing_file=File {0} already exists! Would you like to overwrite it?
 prompt_delete_file=Delete file {0}? You cannot revert this action
+prompt_confirm_quit=Are you sure you want to quit?


### PR DESCRIPTION
user is now prompted to confirm quitting the game when hitting quit in the options menu.
![capture](https://cloud.githubusercontent.com/assets/7608114/19022277/b42d7770-88a2-11e6-9ef8-5cd573f61dc6.PNG)
