### PR TITLE
[Small, Fix] Fix oldRoom not empty error

### DIFF
--- a/Assets/Scripts/Models/Area/Room.cs
+++ b/Assets/Scripts/Models/Area/Room.cs
@@ -82,7 +82,7 @@ namespace ProjectPorcupine.Rooms
 
         public void UnassignTile(Tile tile)
         {
-            if (tiles.Contains(tile))
+            if (tiles.Contains(tile) == false)
             {
                 // This tile in not in this room.
                 return;


### PR DESCRIPTION
Unassign tiles should return when tile isn't in room, not when in room.
Fixes #1480 