### PR TITLE
Fix MissingReferenceException thrown when saving settings

### DIFF
--- a/Assets/Scripts/UI/InGameUI/GameMenu/GameMenuController.cs
+++ b/Assets/Scripts/UI/InGameUI/GameMenu/GameMenuController.cs
@@ -6,6 +6,7 @@
 // file LICENSE, which is part of this source code package, for details.
 // ====================================================
 #endregion
+using System;
 using ProjectPorcupine.Localization;
 using UnityEngine;
 using UnityEngine.UI;
@@ -26,6 +27,29 @@ public class GameMenuController : MonoBehaviour
     public void ToggleMenu(GameObject menu)
     {
         menu.SetActive(!menu.activeSelf);
+    }
+
+    public void LocalizationFilesChanged()
+    {
+        Transform tf;
+        try
+        {
+            tf = gameObject.transform;
+        }
+        catch (MissingReferenceException)
+        {
+            // this sometimes gets called when gameObject doesn't exist
+            // if so the gameObject has obviously been destroyed, so deregister
+            // the callback
+            LocalizationTable.CBLocalizationFilesChanged -= LocalizationFilesChanged;
+            return;
+        }
+
+        string menuItemKey = gameObject.name.Replace("Button - ", string.Empty);
+        tf.GetComponentInChildren<TextLocalizer>().formatValues = new string[]
+            {
+                LocalizationTable.GetLocalization(menuItemKey)
+            };
     }
 
     // Use this for initialization.
@@ -73,23 +97,7 @@ public class GameMenuController : MonoBehaviour
                 }
             });
 
-        string menuItemKey = mainMenuItem.Key;
-        LocalizationTable.CBLocalizationFilesChanged += delegate
-            {
-                Transform tf;
-
-                try
-                {
-                    tf = gameObject.transform;
-                }
-                catch (MissingReferenceException)
-                {
-                    // this sometimes gets called when gameObject doesn't exist
-                    return;
-                }
-
-                tf.GetComponentInChildren<TextLocalizer>().formatValues = new string[] { LocalizationTable.GetLocalization(menuItemKey) };
-            };
+        LocalizationTable.CBLocalizationFilesChanged += LocalizationFilesChanged;
     }
 
     private void Update()

--- a/Assets/Scripts/UI/InGameUI/GameMenu/GameMenuController.cs
+++ b/Assets/Scripts/UI/InGameUI/GameMenu/GameMenuController.cs
@@ -6,7 +6,6 @@
 // file LICENSE, which is part of this source code package, for details.
 // ====================================================
 #endregion
-using System.Collections;
 using ProjectPorcupine.Localization;
 using UnityEngine;
 using UnityEngine.UI;
@@ -77,7 +76,19 @@ public class GameMenuController : MonoBehaviour
         string menuItemKey = mainMenuItem.Key;
         LocalizationTable.CBLocalizationFilesChanged += delegate
             {
-                gameObject.transform.GetComponentInChildren<TextLocalizer>().formatValues = new string[] { LocalizationTable.GetLocalization(menuItemKey) };
+                Transform tf;
+
+                try
+                {
+                    tf = gameObject.transform;
+                }
+                catch (MissingReferenceException)
+                {
+                    // this sometimes gets called when gameObject doesn't exist
+                    return;
+                }
+
+                tf.GetComponentInChildren<TextLocalizer>().formatValues = new string[] { LocalizationTable.GetLocalization(menuItemKey) };
             };
     }
 

--- a/Assets/Scripts/UI/InGameUI/GameMenu/GameMenuController.cs
+++ b/Assets/Scripts/UI/InGameUI/GameMenu/GameMenuController.cs
@@ -29,29 +29,6 @@ public class GameMenuController : MonoBehaviour
         menu.SetActive(!menu.activeSelf);
     }
 
-    public void LocalizationFilesChanged()
-    {
-        Transform tf;
-        try
-        {
-            tf = gameObject.transform;
-        }
-        catch (MissingReferenceException)
-        {
-            // this sometimes gets called when gameObject doesn't exist
-            // if so the gameObject has obviously been destroyed, so deregister
-            // the callback
-            LocalizationTable.CBLocalizationFilesChanged -= LocalizationFilesChanged;
-            return;
-        }
-
-        string menuItemKey = gameObject.name.Replace("Button - ", string.Empty);
-        tf.GetComponentInChildren<TextLocalizer>().formatValues = new string[]
-            {
-                LocalizationTable.GetLocalization(menuItemKey)
-            };
-    }
-
     // Use this for initialization.
     private void Start()
     {
@@ -97,7 +74,30 @@ public class GameMenuController : MonoBehaviour
                 }
             });
 
-        LocalizationTable.CBLocalizationFilesChanged += LocalizationFilesChanged;
+        Action localizationFilesChangedHandler = null;
+        localizationFilesChangedHandler = delegate
+            {
+                Transform tf;
+                try
+                {
+                    tf = gameObject.transform;
+                }
+                catch (MissingReferenceException)
+                {
+                    // this sometimes gets called when gameObject doesn't exist
+                    // if so the gameObject has obviously been destroyed, so deregister
+                    // the callback
+                    LocalizationTable.CBLocalizationFilesChanged -= localizationFilesChangedHandler;
+                    return;
+                }
+
+                string menuItemKey = gameObject.name.Replace("Button - ", string.Empty);
+                tf.GetComponentInChildren<TextLocalizer>().formatValues = new string[]
+                {
+                    LocalizationTable.GetLocalization(menuItemKey)
+                };
+            };
+        LocalizationTable.CBLocalizationFilesChanged += localizationFilesChangedHandler;
     }
 
     private void Update()


### PR DESCRIPTION
Prevents an exception with the following stacktrace by adding a try block:
```
MissingReferenceException: The object of type 'GameObject' has been
destroyed but you are still trying to access it.
Your script should either check if it is null or you should not destroy
the object.
GameMenuController+<CreateButton>c__AnonStorey41.<>m__88 () (at
Assets/Scripts/UI/InGameUI/GameMenu/GameMenuController.cs:80)
ProjectPorcupine.Localization.LocalizationTable.LoadingLanguagesFinished
() (at Assets/Scripts/Localization/LocalizationTable.cs:83)
ProjectPorcupine.Localization.LocalizationLoader.UpdateLocalizationTable
() (at Assets/Scripts/Localization/LocalizationLoader.cs:44)
ProjectPorcupine.Localization.LocalizationLoader.<Awake>m__2F () (at
Assets/Scripts/Localization/LocalizationLoader.cs:85)
ProjectPorcupine.Localization.LocalizationDownloader.OnDownloadLocalizationComplete
(System.Action onLocalizationDownloadedCallback) (at
Assets/Scripts/Localization/LocalizationDownloader.cs:267)
ProjectPorcupine.Localization.LocalizationDownloader+<DownloadLocalizationFromWeb>c__IteratorC.MoveNext
() (at Assets/Scripts/Localization/LocalizationDownloader.cs:143)
UnityEngine.SetupCoroutine.InvokeMoveNext (IEnumerator enumerator, IntPtr
returnValueAddress) (at
C:/buildslave/unity/build/Runtime/Export/Coroutines.cs:17)
```