### PR TITLE
[Small, Fix] Don't overwrite Construction menu names in Update

### DIFF
--- a/Assets/Scripts/UI/InGameUI/MenuLeft/ConstructionMenu.cs
+++ b/Assets/Scripts/UI/InGameUI/MenuLeft/ConstructionMenu.cs
@@ -96,8 +96,6 @@ public class ConstructionMenu : MonoBehaviour
         RenderFurnitureButtons();
         RenderUtilityButtons();
 
-        lastLanguage = LocalizationTable.currentLanguage;
-
         InputField filterField = GetComponentInChildren<InputField>();
         KeyboardManager.Instance.RegisterModalInputField(filterField);
     }

--- a/Assets/Scripts/UI/InGameUI/MenuLeft/ConstructionMenu.cs
+++ b/Assets/Scripts/UI/InGameUI/MenuLeft/ConstructionMenu.cs
@@ -23,8 +23,6 @@ public class ConstructionMenu : MonoBehaviour
     private List<GameObject> tileItems;
     private List<GameObject> taskItems;
 
-    private string lastLanguage;
-
     private bool showAllFurniture;
 
     private MenuLeft menuLeft;

--- a/Assets/Scripts/UI/InGameUI/MenuLeft/ConstructionMenu.cs
+++ b/Assets/Scripts/UI/InGameUI/MenuLeft/ConstructionMenu.cs
@@ -322,19 +322,4 @@ public class ConstructionMenu : MonoBehaviour
         Image image = gameObject.transform.GetChild(0).GetComponentsInChildren<Image>().First();
         image.sprite = SpriteManager.GetSprite("UI", "Deconstruct");
     }
-
-    private void Update()
-    {
-        if (lastLanguage != LocalizationTable.currentLanguage)
-        {
-            lastLanguage = LocalizationTable.currentLanguage;
-
-            TextLocalizer[] localizers = GetComponentsInChildren<TextLocalizer>();
-
-            for (int i = 0; i < localizers.Length; i++)
-            {
-                localizers[i].UpdateText(LocalizationTable.GetLocalization(PrototypeManager.Furniture[i].GetName()));
-            }
-        }
-    }
 }


### PR DESCRIPTION
ConstructionMenu.Update() was checking if language had been changed and was manually changing button names but in the wrong way (was assuming there were no buttons other than Furniture build buttons), removing the Update function allows events to properly take care of updating language.