### PR TITLE
Facing Fix - One-Tile Movement and Job Facing

### DIFF
--- a/Assets/Scripts/State/JobState.cs
+++ b/Assets/Scripts/State/JobState.cs
@@ -71,6 +71,13 @@ namespace ProjectPorcupine.State
             else
             {
                 DebugLog(" - Next action: Work");
+
+                if(Job.tile != character.CurrTile)
+                {
+                    // We aren't standing on the job spot itself, so make sure to face it.
+                    character.FaceTile(Job.tile);
+                }
+
                 Job.DoWork(deltaTime);
             }
         }

--- a/Assets/Scripts/State/MoveState.cs
+++ b/Assets/Scripts/State/MoveState.cs
@@ -153,7 +153,6 @@ namespace ProjectPorcupine.State
             path.RemoveAt(0);
 
             character.FaceTile(nextTile);
-
         }
     }
 }

--- a/Assets/Scripts/State/MoveState.cs
+++ b/Assets/Scripts/State/MoveState.cs
@@ -68,10 +68,7 @@ namespace ProjectPorcupine.State
                     return;
                 }
 
-                nextTile = path[0];
-                path.RemoveAt(0);
-
-                character.FaceTile(nextTile);
+                AdvanceNextTile();
 
                 distToTravel = Mathf.Sqrt(
                     Mathf.Pow(character.CurrTile.X - nextTile.X, 2) +
@@ -134,8 +131,7 @@ namespace ProjectPorcupine.State
                 }
             }
 
-            nextTile = path[0];
-            path.RemoveAt(0);
+            AdvanceNextTile();
 
             distToTravel = Mathf.Sqrt(
                 Mathf.Pow(character.CurrTile.X - nextTile.X, 2) +
@@ -149,6 +145,15 @@ namespace ProjectPorcupine.State
             character.IsWalking = false;
 
             VisualPath.Instance.RemoveVisualPoints(character.name);
+        }
+
+        private void AdvanceNextTile()
+        {
+            nextTile = path[0];
+            path.RemoveAt(0);
+
+            character.FaceTile(nextTile);
+
         }
     }
 }


### PR DESCRIPTION
Fixes an issue where character waits until the end of a tile move to change facing, which lead to "moonwalking" at the start of pathing and is especially prominent during pathfinding that is only one-tile long.

An additional change makes the character face in the directly of the job tile for adjacent-position jobs.

In particular, this fixes some funny movement during floor construction.