### PR TITLE
Better up/down movement

### DIFF
--- a/Assets/Scripts/Pathfinding/Path_AStar.cs
+++ b/Assets/Scripts/Pathfinding/Path_AStar.cs
@@ -210,21 +210,28 @@ public class Path_AStar
         // on a grid at this point.
 
         // Hori/Vert neighbours have a distance of 1
-        if (Mathf.Abs(a.data.X - b.data.X) + Mathf.Abs(a.data.Y - b.data.Y) == 1)
+        if (Mathf.Abs(a.data.X - b.data.X) + Mathf.Abs(a.data.Y - b.data.Y) == 1 && a.data.Z == b.data.Z)
         {
             return 1f;
         }
 
         // Diag neighbours have a distance of 1.41421356237
-        if (Mathf.Abs(a.data.X - b.data.X) == 1 && Mathf.Abs(a.data.Y - b.data.Y) == 1)
+        if (Mathf.Abs(a.data.X - b.data.X) == 1 && Mathf.Abs(a.data.Y - b.data.Y) == 1 && a.data.Z == b.data.Z)
         {
             return 1.41421356237f;
+        }
+
+        // Up/Down neighbors have a distance of 1
+        if (a.data.X == b.data.X && a.data.Y == b.data.Y && Mathf.Abs(a.data.Z - b.data.Z) == 1)
+        {
+            return 1f;
         }
 
         // Otherwise, do the actual math.
         return Mathf.Sqrt(
             Mathf.Pow(a.data.X - b.data.X, 2) +
-            Mathf.Pow(a.data.Y - b.data.Y, 2));
+            Mathf.Pow(a.data.Y - b.data.Y, 2) +
+            Mathf.Pow(a.data.Z - b.data.Z, 2));
     }
 
     private void Reconstruct_path(

--- a/Assets/Scripts/State/MoveState.cs
+++ b/Assets/Scripts/State/MoveState.cs
@@ -72,7 +72,8 @@ namespace ProjectPorcupine.State
 
                 distToTravel = Mathf.Sqrt(
                     Mathf.Pow(character.CurrTile.X - nextTile.X, 2) +
-                    Mathf.Pow(character.CurrTile.Y - nextTile.Y, 2));
+                    Mathf.Pow(character.CurrTile.Y - nextTile.Y, 2) +
+                    Mathf.Pow(character.CurrTile.Z - nextTile.Z, 2));
 
                 if (nextTile.IsEnterable() == Enterability.Yes)
                 {


### PR DESCRIPTION
Neither characters nor pathfinding were properly taking into account Z, meaning they instantly moved up and down (and also considered up and down to basically 0 distance.

This just adds a quick calculation for tiles directly above and below, and includes Z into the calculations for distance both for PathAstar and MoveState