### PR TITLE
[Conflicts]some GUI changes (opinionated)

### DIFF
--- a/Assets/Scripts/UI/DialogBox/DialogBox.cs
+++ b/Assets/Scripts/UI/DialogBox/DialogBox.cs
@@ -18,9 +18,9 @@ public class DialogBox : MonoBehaviour
 
     public virtual void ShowDialog()
     {
-        openedWhileModal = WorldController.Instance.IsModal ? true : false;
+        //openedWhileModal = WorldController.Instance.IsModal ? true : false;
 
-        WorldController.Instance.IsModal = true;
+        //WorldController.Instance.IsModal = true;
 
         gameObject.transform.SetAsLastSibling();
         gameObject.SetActive(true);
@@ -30,7 +30,7 @@ public class DialogBox : MonoBehaviour
     {
         if (!openedWhileModal)
         {
-            WorldController.Instance.IsModal = false;
+            //WorldController.Instance.IsModal = false;
         }
 
         gameObject.SetActive(false);

--- a/Assets/Scripts/UI/DialogBox/DialogBoxManager.cs
+++ b/Assets/Scripts/UI/DialogBox/DialogBoxManager.cs
@@ -77,8 +77,36 @@ public class DialogBoxManager : MonoBehaviour
     private void AddMainMenuItems()
     {
         GameMenuManager.Instance.AddMenuItem(
+            "menu_construction",
+            () =>
+            {
+                // seems like the construction menu is different from a dialogBox?
+                // either way, grouped all menumanager.instance.addmenuitem calls here from /UI/InGameUI/MenuLeft.cs
+                MenuLeft menuLeft;
+                menuLeft = GameObject.Find("MenuLeft").GetComponent<MenuLeft>();
+                if (menuLeft.CurrentlyOpen != null && menuLeft.CurrentlyOpen.gameObject.name == "ConstructionMenu")
+                {
+                    menuLeft.CloseMenu();
+                }
+                else
+                {
+                    menuLeft.OpenMenu("ConstructionMenu");
+                }
+            },
+            0);
+
+        GameMenuManager.Instance.AddMenuItem(
             "menu_work",
-            () => dialogBoxJobList.ShowDialog(),
+            () =>
+            {
+                if (dialogBoxJobList.isActiveAndEnabled)
+                {
+                    dialogBoxJobList.CloseDialog();
+                    return;
+                }
+
+                dialogBoxJobList.ShowDialog();
+            },
             "menu_construction");
 
         GameMenuManager.Instance.AddMenuItem(
@@ -88,16 +116,25 @@ public class DialogBoxManager : MonoBehaviour
 
         GameMenuManager.Instance.AddMenuItem(
             "menu_quests",
-            () => dialogBoxQuests.ShowDialog(),
+            () => {
+                if (dialogBoxQuests.isActiveAndEnabled)
+                {
+                    dialogBoxQuests.CloseDialog();
+                    return;
+                }
+
+                dialogBoxQuests.ShowDialog();
+            },
             "menu_world");
 
         GameMenuManager.Instance.AddMenuItem(
             "menu_options",
             () =>
             {
-                if (dialogBoxSettings.isActiveAndEnabled)
+                if (dialogBoxOptions.isActiveAndEnabled)
                 {
-                    dialogBoxSettings.CloseDialog();
+                    dialogBoxOptions.CloseDialog();
+                    return;
                 }
 
                 dialogBoxOptions.ShowDialog();

--- a/Assets/Scripts/UI/InGameUI/GameMenu/GameMenuController.cs
+++ b/Assets/Scripts/UI/InGameUI/GameMenu/GameMenuController.cs
@@ -55,7 +55,7 @@ public class GameMenuController : MonoBehaviour
             CreateButton(mainMenuItem);
         }
 
-        DeactivateAll();
+        //DeactivateAll();
     }
 
     private void CreateButton(GameMenuItem mainMenuItem)
@@ -69,7 +69,7 @@ public class GameMenuController : MonoBehaviour
             {
                 if (!WorldController.Instance.IsModal)
                 {
-                    DeactivateAll();
+                    //DeactivateAll();
                     mainMenuItem.Trigger();
                 }
             });

--- a/Assets/Scripts/UI/InGameUI/MenuLeft.cs
+++ b/Assets/Scripts/UI/InGameUI/MenuLeft.cs
@@ -21,18 +21,15 @@ public class MenuLeft : MonoBehaviour
         parent = this.gameObject.transform;
 
         AddMenu("ConstructionMenu");
-
-        GameMenuManager.Instance.AddMenuItem("menu_construction", OnButtonConstruction, 0);
     }
 
     public void OpenMenu(string menuName)
     {
         GameObject menu = parent.FindChild(menuName).gameObject;
 
-        CloseMenu();
-
         menu.SetActive(true);
         CurrentlyOpen = menu;
+
         if (CurrentlyOpen.name == "ConstructionMenu")
         {
             WorldController.Instance.spawnInventoryController.SetUIVisibility(false);
@@ -62,16 +59,4 @@ public class MenuLeft : MonoBehaviour
         tempGoObj.name = menuName;
         tempGoObj.transform.SetParent(parent, false);
     }
-
-    private void OnButtonConstruction()
-    {
-        if (CurrentlyOpen != null && CurrentlyOpen.gameObject.name == "ConstructionMenu")
-        {
-            CloseMenu();
-        }
-        else
-        {
-            OpenMenu("ConstructionMenu");
-        }
-    } 
 }

--- a/Assets/Scripts/UI/InGameUI/MenuLeft/ConstructionMenu.cs
+++ b/Assets/Scripts/UI/InGameUI/MenuLeft/ConstructionMenu.cs
@@ -134,7 +134,7 @@ public class ConstructionMenu : MonoBehaviour
             button.onClick.AddListener(delegate
                 {
                     buildModeController.SetMode_BuildFurniture(objectId);
-                    menuLeft.CloseMenu();
+                    //menuLeft.CloseMenu();
                 });
 
             // http://stackoverflow.com/questions/1757112/anonymous-c-sharp-delegate-within-a-loop
@@ -183,7 +183,7 @@ public class ConstructionMenu : MonoBehaviour
             button.onClick.AddListener(delegate
                 {
                     buildModeController.SetMode_DesignateRoomBehavior(objectId);
-                    menuLeft.CloseMenu();
+                    //menuLeft.CloseMenu();
                 });
 
             // http://stackoverflow.com/questions/1757112/anonymous-c-sharp-delegate-within-a-loop
@@ -232,7 +232,7 @@ public class ConstructionMenu : MonoBehaviour
             button.onClick.AddListener(delegate
                 {
                     buildModeController.SetMode_BuildUtility(objectId);
-                    menuLeft.CloseMenu();
+                    //menuLeft.CloseMenu();
                 });
 
             // http://stackoverflow.com/questions/1757112/anonymous-c-sharp-delegate-within-a-loop


### PR DESCRIPTION
perhaps the only good thing in this commit is the attempt to group how the menu buttons are made (or at least... temporarily made). I'm not sure if the construction menu is _supposed_ to be treated differently from the other dialogs, but i'm guessing not.. or not so in the future... either way, it's now all in sorta one place (not really, just what used to be the OnButtonConstruction function is now an anonymous function similar to all the other dialogs upon construction of the main menu)

**opinionated stuff below this**

i don't like modality too much on gui things in games like these, but... turning it off in the Dialog class might be a bit too much... i noticed it kinda breaks the menu -> settings (and you can now reopen menu behind the settings dialog)

I also thought not auto closing the construction menu on certain categories (essentially anything but 'floor' and 'floor removal') would be more user friendly??, if you want to build multiple things at once, it kinda saves you a step / having to reopen the dialog every time.