### PR TITLE
Update Localization table in Start

### DIFF
--- a/Assets/Scripts/Localization/LocalizationLoader.cs
+++ b/Assets/Scripts/Localization/LocalizationLoader.cs
@@ -84,6 +84,14 @@ namespace ProjectPorcupine.Localization
             // Update localization from the internet.
             StartCoroutine(LocalizationDownloader.CheckIfCurrentLocalizationIsUpToDate(delegate { UpdateLocalizationTable(); }));
 
+            // Even though it's ran again in start, UpdateLocalizationTable still needs ran here to actually have the chose language
+            // show on start, I don't really know why.
+            UpdateLocalizationTable();
+        }
+
+        private void Start()
+        {
+            // UpdateLocalizationTable needs to run after everything with TextLocalizer components have set their callbacks, so we run in start.
             UpdateLocalizationTable();
         }
     }


### PR DESCRIPTION
I'm not sure why UpdateLocalizationTable needs called from both awake and start, but I tried removing it from awake, and things didn't work.... so... o.O I don't really know why it's still needed in awake... not even trying to touch the other one in the delegate because there's certainly some stuff going on that I don't fully understand... but at least this works as advertised :D