### PR TITLE
[Fix, Small] Characters continue working repeating jobs

### DIFF
--- a/Assets/Scripts/Models/Job/Job.cs
+++ b/Assets/Scripts/Models/Job/Job.cs
@@ -215,7 +215,8 @@ public class Job : ISelectable, IPrototypable
         set;
     }
 
-    public bool IsRepeating{
+    public bool IsRepeating
+    {
         get
         {
             return jobRepeats;

--- a/Assets/Scripts/Models/Job/Job.cs
+++ b/Assets/Scripts/Models/Job/Job.cs
@@ -215,6 +215,13 @@ public class Job : ISelectable, IPrototypable
         set;
     }
 
+    public bool IsRepeating{
+        get
+        {
+            return jobRepeats;
+        }
+    }
+
     public Pathfinder.GoalEvaluator IsTileAtJobSite
     {
         get

--- a/Assets/Scripts/State/JobState.cs
+++ b/Assets/Scripts/State/JobState.cs
@@ -137,17 +137,21 @@ namespace ProjectPorcupine.State
 
         private void OnJobCompleted(Job finishedJob)
         {
-            DebugLog(" - Job finished");
-
-            jobFinished = true;
-
-            finishedJob.OnJobCompleted -= OnJobCompleted;
-            finishedJob.OnJobStopped -= OnJobStopped;
-
-            if (Job != finishedJob)
+            // Finish job, unless it repeats, in which case continue as if nothing happened.
+            if (finishedJob.IsRepeating == false)
             {
-                Debug.ULogErrorChannel("Character", "Character being told about job that isn't his. You forgot to unregister something.");
-                return;
+                DebugLog(" - Job finished");
+
+                jobFinished = true;
+
+                finishedJob.OnJobCompleted -= OnJobCompleted;
+                finishedJob.OnJobStopped -= OnJobStopped;
+
+                if (Job != finishedJob)
+                {
+                    Debug.ULogErrorChannel("Character", "Character being told about job that isn't his. You forgot to unregister something.");
+                    return;
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes #1505

Repeating jobs weren't being returned to the queue or being cancelled, but characters silently dumped them when finished with one cycle. They now keep the job if it is a repeating job (added a public property to see if a job repeats), only abandoning it if something else comes up, this seems to most closely match pre-FSM behavior, and seems more desirable to have a single character keep working a job as long as nothing else interrupts them, rather than repeatedly returning it to the queue and having new characters take turns doing it.