### PR TITLE
[Fix, Small] Options Menu now Localizes Languages

### DIFF
--- a/Assets/Scripts/Localization/LocalizationTable.cs
+++ b/Assets/Scripts/Localization/LocalizationTable.cs
@@ -37,7 +37,7 @@ namespace ProjectPorcupine.Localization
 
         public static event Action CBLocalizationFilesChanged;
 
-        private enum FallbackMode
+        public enum FallbackMode
         {
             ReturnKey, ReturnDefaultLanguage
         }
@@ -106,10 +106,32 @@ namespace ProjectPorcupine.Localization
                     localizationTable[localizationCode] = new Dictionary<string, string>();
                 }
 
+                //Read all lines in advance, we need it to know how the language is called.
+                string[] lines = File.ReadAllLines(path);
+
+                //We assume that A) the key is the first line B) the key is always the localizationCode
+                //If not, we know this language hasn't been updated yet, so insert the localizationCode as key and value
+                if (lines.Length > 0) //If this if check will ever return false... we now something is terribly wrong!
+                {
+                    //Split the line
+                    string[] line = lines[0].Split(new char[] { '=' }, 2);
+
+                    //Check if the language starts with a valid name.
+                    if(line[0] == localizationCode)
+                    {
+                        //It does, add it to the list, we need it later.
+                        localizationTable[localizationCode][localizationCode] = line[1];
+                    }
+                    else
+                    {
+                        //It doesn't, add the localizationCode as a fallback for now.
+                        localizationTable[localizationCode][localizationCode] = localizationCode;
+                    }
+                }
+
                 // Only the current and default languages translations will be loaded in memory.
                 if (localizationCode == DefaultLanguage || localizationCode == currentLanguage)
                 {
-                    string[] lines = File.ReadAllLines(path);
                     foreach (string line in lines)
                     {
                         string[] keyValuePair = line.Split(new char[] { '=' }, 2);
@@ -132,7 +154,7 @@ namespace ProjectPorcupine.Localization
         /// <summary>
         /// Returns the localization for the given key, or the key itself, if no translation exists.
         /// </summary>
-        private static string GetLocalization(string key, FallbackMode fallbackMode, string language, params string[] additionalValues)
+        public static string GetLocalization(string key, FallbackMode fallbackMode, string language, params string[] additionalValues)
         {
             string value;
             if (localizationTable.ContainsKey(language) && localizationTable[language].TryGetValue(key, out value))

--- a/Assets/Scripts/Localization/LocalizationTable.cs
+++ b/Assets/Scripts/Localization/LocalizationTable.cs
@@ -117,15 +117,15 @@ namespace ProjectPorcupine.Localization
                     string[] line = lines[0].Split(new char[] { '=' }, 2);
 
                     //Check if the language starts with a valid name.
-                    if(line[0] == localizationCode)
+                    if(line[0] == "lang")
                     {
                         //It does, add it to the list, we need it later.
-                        localizationTable[localizationCode][localizationCode] = line[1];
+                        localizationTable[localizationCode]["lang"] = line[1];
                     }
                     else
                     {
                         //It doesn't, add the localizationCode as a fallback for now.
-                        localizationTable[localizationCode][localizationCode] = localizationCode;
+                        localizationTable[localizationCode]["lang"] = localizationCode;
                     }
                 }
 

--- a/Assets/Scripts/UI/LanguageDropdownUpdater.cs
+++ b/Assets/Scripts/UI/LanguageDropdownUpdater.cs
@@ -28,7 +28,7 @@ public class LanguageDropdownUpdater : MonoBehaviour
 
         foreach (string lang in languages)
         {
-            dropdown.options.Add(new Dropdown.OptionData(lang));
+            dropdown.options.Add(new DropdownValue(lang));
         }
 
         for (int i = 0; i < languages.Length; i++)
@@ -43,5 +43,16 @@ public class LanguageDropdownUpdater : MonoBehaviour
 
         // Set scroll sensitivity based on the save-item count.
         dropdown.template.GetComponent<ScrollRect>().scrollSensitivity = dropdown.options.Count / 3;
+    }
+
+    public class DropdownValue : Dropdown.OptionData
+    {
+        public string language;
+
+        public DropdownValue(string lang)
+        {
+            language = lang;
+            text = LocalizationTable.GetLocalization(lang, LocalizationTable.FallbackMode.ReturnKey, lang);
+        }
     }
 }

--- a/Assets/Scripts/UI/LanguageDropdownUpdater.cs
+++ b/Assets/Scripts/UI/LanguageDropdownUpdater.cs
@@ -52,7 +52,7 @@ public class LanguageDropdownUpdater : MonoBehaviour
         public DropdownValue(string lang)
         {
             language = lang;
-            text = LocalizationTable.GetLocalization(lang, LocalizationTable.FallbackMode.ReturnKey, lang);
+            text = LocalizationTable.GetLocalization("lang", LocalizationTable.FallbackMode.ReturnKey, lang);
         }
     }
 }

--- a/Assets/StreamingAssets/Localization/en_US.lang
+++ b/Assets/StreamingAssets/Localization/en_US.lang
@@ -1,3 +1,4 @@
+en_US=English (US)
 menu_apply=Apply
 menu_construction=Construction
 menu_work=Work

--- a/Assets/StreamingAssets/Localization/en_US.lang
+++ b/Assets/StreamingAssets/Localization/en_US.lang
@@ -1,4 +1,4 @@
-en_US=English (US)
+lang=English (US)
 menu_apply=Apply
 menu_construction=Construction
 menu_work=Work


### PR DESCRIPTION
The options menu now localizes the languages you can select. It does this at the moment only for US English, but the people who work on localization can add this to other languages too. This is to finally close #358 and this is also a milestone for Version 0.2.