### PR TITLE
Correctly wait for saving to be completed

### DIFF
--- a/Assets/Scripts/UI/DialogBox/FileSaveLoad/DialogBoxSaveGame.cs
+++ b/Assets/Scripts/UI/DialogBox/FileSaveLoad/DialogBoxSaveGame.cs
@@ -93,9 +93,16 @@ public class DialogBoxSaveGame : DialogBoxLoadSaveGame
             dbm.dialogBoxPromptOrInfo.SetPrompt("message_saving_game");
             dbm.dialogBoxPromptOrInfo.ShowDialog();
 
-            yield return new WaitForSecondsRealtime(.05f);
+            // Skip a frame so that user will see pop-up
+            yield return null;
 
-            SaveWorld(filePath);
+            Thread t = SaveWorld(filePath);
+
+            // Wait for data to be saved to HDD.
+            while (t.IsAlive)
+            {
+                yield return null;
+            }
 
             dbm.dialogBoxPromptOrInfo.CloseDialog();
 
@@ -111,7 +118,13 @@ public class DialogBoxSaveGame : DialogBoxLoadSaveGame
         }
     }
 
-    public void SaveWorld(string filePath)
+    /// <summary>
+    /// Serializes current Instance of the World and starts a thread
+    /// that actually saves serialized world to HDD.
+    /// </summary>
+    /// <param name="filePath">Where to save (Full path).</param>
+    /// <returns>Returns the thread that is currently saving data to HDD.</returns>
+    public Thread SaveWorld(string filePath)
     {
         // This function gets called when the user confirms a filename
         // from the save dialog box.
@@ -143,10 +156,12 @@ public class DialogBoxSaveGame : DialogBoxLoadSaveGame
         // This reduces lag while saving by a little bit.
         Thread t = new Thread(new ThreadStart(delegate { SaveWorldToHdd(filePath, writer); }));
         t.Start();
+
+        return t;
     }
 
     /// <summary>
-    /// Create/overwrite the save file with the xml text.
+    /// Create/overwrite the save file with the XML text.
     /// </summary>
     /// <param name="filePath">Full path to file.</param>
     /// <param name="writer">TextWriter that contains serialized World data.</param>

--- a/Assets/Scripts/UI/DialogBox/FileSaveLoad/DialogBoxSaveGame.cs
+++ b/Assets/Scripts/UI/DialogBox/FileSaveLoad/DialogBoxSaveGame.cs
@@ -138,7 +138,7 @@ public class DialogBoxSaveGame : DialogBoxLoadSaveGame
         writer.Close();
 
         // Leaving this unchanged as UberLogger doesn't handle multi-line messages well.
-        Debug.Log(writer.ToString());
+        //Debug.Log(writer.ToString());
 
         // PlayerPrefs.SetString("SaveGame00", writer.ToString());
 


### PR DESCRIPTION
Before that user would see "saving complete" pop-up, but in reality a separate thread was still writing data.
Also - I disabled dumping raw XML onto editor's console because it was really hanging the editor.

Sorry for not including this in #1496