### PR TITLE
Initial job lag fix

### DIFF
--- a/Assets/Scripts/Models/Area/World.cs
+++ b/Assets/Scripts/Models/Area/World.cs
@@ -56,6 +56,8 @@ public class World : IXmlSerializable
         WorldGenerator.Generate(this, seed);
         Debug.ULogChannel("World", "Generated World");
 
+        tileGraph = new Path_TileGraph(this);
+
         // Adding air to enclosed rooms
         foreach (Room room in this.RoomManager)
         {
@@ -351,6 +353,7 @@ public class World : IXmlSerializable
         Depth = int.Parse(reader.GetAttribute("Depth"));
 
         SetupWorld(Width, Height, Depth);
+        tileGraph = new Path_TileGraph(this);
 
         while (reader.Read())
         {

--- a/Assets/Scripts/Models/Area/World.cs
+++ b/Assets/Scripts/Models/Area/World.cs
@@ -56,6 +56,7 @@ public class World : IXmlSerializable
         WorldGenerator.Generate(this, seed);
         Debug.ULogChannel("World", "Generated World");
 
+
         // Adding air to enclosed rooms
         foreach (Room room in this.RoomManager)
         {
@@ -351,6 +352,7 @@ public class World : IXmlSerializable
         Depth = int.Parse(reader.GetAttribute("Depth"));
 
         SetupWorld(Width, Height, Depth);
+        tileGraph = new Path_TileGraph(this);
 
         while (reader.Read())
         {

--- a/Assets/Scripts/Models/Area/World.cs
+++ b/Assets/Scripts/Models/Area/World.cs
@@ -56,7 +56,6 @@ public class World : IXmlSerializable
         WorldGenerator.Generate(this, seed);
         Debug.ULogChannel("World", "Generated World");
 
-
         // Adding air to enclosed rooms
         foreach (Room room in this.RoomManager)
         {
@@ -352,7 +351,6 @@ public class World : IXmlSerializable
         Depth = int.Parse(reader.GetAttribute("Depth"));
 
         SetupWorld(Width, Height, Depth);
-        tileGraph = new Path_TileGraph(this);
 
         while (reader.Read())
         {


### PR DESCRIPTION
Moved the tilegraph creation to the world constructor. This way the tilegraph is created when the world is initialized instead of on the first job request.