### PR TITLE
Remove commented out code and fix stylecop violation

### DIFF
--- a/Assets/Scripts/UI/DialogBox/FileSaveLoad/DialogBoxSaveGame.cs
+++ b/Assets/Scripts/UI/DialogBox/FileSaveLoad/DialogBoxSaveGame.cs
@@ -137,10 +137,8 @@ public class DialogBoxSaveGame : DialogBoxLoadSaveGame
         serializer.Serialize(writer, WorldController.Instance.World);
         writer.Close();
 
-        // Leaving this unchanged as UberLogger doesn't handle multi-line messages well.
-        //Debug.Log(writer.ToString());
-
-        // PlayerPrefs.SetString("SaveGame00", writer.ToString());
+        // UberLogger doesn't handle multi-line messages well.
+        // Debug.Log(writer.ToString());
 
         // Make sure the save folder exists.
         if (Directory.Exists(WorldController.Instance.FileSaveBasePath()) == false)


### PR DESCRIPTION
- remove commented out code from when saves were done in a playerpref 
- fixed stylecop error for no space between `//` and comment text

Ill be self merging this since it doesn't touch any real code and I didn't catch the stylecop error when I merged a previous PR