### PR TITLE
Create Github Issue and Pull Request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,31 @@
+Check your title. Try to make it short but descriptive. Have a quick look at the available [labels](https://github.com/TeamPorcupine/ProjectPorcupine/labels). If one seems relevant prefix the title with [label name].
+
+NOTE: This template is not enforced. You are encouraged to include all of the detail below, but if anything doesn't fit this particular issue feel free to delete it!
+
+### Expected behavior
+
+Should do X
+
+### Actual behavior
+
+Instead does Y
+
+```
+include error messages or stack trace if there are any exceptions
+```
+
+### Steps to reproduce the behavior
+
+- Step 1: do foo
+- Step 2: do bar
+- Step 3: do baz
+
+### Related issues / pull requests
+
+Reference #numbers here
+
+### Specs
+
+Any relevant system / version information. Include the output of running `git describe --tags` on the local repository you are testing against.
+
+Pings: @mentions (Note: all project maintainers are automatically notified of new issues. Only ping one if it is specifically relevant to them.)

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -9,6 +9,7 @@ Should do X
 ### Actual behavior
 
 Instead does Y
+If it would help, you may include an image or animated gif of the problem.
 
 ```
 include error messages or stack trace if there are any exceptions

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,10 +12,11 @@ Closes #
 ### What this PR does
 
 Describe _how_ you have fixed the issue(s).
-If there are any UI or sprite changes, please include an image showing the new element(s).
+If there are any UI or sprite changes, please include an image showing the new element(s) and keep it updated for subsequent changes.
+For any animations it is helpful to include an animated gif.
 Please ensure that you have the proper permission to include any copyrighted art or sound assets under license terms compatible with the open source licensing of this project.
 
-## TODO (if this is a [WIP] PR)
+### TODO (if this is a [WIP] PR)
 
 - [ ] foo
 - [ ] bar

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+First check your title. If this pull request has incomplete or unstable code prefix the title with [WIP]. Often people will give you feedback anyway, but if you are specifically requesting feedback prefix [Feedback Requested] to the title.
+
+NOTE: This template is not enforced. You are encouraged to include all of the detail below, but if anything doesn't fit this particular pull request feel free to delete it!
+
+### The issue this fixes
+
+Briefly describe the issue(s) addressed by this pull request. If there are any relevant issues or pull requests on Github reference their #numbers here.
+
+Fixes # 
+Closes # 
+
+### What this PR does
+
+Describe _how_ you have fixed the issue(s).
+If there are any UI or sprite changes, please include an image showing the new element(s).
+Please ensure that you have the proper permission to include any copyrighted art or sound assets under license terms compatible with the open source licensing of this project.
+
+## TODO (if this is a [WIP] PR)
+
+- [ ] foo
+- [ ] bar
+- [ ] baz
+
+Pings: @mentions (Note: all project maintainers are automatically notified of new pull requests. Only ping one if it is specifically relevant to them.)


### PR DESCRIPTION
These templates are automatically filled in the editor textarea when
someone creates an Issue or Pull request on Github.
The text can be changed or deleted at will by the user, it is there merely
to serve as a prompt to include the pertinent information and format it in
a useful way.

Here is an example of how this PR might look if using the template:

----

### The issue this fixes

Issues and pull request messages have been of very uneven quality. I am as guilty as anyone in terms of including inadequate or poorly presented information in pull requests. But over the history of the project so far, people have submitted things ranging from impossible to read stream of consciousness style messages, to messages with no informative content at all.

### What this PR does

Luckily Github makes it possible to create [issue](https://help.github.com/articles/creating-an-issue-template-for-your-repository/) and [pull request](https://help.github.com/articles/creating-a-pull-request-template-for-your-repository/) templates to make it easier for contributors to write meaningful messages that are informative and follow the contributing guidelines for the project.

I've taken the liberty of creating some templates based on the contributing guidelines and discord feedback.

Pings: Thanks @frankitox16 @bjubes and @TomMalbran for useful feedback via discord.
