### PR TITLE
[Fix] Don't phase through floors traveling up, and don't work through floor tiles

### DIFF
--- a/Assets/Scripts/Models/Area/World.cs
+++ b/Assets/Scripts/Models/Area/World.cs
@@ -543,6 +543,7 @@ public class World : IXmlSerializable
         if (tileGraph != null)
         {
             tileGraph.RegenerateGraphAtTile(t);
+            tileGraph.RegenerateGraphAtTile(t.Down());
         }
     }
 

--- a/Assets/Scripts/Models/Buildable/Tile.cs
+++ b/Assets/Scripts/Models/Buildable/Tile.cs
@@ -459,6 +459,16 @@ public class Tile : IXmlSerializable, ISelectable, IContextActionProvider, IComp
         return World.Current.GetTileAt(X - 1, Y, Z);
     }
 
+    public Tile Up()
+    {
+        return World.Current.GetTileAt(X, Y, Z - 1);
+    }
+
+    public Tile Down()
+    {
+        return World.Current.GetTileAt(X, Y, Z + 1);
+    }
+
     public Enterability IsEnterable()
     {
         // This returns true if you can enter this tile right this moment.

--- a/Assets/Scripts/Models/Buildable/Tile.cs
+++ b/Assets/Scripts/Models/Buildable/Tile.cs
@@ -343,7 +343,7 @@ public class Tile : IXmlSerializable, ISelectable, IContextActionProvider, IComp
     /// </summary>
     /// <returns>The neighbours.</returns>
     /// <param name="diagOkay">Is diagonal movement okay?.</param>
-    public Tile[] GetNeighbours(bool diagOkay = false)
+    public Tile[] GetNeighbours(bool diagOkay = false, bool vertOkay = false)
     {
         Tile[] tiles = diagOkay == false ? new Tile[6] : new Tile[10];
         tiles[0] = World.Current.GetTileAt(X, Y + 1, Z);
@@ -352,17 +352,12 @@ public class Tile : IXmlSerializable, ISelectable, IContextActionProvider, IComp
         tiles[3] = World.Current.GetTileAt(X - 1, Y, Z);
 
         // FIXME: This is a bit of a dirty hack, but it works for preventing characters from phasing through the floor for now.
-        Tile tileup = World.Current.GetTileAt(X, Y, Z - 1);
-        if (tileup != null && tileup.Type == TileType.Empty)
+        if (vertOkay)
         {
-            tiles[4] = World.Current.GetTileAt(X, Y, Z - 1);
+            Tile[] vertTiles = GetVerticalNeighbors(true);
+            tiles[4] = vertTiles[0];
+            tiles[5] = vertTiles[1];
         }
-
-        if (Type == TileType.Empty)
-        {
-            tiles[5] = World.Current.GetTileAt(X, Y, Z + 1);
-        }
-
         if (diagOkay == true)
         {
             tiles[6] = World.Current.GetTileAt(X + 1, Y + 1, Z);
@@ -374,12 +369,34 @@ public class Tile : IXmlSerializable, ISelectable, IContextActionProvider, IComp
         return tiles.Where(tile => tile != null).ToArray();
     }
 
+    public Tile[] GetVerticalNeighbors(bool nullOkay = false)
+    {
+        Tile[] tiles = new Tile[2];
+        Tile tileup = World.Current.GetTileAt(X, Y, Z - 1);
+        if (tileup != null && tileup.Type == TileType.Empty)
+        {
+            tiles[0] = World.Current.GetTileAt(X, Y, Z - 1);
+        }
+
+        if (Type == TileType.Empty)
+        {
+            tiles[1] = World.Current.GetTileAt(X, Y, Z + 1);
+        }   
+        if(!nullOkay)
+        {
+            return tiles.Where(tile => tile != null).ToArray();
+        }
+        else
+        {
+            return tiles;
+        }
+    }
     /// <summary>
     /// If one of the 8 neighbouring tiles is of TileType type then this returns true.
     /// </summary>
     public bool HasNeighboursOfType(TileType tileType)
     {
-        return GetNeighbours(true).Any(tile => (tile != null && tile.Type == tileType));
+        return GetNeighbours(true, true).Any(tile => (tile != null && tile.Type == tileType));
     }
 
     /// <summary>
@@ -388,7 +405,9 @@ public class Tile : IXmlSerializable, ISelectable, IContextActionProvider, IComp
     /// <param name="checkDiagonals">Will test diagonals as well if true.</param>
     public bool IsReachableFromAnyNeighbor(bool checkDiagonals = false)
     {
-        return GetNeighbours(checkDiagonals).Any(tile => tile != null && tile.MovementCost > 0 && (checkDiagonals == false || IsClippingCorner(tile) == false));
+        bool reachableFromSameLevel = GetNeighbours(checkDiagonals).Any(tile => tile != null && tile.MovementCost > 0 && (checkDiagonals == false || IsClippingCorner(tile) == false));
+        bool reachableVertically = GetVerticalNeighbors().Length > 0;
+        return reachableFromSameLevel || reachableVertically;
     }
 
     public bool IsClippingCorner(Tile neighborTile)

--- a/Assets/Scripts/Models/Buildable/Tile.cs
+++ b/Assets/Scripts/Models/Buildable/Tile.cs
@@ -343,6 +343,7 @@ public class Tile : IXmlSerializable, ISelectable, IContextActionProvider, IComp
     /// </summary>
     /// <returns>The neighbours.</returns>
     /// <param name="diagOkay">Is diagonal movement okay?.</param>
+    /// <param name="vertOkay">Is vertical movement okay?.</param>
     public Tile[] GetNeighbours(bool diagOkay = false, bool vertOkay = false)
     {
         Tile[] tiles = diagOkay == false ? new Tile[6] : new Tile[10];

--- a/Assets/Scripts/Models/Buildable/Tile.cs
+++ b/Assets/Scripts/Models/Buildable/Tile.cs
@@ -359,6 +359,7 @@ public class Tile : IXmlSerializable, ISelectable, IContextActionProvider, IComp
             tiles[4] = vertTiles[0];
             tiles[5] = vertTiles[1];
         }
+
         if (diagOkay == true)
         {
             tiles[6] = World.Current.GetTileAt(X + 1, Y + 1, Z);
@@ -382,8 +383,9 @@ public class Tile : IXmlSerializable, ISelectable, IContextActionProvider, IComp
         if (Type == TileType.Empty)
         {
             tiles[1] = World.Current.GetTileAt(X, Y, Z + 1);
-        }   
-        if(!nullOkay)
+        }
+
+        if (!nullOkay)
         {
             return tiles.Where(tile => tile != null).ToArray();
         }
@@ -392,6 +394,7 @@ public class Tile : IXmlSerializable, ISelectable, IContextActionProvider, IComp
             return tiles;
         }
     }
+
     /// <summary>
     /// If one of the 8 neighbouring tiles is of TileType type then this returns true.
     /// </summary>

--- a/Assets/Scripts/Pathfinding/Path_AStar.cs
+++ b/Assets/Scripts/Pathfinding/Path_AStar.cs
@@ -201,7 +201,8 @@ public class Path_AStar
 
         return Mathf.Sqrt(
             Mathf.Pow(a.data.X - b.data.X, 2) +
-            Mathf.Pow(a.data.Y - b.data.Y, 2));
+            Mathf.Pow(a.data.Y - b.data.Y, 2) +
+            Mathf.Pow(a.data.Z - b.data.Z, 2));
     }
 
     private float Dist_between(Path_Node<Tile> a, Path_Node<Tile> b)

--- a/Assets/Scripts/Pathfinding/Path_TileGraph.cs
+++ b/Assets/Scripts/Pathfinding/Path_TileGraph.cs
@@ -26,6 +26,7 @@ public class Path_TileGraph
         *  Do we create nodes for non-floor tiles?  NO!
         *  Do we create nodes for tiles that are completely unwalkable (i.e. walls)?  NO!
         */
+
         nodes = new Dictionary<Tile, Path_Node<Tile>>();
 
         for (int x = 0; x < world.Width; x++)
@@ -74,7 +75,7 @@ public class Path_TileGraph
         List<Path_Edge<Tile>> edges = new List<Path_Edge<Tile>>();
 
         // Get a list of neighbours for the tile
-        Tile[] neighbours = t.GetNeighbours(true);
+        Tile[] neighbours = t.GetNeighbours(true, true);
 
         // NOTE: Some of the array spots could be null.
         // If neighbour is walkable, create an edge to the relevant node.

--- a/Assets/Scripts/Pathfinding/Pathfinder.cs
+++ b/Assets/Scripts/Pathfinding/Pathfinder.cs
@@ -180,14 +180,17 @@ namespace ProjectPorcupine.Pathfinding
                 int minZ = goalTile.Z - 1;
                 int maxZ = goalTile.Z + 1;
 
+                // Tile is either adjacent on the same level, or directly above/below, and if above, is empty
                 return tile => (
                     (tile.X >= minX && tile.X <= maxX &&
                     tile.Y >= minY && tile.Y <= maxY &&
                     tile.Z == goalTile.Z &&
                     goalTile.IsClippingCorner(tile) == false) || 
-                    (tile.Z >= minZ && tile.Z <= maxZ &&
+                    ((tile.Z >= minZ && tile.Z <= maxZ &&
                     tile.X == goalTile.X &&
-                    tile.Y == goalTile.Y));
+                    tile.Y == goalTile.Y) && 
+                    (tile.Z >= goalTile.Z ||
+                    tile.Type == TileType.Empty)));
             }
             else
             {

--- a/Assets/Scripts/UI/VisualPath.cs
+++ b/Assets/Scripts/UI/VisualPath.cs
@@ -107,7 +107,7 @@ public class VisualPath : MonoBehaviour
             {
                 if (i != 0)
                 {
-                    GL.Vertex3(VisualPoints[entry][i - 1].X, VisualPoints[entry][i - 1].Y, VisualPoints[entry][i-1].Z);
+                    GL.Vertex3(VisualPoints[entry][i - 1].X, VisualPoints[entry][i - 1].Y, VisualPoints[entry][i - 1].Z);
                 }
                 else
                 {

--- a/Assets/Scripts/UI/VisualPath.cs
+++ b/Assets/Scripts/UI/VisualPath.cs
@@ -107,14 +107,14 @@ public class VisualPath : MonoBehaviour
             {
                 if (i != 0)
                 {
-                    GL.Vertex3(VisualPoints[entry][i - 1].X, VisualPoints[entry][i - 1].Y, 0);
+                    GL.Vertex3(VisualPoints[entry][i - 1].X, VisualPoints[entry][i - 1].Y, VisualPoints[entry][i-1].Z);
                 }
                 else
                 {
-                    GL.Vertex3(VisualPoints[entry][i].X, VisualPoints[entry][i].Y, 0);
+                    GL.Vertex3(VisualPoints[entry][i].X, VisualPoints[entry][i].Y, VisualPoints[entry][i].Z);
                 }
 
-                GL.Vertex3(VisualPoints[entry][i].X, VisualPoints[entry][i].Y, 0);
+                GL.Vertex3(VisualPoints[entry][i].X, VisualPoints[entry][i].Y,  VisualPoints[entry][i].Z);
             }
         }
 


### PR DESCRIPTION
Currently, characters will travel up through newly place floor tiles, and will work on a tile from below, even if there is a floor tile in the way.

This regenerates the tilegraph around the tile below a newly placed tile, making the tileGraph aware that access to the tile from below is blocked by the floor tile. A separate check is added when getting acceptable tiles to work adjacent from so that a floor tile in the tile that needs to be worked will block adjacency from below.

Additionally minor changes were made to GetNeighbors (vertical adjacency is optional, and off by default, and the vertical adjacency is farmed to a separate method, to allow access to only vertical neighbors for situations when they need to be handled specially. Also convenience methods were added to access the Up and Down neighbors. The Heuristic Cost Estimate was also adjusted to take vertical distance into account, as this wasn't accounted for in the previous PR adapting the pathfinding to z-layers.

To test:
1st Part: Build a room separate from the starting base on the top level, place inventory in the separate room, in master, a crew will phase through one of the floor tiles, in this PR, they won't start moving.
2nd Part: Find an asteroid on the top level, that doesn't have a layer of asteroid below it (alternatively an asteroid on a lower level that has direct access to the top of it blocked by a layer of asteroid above), and attempt to mine somewhere in the middle, in master crew will happily mine from below, in this PR, they won't. (Testing this portion with the new room won't work as inability to bring inventory to a furniture to be built will mask the lack of ability to work from below through the floor)

Caveat: FPS will drop when the crew is unable to reach the inventory in the newly built room, due to a separate issue in the pathfinder (continually trying to path to it)