### PR TITLE
[Small][Fix] Check if FPS Counter is null before applying settings

### DIFF
--- a/Assets/Scripts/UI/DialogBox/Settings/DialogBoxSettings.cs
+++ b/Assets/Scripts/UI/DialogBox/Settings/DialogBoxSettings.cs
@@ -48,7 +48,11 @@ public class DialogBoxSettings : DialogBox
     {
         LocalizationTable.SetLocalization(languageDropdown.value);
         
-        fpsObject.SetActive(fpsToggle.isOn);
+        if (fpsObject != null)
+        {
+            fpsObject.SetActive(fpsToggle.isOn);
+        }
+
         WorldController.Instance.spawnInventoryController.SetUIVisibility(developerModeToggle.isOn);
 
         // MasterTextureLimit should get 0 for High quality and higher values for lower qualities.
@@ -93,7 +97,10 @@ public class DialogBoxSettings : DialogBox
 
         fullScreenToggle.isOn = Screen.fullScreen;
 
-        fpsObject = FindObjectOfType<FPSCounter>().gameObject;
+        if (FindObjectOfType<FPSCounter>() != null)
+        {
+            fpsObject = FindObjectOfType<FPSCounter>().gameObject;
+        }       
 
         CreateResolutionDropdown();
 


### PR DESCRIPTION
### Fixes DialogBoxSettings error
Fixes #1526 

### What this PR does
Now DialogBoxSettings checks if the FPSCounter is null, to avoid errors while loading settings. 
