### PR TITLE
Adjust Charaters speed.

### DIFF
--- a/Assets/Scripts/Models/Character/Character.cs
+++ b/Assets/Scripts/Models/Character/Character.cs
@@ -611,8 +611,8 @@ public class Character : IXmlSerializable, ISelectable, IContextActionProvider
     /// </summary>
     private void UseStats()
     {
-        // The speed is equal to (baseSpeed +/-50% of baseSpeed depending on Dexterity)
-        speed = baseSpeed + (0.5f * baseSpeed * ((Convert.ToSingle(stats["Dexterity"].Value) - 10) / 10));
+        // The speed is equal to (baseSpeed +/-30% of baseSpeed depending on Dexterity)
+        speed = baseSpeed + (0.3f * baseSpeed * ((Convert.ToSingle(stats["Dexterity"].Value) - 10) / 10));
 
         // Base character max health on their constitution.
         health = new HealthSystem(50 + (Convert.ToSingle(stats["Constitution"].Value) * 5));

--- a/Assets/Scripts/Models/Character/Character.cs
+++ b/Assets/Scripts/Models/Character/Character.cs
@@ -63,7 +63,8 @@ public class Character : IXmlSerializable, ISelectable, IContextActionProvider
     private List<Tile> movementPath;
 
     /// Tiles per second.
-    private float speed = 5f;
+    private float speed;
+    private float baseSpeed = 5f;
 
     /// Used for health system.
     private HealthSystem health;
@@ -610,8 +611,8 @@ public class Character : IXmlSerializable, ISelectable, IContextActionProvider
     /// </summary>
     private void UseStats()
     {
-        // Base character speed on their dexterity.
-        speed = Convert.ToSingle(stats["Dexterity"].Value) / 2;
+        // The speed is equal to (baseSpeed +/-50% of baseSpeed depending on Dexterity)
+        speed = baseSpeed + (0.5f * baseSpeed * ((Convert.ToSingle(stats["Dexterity"].Value) - 10) / 10));
 
         // Base character max health on their constitution.
         health = new HealthSystem(50 + (Convert.ToSingle(stats["Constitution"].Value) * 5));


### PR DESCRIPTION
I adjust characters speed with this formula.

speed = baseSpeed +/-30% of baseSpeed depending on Dexterity.

The baseSpeed is 5 tile per sec. So it can go from 3.5 to 6.5.

The original formula is Dexterity / 2 so there is a range of 0.5 to 10. It feel a little too extreme.