### PR TITLE
[Fix] Fixes crash when loading save with character carrying inventory

### DIFF
--- a/Assets/Scripts/Models/Inventory/InventoryManager.cs
+++ b/Assets/Scripts/Models/Inventory/InventoryManager.cs
@@ -161,6 +161,10 @@ public class InventoryManager
         {
             character.inventory = sourceInventory.Clone();
             character.inventory.StackSize = 0;
+            if (Inventories.ContainsKey(character.inventory.Type) == false)
+            {
+                Inventories[character.inventory.Type] = new List<Inventory>();
+            }
             Inventories[character.inventory.Type].Add(character.inventory);
         }
         else if (character.inventory.Type != sourceInventory.Type)

--- a/Assets/Scripts/Models/Inventory/InventoryManager.cs
+++ b/Assets/Scripts/Models/Inventory/InventoryManager.cs
@@ -165,6 +165,7 @@ public class InventoryManager
             {
                 Inventories[character.inventory.Type] = new List<Inventory>();
             }
+            
             Inventories[character.inventory.Type].Add(character.inventory);
         }
         else if (character.inventory.Type != sourceInventory.Type)


### PR DESCRIPTION
Fixes bug where loading character inventory gave Dictionary - keys doesn't exist exception.
To reproduce: save game while character is holding some inventory, load it.
As jobs are not persisted yet, character will hold the inventory, but he 'forgets' what he was doing...