### PR TITLE
Fix for no audio when game is build

### DIFF
--- a/Assets/Scripts/Controllers/InputOutput/SoundController.cs
+++ b/Assets/Scripts/Controllers/InputOutput/SoundController.cs
@@ -36,7 +36,7 @@ public class SoundController
              return;
         }
  
-        AudioClip ac = AudioManager.GetAudio("Sound", "MenuClick");
+        AudioClip ac = WorldController.Instance.audioManager.GetAudio("Sound", "MenuClick");
         AudioSource.PlayClipAtPoint(ac, Camera.main.transform.position);
         soundCooldown = 0.1f;
     }
@@ -49,7 +49,7 @@ public class SoundController
             return;
         }
     
-        AudioClip ac = AudioManager.GetAudio("Sound", furniture.Type + "_OnCreated");
+        AudioClip ac = WorldController.Instance.audioManager.GetAudio("Sound", furniture.Type + "_OnCreated");
         AudioSource.PlayClipAtPoint(ac, Camera.main.transform.position);
         soundCooldown = 0.1f;
     }
@@ -64,7 +64,7 @@ public class SoundController
 
         if (tileData.ForceTileUpdate)
         {  
-            AudioClip ac = AudioManager.GetAudio("Sound", "Floor_OnCreated");
+            AudioClip ac = WorldController.Instance.audioManager.GetAudio("Sound", "Floor_OnCreated");
             AudioSource.PlayClipAtPoint(ac, Camera.main.transform.position);
             soundCooldown = 0.1f;
         }

--- a/Assets/Scripts/Controllers/WorldController.cs
+++ b/Assets/Scripts/Controllers/WorldController.cs
@@ -21,6 +21,7 @@ using Random = UnityEngine.Random;
 public class WorldController : MonoBehaviour
 {
     public SoundController soundController;
+    public AudioManager audioManager;
     public TileSpriteController tileSpriteController;
     public CharacterSpriteController characterSpriteController;
     public JobSpriteController jobSpriteController;
@@ -78,7 +79,7 @@ public class WorldController : MonoBehaviour
         new PrototypeManager();
         new CharacterNameManager();
         new SpriteManager();
-        new AudioManager();
+        audioManager = new AudioManager();
 
         // FIXME: Do something real here. This is just to show how to register a C# event prototype for the Scheduler.
         PrototypeManager.ScheduledEvent.Add(

--- a/Assets/Scripts/Models/InputOutput/AudioManager.cs
+++ b/Assets/Scripts/Models/InputOutput/AudioManager.cs
@@ -48,7 +48,7 @@ public class AudioManager
     /// </param>
     /// <param name="audioName">The name of the AudioClip.</param>
     /// <returns>AudioClip form the specified category with the specified name.</returns>
-    public static AudioClip GetAudio(string categoryName, string audioName)
+    public AudioClip GetAudio(string categoryName, string audioName)
     {
         AudioClip clip = new AudioClip();
 
@@ -78,7 +78,7 @@ public class AudioManager
     /// Loads all the audio files from the specified directory.
     /// </summary>
     /// <param name="directoryPath">The path of the directory you want to load the audio files from.</param>
-    public static void LoadAudioFiles(string directoryPath)
+    public void LoadAudioFiles(string directoryPath)
     {
         string[] subDirectories = Directory.GetDirectories(directoryPath);
         foreach (string subDirectory in subDirectories)
@@ -95,7 +95,7 @@ public class AudioManager
         }
     }
 
-    private static IEnumerable<WWW> LoadAudioFile(string[] filesInDir, string directoryPath)
+    private IEnumerable<WWW> LoadAudioFile(string[] filesInDir, string directoryPath)
     {
         foreach (string file in filesInDir)
         {

--- a/Assets/Scripts/Models/InputOutput/ModsManager.cs
+++ b/Assets/Scripts/Models/InputOutput/ModsManager.cs
@@ -54,7 +54,7 @@ public class ModsManager
         LoadCharacterNames("CharacterNames.txt");
         
         LoadDirectoryAssets("Images", SpriteManager.LoadSpriteFiles);
-        LoadDirectoryAssets("Audio", AudioManager.LoadAudioFiles);
+        LoadDirectoryAssets("Audio", WorldController.Instance.audioManager.LoadAudioFiles);
     }
 
     public DirectoryInfo[] GetMods()


### PR DESCRIPTION
Fixes #1533
Having LoadAudio and GetAudio static in AudioController seems to be a problem when the game is build.

**Edit** : Looks like it's only an uncomplete fix as The Player Settings>Other Settings > Logging>Log level need to be set to Full for the sounds to played. Developpement build is not needed.