### PR TITLE
[Fix] Fixes power icons update on furniture placement

### DIFF
--- a/Assets/Scripts/Controllers/Sprites/FurnitureSpriteController.cs
+++ b/Assets/Scripts/Controllers/Sprites/FurnitureSpriteController.cs
@@ -140,15 +140,8 @@ public class FurnitureSpriteController : BaseSpriteController<Furniture>
         powerSpriteRenderer.sortingLayerName = "Power";
         powerSpriteRenderer.color = Color.red;
 
-        if ((furniture.Requirements & BuildableComponent.Requirements.Power) == 0)        
-        {
-            powerGameObject.SetActive(false);
-        }
-        else
-        {
-            powerGameObject.SetActive(true);
-        }
-
+        UpdateIconObjectsVisibility(furniture, powerGameObject);
+        
         if (furniture.Animation != null)
         { 
             furniture.Animation.Renderer = sr;
@@ -240,7 +233,12 @@ public class FurnitureSpriteController : BaseSpriteController<Furniture>
         }
 
         GameObject powerGameObject = powerStatusGameObjectMap[furniture];
-        if (furniture.IsOperating)
+        UpdateIconObjectsVisibility(furniture, powerGameObject);
+    }
+
+    private void UpdateIconObjectsVisibility(Furniture furniture, GameObject powerGameObject)
+    {
+        if ((furniture.Requirements & BuildableComponent.Requirements.Power) == 0)
         {
             powerGameObject.SetActive(false);
         }

--- a/Assets/Scripts/Models/Buildable/Furniture.cs
+++ b/Assets/Scripts/Models/Buildable/Furniture.cs
@@ -154,6 +154,9 @@ public class Furniture : IXmlSerializable, ISelectable, IPrototypable, IContextA
 
         LocalizationCode = other.LocalizationCode;
         UnlocalizedDescription = other.UnlocalizedDescription;
+
+        // force true as default, to trigger OnIsOperatingChange (to sync the furniture icons after initialization)
+        IsOperating = true;
     }
     #endregion
 
@@ -441,7 +444,7 @@ public class Furniture : IXmlSerializable, ISelectable, IPrototypable, IContextA
                 }
             }
         }
-
+        
         // Let our workspot tile know it is reserved for us
         World.Current.ReserveTileAsWorkSpot(furnObj);
 


### PR DESCRIPTION
Fixes issue when power icon was not appearing after placement of new furniture (initialize) and there was lack of power. Machines were not operational though (correct behavior).. so only icons were not synced.
![image](https://cloud.githubusercontent.com/assets/12616499/19622987/b6bcd14a-98b8-11e6-8b50-1f9bb42091bb.png)
