### PR TITLE
[Fix] Fixes context menu for workshops with 1 prod. chain

### DIFF
--- a/Assets/Scripts/Models/Buildable/Components/Workshop.cs
+++ b/Assets/Scripts/Models/Buildable/Components/Workshop.cs
@@ -168,7 +168,14 @@ namespace ProjectPorcupine.Buildable.Components
 
         public override List<ContextMenuAction> GetContextMenu()
         {
-            return WorkshopMenuActions.Select(x => CreateComponentContextMenuItem(x)).ToList();
+            if (WorkshopMenuActions != null)
+            {
+                return WorkshopMenuActions.Select(x => CreateComponentContextMenuItem(x)).ToList();
+            }
+            else
+            {
+                return null;
+            }
         }
 
         protected override void Initialize()


### PR DESCRIPTION
Fixes 'Argument cannot be null' when trying to get context menu on workshops with one production chain (power generator, power cell press)