### PR TITLE
[Tiny, Fix] Fix error on building tiles on lowest layer

### DIFF
--- a/Assets/Scripts/Pathfinding/Path_TileGraph.cs
+++ b/Assets/Scripts/Pathfinding/Path_TileGraph.cs
@@ -57,6 +57,10 @@ public class Path_TileGraph
         
     public void RegenerateGraphAtTile(Tile changedTile)
     {
+        if (changedTile == null)
+        {
+            return;
+        }
         GenerateEdgesByTile(changedTile);
         foreach (Tile tile in changedTile.GetNeighbours(true))
         {


### PR DESCRIPTION
When building a tile on the lowest layer, an error will occur due to a null tile (the down tile from the tile being built) being passed to RegenerateGraphAtTile. This simply returns from RegenerateGraphAtTile if passed a null tile.