### PR TITLE
[Small] Fix incorrect logging fuction name in lua

### DIFF
--- a/Assets/StreamingAssets/LUA/Furniture.lua
+++ b/Assets/StreamingAssets/LUA/Furniture.lua
@@ -519,7 +519,7 @@ function AirPump_OnUpdate(furniture, deltaTime)
                 targetRoom = west.Room
             end
         else
-            ModUtils.UChannelLogWarning("Furniture", "Air Pump blocked. Direction unclear")
+            ModUtils.ULogWarningChannel("Furniture", "Air Pump blocked. Direction unclear")
             return
         end
         


### PR DESCRIPTION

### The issue this fixes
fixes an outdated function name being used in furniture.lua.
`UChannelLogWarning -> ULogWarningChannel`