### PR TITLE
[Small, Fix] Slightly better Lua Error messages

### DIFF
--- a/Assets/Scripts/Models/Functions/LuaFunctions.cs
+++ b/Assets/Scripts/Models/Functions/LuaFunctions.cs
@@ -6,14 +6,15 @@
 // file LICENSE, which is part of this source code package, for details.
 // ====================================================
 #endregion
+
 using System;
-using System.IO;
 using MoonSharp.Interpreter;
 using ProjectPorcupine.PowerNetwork;
 
 public class LuaFunctions
 {
     protected Script script;
+    private string scriptName;
 
     public LuaFunctions()
     {
@@ -63,6 +64,7 @@ public class LuaFunctions
     /// <param name="scriptName">The script name.</param>
     public bool LoadScript(string text, string scriptName)
     {
+        this.scriptName = scriptName;
         try
         {
             script.DoString(text);
@@ -97,7 +99,7 @@ public class LuaFunctions
         }
         catch (ScriptRuntimeException e)
         {
-            Debug.ULogErrorChannel("Lua", e.DecoratedMessage);
+            Debug.ULogErrorChannel("Lua", "[" + scriptName + "] LUA RunTime error: " + e.DecoratedMessage);
             return null;
         }
     }
@@ -129,11 +131,14 @@ public class LuaFunctions
             instanceAndParams[0] = instance;
             parameters.CopyTo(instanceAndParams, 1);
 
-            result = Call(fn, instanceAndParams);
-
-            if (result != null && result.Type == DataType.String)
+            try
             {
-                Debug.ULogErrorChannel("Lua", result.String);
+                result = Call(fn, instanceAndParams);
+            }
+            catch (ScriptRuntimeException e)
+            {
+                Debug.ULogErrorChannel("Lua", "[" + scriptName + "] LUA RunTime error: "+ e.DecoratedMessage);
+
             }
         }
     }


### PR DESCRIPTION
Currently lua runtime errors (such as trying to access an inaccessible part of userdata) can be a little difficult to debug as they don't specifically say what script is calling them, this PR stores the script name in a private field and includes that in the error message generated when an error is encountered running a script.

Also lua called with CallWithInstance generates an error message with the script name.