### PR TITLE
[Fix] Fix Error on saving settings from main menu

### DIFF
--- a/Assets/Scripts/UI/DialogBox/Settings/DialogBoxSettings.cs
+++ b/Assets/Scripts/UI/DialogBox/Settings/DialogBoxSettings.cs
@@ -72,7 +72,10 @@ public class DialogBoxSettings : DialogBox
         Resolution resolution = selectedOption.Resolution;
         Screen.SetResolution(resolution.width, resolution.height, fullScreenToggle.isOn, resolution.refreshRate);
 
-        WorldController.Instance.autosaveManager.SetAutosaveInterval(int.Parse(autosaveInterval.text));
+        if (WorldController.Instance != null)
+        {
+            WorldController.Instance.autosaveManager.SetAutosaveInterval(int.Parse(autosaveInterval.text));
+        }
 
         // One to many but we want an applying feature;
         PerformanceHUDManager.DirtyUI();


### PR DESCRIPTION
Currently saving settings fails on main menu due to trying to access WorldController.Instance, which is null at the time. This checks for null and skips trying to update the autosaveManager (which doesn't exist at the time and therefore doesn't need directly updated, with the new autosave settings.

Fixes #1599