### PR TITLE
[Small][Fix] Wrong path to TradeItem Prefab

### DIFF
--- a/Assets/Scripts/UI/DialogBox/Trade/DialogBoxTrade.cs
+++ b/Assets/Scripts/UI/DialogBox/Trade/DialogBoxTrade.cs
@@ -116,7 +116,7 @@ public class DialogBoxTrade : DialogBox
 
         foreach (TradeItem tradeItem in trade.TradeItems)
         {
-            GameObject go = (GameObject)Instantiate(Resources.Load("Prefab/TradeItemPrefab"), TradeItemListPanel);
+            GameObject go = (GameObject)Instantiate(Resources.Load("UI/Components/TradeItemPrefab"), TradeItemListPanel);
 
             DialogBoxTradeItem tradeItemBehaviour = go.GetComponent<DialogBoxTradeItem>();
             tradeItemBehaviour.OnTradeAmountChangedEvent += item => BuildInterfaceHeader();


### PR DESCRIPTION
A small fix. 
The prefab have been moved but the path is still on previous location.