### PR TITLE
Standalone Stylecop settings

### DIFF
--- a/Assets/Settings.StyleCop
+++ b/Assets/Settings.StyleCop
@@ -1,0 +1,5 @@
+<StyleCopSettings Version="105">
+  <GlobalSettings>
+    <StringProperty Name="MergeSettingsFiles">Parent</StringProperty>
+  </GlobalSettings>
+</StyleCopSettings>

--- a/Assets/Settings.StyleCop.meta
+++ b/Assets/Settings.StyleCop.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 287ef7cf5acfeab499ef96e1ea51c971
+timeCreated: 1478323475
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Settings.StyleCop
+++ b/Settings.StyleCop
@@ -1,4 +1,23 @@
 <StyleCopSettings Version="105">
+  <GlobalSettings>
+    <CollectionProperty Name="DeprecatedWords">
+      <Value>preprocessor,pre-processor</Value>
+      <Value>shortlived,short-lived</Value>
+    </CollectionProperty>
+    <StringProperty Name="MergeSettingsFiles">NoMerge</StringProperty>
+  </GlobalSettings>
+  <Parsers>
+    <Parser ParserId="StyleCop.CSharp.CsParser">
+      <ParserSettings>
+        <CollectionProperty Name="GeneratedFileFilters">
+          <Value>\.g\.cs$</Value>
+          <Value>\.generated\.cs$</Value>
+          <Value>\.g\.i\.cs$</Value>
+          <Value>TemporaryGeneratedFile_.*\.cs$</Value>
+        </CollectionProperty>
+      </ParserSettings>
+    </Parser>
+  </Parsers>
   <Analyzers>
     <Analyzer AnalyzerId="StyleCop.CSharp.DocumentationRules">
       <Rules>
@@ -227,11 +246,11 @@
             <BooleanProperty Name="Enabled">False</BooleanProperty>
           </RuleSettings>
         </Rule>
-          <Rule Name="PrefixLocalCallsWithThis">
-            <RuleSettings>
-              <BooleanProperty Name="Enabled">False</BooleanProperty>
-            </RuleSettings>
-          </Rule>
+        <Rule Name="PrefixLocalCallsWithThis">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
       </Rules>
       <AnalyzerSettings />
     </Analyzer>
@@ -253,7 +272,27 @@
           </RuleSettings>
         </Rule>
       </Rules>
-      <AnalyzerSettings />
+      <AnalyzerSettings>
+        <CollectionProperty Name="Hungarian">
+          <Value>as</Value>
+          <Value>do</Value>
+          <Value>id</Value>
+          <Value>if</Value>
+          <Value>in</Value>
+          <Value>ip</Value>
+          <Value>is</Value>
+          <Value>mx</Value>
+          <Value>my</Value>
+          <Value>no</Value>
+          <Value>on</Value>
+          <Value>to</Value>
+          <Value>ui</Value>
+          <Value>vs</Value>
+          <Value>x</Value>
+          <Value>y</Value>
+          <Value>z</Value>
+        </CollectionProperty>
+      </AnalyzerSettings>
     </Analyzer>
     <Analyzer AnalyzerId="StyleCop.CSharp.OrderingRules">
       <Rules>


### PR DESCRIPTION
Currently our stylecop settings are merged with system defaults, however, apparently there are differences between the defaults of Visual Stylecop and Monodevelop Stylecop, one recent example is the differences in the exception list for the Hungarian rule (Monodevelop Stylecop has x, y, and z as exceptions, whereas Visual Stylecop doesn't).

This sets our settings as standalone (not merged with defaults), so differences between the defaults won't cause issues. One notable exception is Monodevelop Stylecop won't raise a violation when there is a space after the license header (as shown in following), whereas VIsual Stylecop will. 
```
#region License
// ====================================================
// Project Porcupine Copyright(C) 2016 Team Porcupine
// This program comes with ABSOLUTELY NO WARRANTY; This is free software, 
// and you are welcome to redistribute it under certain conditions; See 
// file LICENSE, which is part of this source code package, for details.
// ====================================================

#endregion
```

This doesn't seem to be based off of any setting, just a difference between the two.