### PR TITLE
[Small] Remove commented out code in MouseOver classes

### DIFF
--- a/Assets/Scripts/UI/MouseOver.cs
+++ b/Assets/Scripts/UI/MouseOver.cs
@@ -36,7 +36,7 @@ public abstract class MouseOver : MonoBehaviour
     }
 
     /// <summary>
-    /// Obtains a string that represents some info about tile t.
+    /// Obtains a string that represents info about the tile.
     /// </summary>
     /// <param name="tile">The in game tile that our mouse is currently over.</param>
     protected abstract string GetMouseOverString(Tile tile);

--- a/Assets/Scripts/UI/MouseOverRoomDetails.cs
+++ b/Assets/Scripts/UI/MouseOverRoomDetails.cs
@@ -37,15 +37,6 @@ public class MouseOverRoomDetails : MouseOver
             foreach (RoomBehavior behavior in tile.Room.RoomBehaviors.Values)
             {
                 roomDetails += behavior.Name + "\n";
-
-///                foreach (string key in behavior.ControlledFurniture.Keys)
-///                {
-///                    s += key + "\t\n";
-///                    foreach (Furniture furniture in behavior.ControlledFurniture[key])
-///                    {
-///                        s += furniture.Name + "\t\t\n";
-///                    }
-///                }
             }
         }
 


### PR DESCRIPTION
Removed commented out code inside MouseOverRoomDetail and fixed a summary in MouseOver.
No code was altered.