### PR TITLE
[Small] Update Unity 5.4 download link to stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Please check the [CONTRIBUTING.md](CONTRIBUTING.md) file for contribution instru
 
 For further information, such as Roadmaps, explanations of systems and features, Standards and Conventions, and all your Git needs and troubleshooting see the [Wiki](https://github.com/TeamPorcupine/ProjectPorcupine/wiki)
 
-Make sure that you are using [Unity 5.4] (https://store.unity.com/download?ref=personal).
+Make sure that you are using Unity 5.4.2 [Windows] (https://unity3d.com/get-unity/download?thank-you=update&download_nid=43049&os=Win) | [Mac] (https://unity3d.com/get-unity/download?thank-you=update&download_nid=43049&os=Win)
 
 ## Vote on Proposed Features
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Please check the [CONTRIBUTING.md](CONTRIBUTING.md) file for contribution instru
 
 For further information, such as Roadmaps, explanations of systems and features, Standards and Conventions, and all your Git needs and troubleshooting see the [Wiki](https://github.com/TeamPorcupine/ProjectPorcupine/wiki)
 
-Make sure that you are using Unity 5.4.2 [Windows] (https://unity3d.com/get-unity/download?thank-you=update&download_nid=43049&os=Win) | [Mac] (https://unity3d.com/get-unity/download?thank-you=update&download_nid=43049&os=Win)
+Make sure that you are using Unity 5.4.2 [Windows] (https://unity3d.com/get-unity/download?thank-you=update&download_nid=43049&os=Win) | [Mac] (https://unity3d.com/get-unity/download?thank-you=update&download_nid=43049&os=Mac)
 
 ## Vote on Proposed Features
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Please check the [CONTRIBUTING.md](CONTRIBUTING.md) file for contribution instru
 
 For further information, such as Roadmaps, explanations of systems and features, Standards and Conventions, and all your Git needs and troubleshooting see the [Wiki](https://github.com/TeamPorcupine/ProjectPorcupine/wiki)
 
-Make sure that you are using [Unity 5.4] (https://unity3d.com/unity/beta).
+Make sure that you are using [Unity 5.4] (https://store.unity.com/download?ref=personal).
 
 ## Vote on Proposed Features
 


### PR DESCRIPTION
The download link goes to a unity beta download, which is for 5.5.0. Unity 5.4 is now stable.