### PR TITLE
Fix quest furniture counting and reward inventory placing (#1559)

### DIFF
--- a/Assets/Scripts/Models/Buildable/FurnitureManager.cs
+++ b/Assets/Scripts/Models/Buildable/FurnitureManager.cs
@@ -10,9 +10,9 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using MoonSharp.Interpreter;
 using Newtonsoft.Json.Linq;
 using UnityEngine;
-using MoonSharp.Interpreter;
 
 [MoonSharpUserData]
 public class FurnitureManager : IEnumerable<Furniture>

--- a/Assets/Scripts/Models/Buildable/FurnitureManager.cs
+++ b/Assets/Scripts/Models/Buildable/FurnitureManager.cs
@@ -12,7 +12,9 @@ using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json.Linq;
 using UnityEngine;
+using MoonSharp.Interpreter;
 
+[MoonSharpUserData]
 public class FurnitureManager : IEnumerable<Furniture>
 {
     private List<Furniture> furnitures;

--- a/Assets/StreamingAssets/LUA/Quest.lua
+++ b/Assets/StreamingAssets/LUA/Quest.lua
@@ -16,21 +16,20 @@ function Quest_Have_Furniture_Built(goal)
     goal.IsCompleted = false
     local type = goal.Parameters["type"].Value
     local amount = goal.Parameters["amount"].ToInt()
-    local amountFound = World.Current.CountFurnitureType(type)
+    local amountFound = World.Current.FurnitureManager.CountWithType(type)
     if (amountFound >= amount) then
         goal.IsCompleted = true
     end
 end
 
 function Quest_Spawn_Inventory(reward)
-    --tile = World.Current.GetCenterTile()
-    local tile = World.Current.GetFirstCenterTileWithNoInventory(6)
-    if (tile == nil) then
-        return
-    end
     local type = reward.Parameters["type"].Value
     local amount = reward.Parameters["amount"].ToInt()
     local inv = Inventory.__new(type, amount, amount)
+    local tile = World.Current.InventoryManager.GetFirstTileWithValidInventoryPlacement(6, World.Current.GetCenterTile(), inv)
+    if (tile == nil) then
+        return
+    end
     World.Current.inventoryManager.PlaceInventory(tile, inv)
     reward.IsCollected = true;
 end


### PR DESCRIPTION
### The issue this fixes

This PR fixes quests. They can now be completed and reward inventory will be placed.

Fixes #1559 
Closes #1559 

### What this PR does

- Exposes the FurnitureManager to lua in order to query if the furniture required to complete the quest are built.
- Fixes function call to get the number of furniture of a type.
- Fixes function call to get the tile closes to center tile to place the rewards.
