### PR TITLE
[Feedback Requested] ReferenceManager, helper script added

### DIFF
--- a/Assets/Scripts/Models/ReferenceManager.meta
+++ b/Assets/Scripts/Models/ReferenceManager.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 4afe36c34fffa6a468ccd07e2b474112
+folderAsset: yes
+timeCreated: 1479367921
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Models/ReferenceManager/IReferenceManager.cs
+++ b/Assets/Scripts/Models/ReferenceManager/IReferenceManager.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+public interface IReferenceManager
+{
+    /*
+    bool MakeConnection<T1, T2>(T1 reference1, T2 reference2)
+        where T1 : IReferenceable
+        where T2 : IReferenceable;
+    bool BreakConnection<T1, T2>(T1 reference1, T2 reference2)
+        where T1 : IReferenceable
+        where T2 : IReferenceable;
+    bool BreakAllConnections<T1>(T1 reference1)
+        where T1 : IReferenceable;
+    */
+    int GetCountOfType<K>()
+        where K : class, IReferenceable;
+    IEnumerable<K> GetEnumeratorOfType<K>()
+        where K : class, IReferenceable;
+    K GetFirstOfType<K>()
+        where K : class, IReferenceable;
+}
+

--- a/Assets/Scripts/Models/ReferenceManager/IReferenceManager.cs.meta
+++ b/Assets/Scripts/Models/ReferenceManager/IReferenceManager.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 7e1b6fc3a3caca349b004a9ed94f9742
+timeCreated: 1479274843
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Models/ReferenceManager/IReferenceable.cs
+++ b/Assets/Scripts/Models/ReferenceManager/IReferenceable.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+public interface IReferenceable
+{
+    //this should be IReferenceManager but it is 
+    // better to hide the implementation of the 
+    // folowing methods from the consumer:
+    // HasLinkInstance
+    // AddLinkInstance
+    // RemoveLinkInstance
+    // FirstLinkInstance
+    ReferenceManager ReferenceManager { get; }
+}
+

--- a/Assets/Scripts/Models/ReferenceManager/IReferenceable.cs.meta
+++ b/Assets/Scripts/Models/ReferenceManager/IReferenceable.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: cbe2582f47149a94482f360811146761
+timeCreated: 1479274843
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Models/ReferenceManager/ReferenceManager.cs
+++ b/Assets/Scripts/Models/ReferenceManager/ReferenceManager.cs
@@ -1,0 +1,198 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+/// <summary>
+/// This class it ment to replace all references between 
+/// </summary>
+public class ReferenceManager : IReferenceManager
+{
+    //all the references this manager is controling 
+    HashSet<IReferenceable> _references;
+    
+    public ReferenceManager()
+    {
+        _references = new HashSet<IReferenceable>();
+    }
+    
+    /*
+     * currently callback system not implemented out of simplicity
+     * 
+    event Action<IReferenceable, IReferenceable> _referencesChanged;
+    public void RegisterChange(Action<IReferenceable, IReferenceable> handler)
+    {
+        _referencesChanged += handler;
+    }
+    public void UnregisterChange(Action<IReferenceable, IReferenceable> handler)
+    {
+        _referencesChanged -= handler;
+    }
+    */
+
+    //this method operates as if it was static (i.e it does not reference any memeber variables),
+    //but interfaces dont enforce the use of static methods
+    public static bool MakeConnection<T1, T2>(T1 reference1, T2 reference2)
+        where T1 : IReferenceable
+        where T2 : IReferenceable
+    {
+        if (reference1 == null || reference2 == null)
+        {
+            Debug.ULogErrorChannel("ReferenceManager", "Incorrect use of MakeConnection!");
+            return false;
+        }
+        if (reference1.ReferenceManager.HasLinkInstance(reference2) && reference2.ReferenceManager.HasLinkInstance(reference1))
+        {
+            //connection already made
+            Debug.ULogWarningChannel("ReferenceManager", "Reference already created between these class instances.");
+            return false;
+        }
+        else if (reference1.ReferenceManager.HasLinkInstance(reference2) || reference2.ReferenceManager.HasLinkInstance(reference1))
+        {
+            //one knows of the connection the other is oblivious
+            // this is a problem... improper use
+            Debug.ULogErrorChannel("ReferenceManager", "References not being maintained correctly!");
+            return false;
+        }
+        else
+        {
+            //make connection
+            reference1.ReferenceManager.AddLinkInstance(reference2);
+            reference2.ReferenceManager.AddLinkInstance(reference1);
+            return true;
+        }
+    }
+
+    //this method operates as if it was static (i.e it does not reference any memeber variables),
+    //but interfaces dont enforce the use of static methods
+    public static bool BreakConnection<T1, T2>(T1 reference1, T2 reference2)
+        where T1 : IReferenceable
+        where T2 : IReferenceable
+    {
+        if(reference1 == null || reference2 == null)
+        {
+            Debug.ULogErrorChannel("ReferenceManager", "Incorrect use of MakeConnection!");
+            return false;
+        }
+        if (reference1.ReferenceManager.HasLinkInstance(reference2) && reference2.ReferenceManager.HasLinkInstance(reference1))
+        {
+            //remove connection
+            reference1.ReferenceManager.RemoveLinkInstance(reference2);
+            reference2.ReferenceManager.RemoveLinkInstance(reference1);
+            return true;
+        }
+        else if (reference1.ReferenceManager.HasLinkInstance(reference2) || reference2.ReferenceManager.HasLinkInstance(reference1))
+        {
+            //one knows of the connection the other is oblivious
+            // this is a problem... improper use
+            Debug.ULogErrorChannel("ReferenceManager", "References not being maintained correctly!");
+            return false;
+        }
+        else
+        {
+            //connection doesn't exsist
+            Debug.ULogWarningChannel("ReferenceManager","Reference does not exsist between these class instances.");
+            return false;
+        }
+    }
+    
+    //all Reference managers should have these methods but interfaces cant enforce the use of static methods
+    //use this function to delete the referance manager used by reference1
+    public static bool BreakAllConnections<T1>(T1 reference1)
+        where T1 : IReferenceable
+    {
+        return reference1.ReferenceManager.BreakAllConnectionsOfInstance<T1>(reference1); 
+    }
+
+    private bool BreakAllConnectionsOfInstance<T1>(T1 reference1)
+        where T1 : IReferenceable
+    {
+        bool result = true;
+        while (_references.Count > 0)
+        {
+            //reference1 is the owner of the reference manager
+            IReferenceable remove = FirstLinkInstance();
+            if (BreakConnection(reference1, remove) == false)
+            {
+                result = false;
+            }
+        }
+        return result;
+    }
+
+    //looks through the hash set and finds the number of items of type k (i.e Character, Tile, Furniture)
+    public int GetCountOfType<K>()
+        where K : class, IReferenceable
+    {
+        int count = 0;
+        foreach (IReferenceable reference in _references)
+        {
+            K check = reference as K;
+            if (check != null)
+            {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    //looks through the hash set and finds the items of type k (i.e Character, Tile, Furniture) then puts them in a list;
+    public IEnumerable<K> GetEnumeratorOfType<K>()
+        where K : class, IReferenceable
+    {
+        HashSet<K> result = new HashSet<K>();
+        foreach (IReferenceable reference in _references)
+        {
+            K check = reference as K;
+            if (check != null)
+            {
+                if (result.Contains(check))
+                {
+                    Debug.ULogErrorChannel("ReferenceManager", "References not being maintained correctly!");
+                }
+                else
+                {
+                    result.Add(check);
+                }
+            }
+        }
+        return result;
+    }
+
+    public K GetFirstOfType<K>()
+        where K : class, IReferenceable
+    {
+        //return the first instance where the conversion of IReferenceable to K is not null
+        return _references.FirstOrDefault((con) => (con as K != null)) as K;
+    }
+
+    private bool HasLinkInstance(IReferenceable link)
+    {
+        return _references.Contains(link);
+    }
+
+    private bool AddLinkInstance(IReferenceable link)
+    {
+        if (_references.Contains(link))
+        {
+            return false;
+        }
+        _references.Add(link);
+        return true;
+    }
+
+    private bool RemoveLinkInstance(IReferenceable link)
+    {
+        if (_references.Contains(link))
+        {   
+            _references.Remove(link);
+            return true;
+        }
+        return false;
+    }
+    
+    private IReferenceable FirstLinkInstance()
+    {
+        return _references.FirstOrDefault();
+    }
+}

--- a/Assets/Scripts/Models/ReferenceManager/ReferenceManager.cs.meta
+++ b/Assets/Scripts/Models/ReferenceManager/ReferenceManager.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: cc1b713eabc2d864884797dcf27cd2ce
+timeCreated: 1479274843
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
There is lack of consistency with how classes should maintain references between each other (i.e Tile, Character, Furniture, and Room). The goal of these additions is to create a base for managing references.

The idea here is two classes who would like to grab information from each other must implement the IReferenceable interface. Then to make a reference between the classes a call to the static method MakeConnection in the ReferenceManager class should be made. Once the reference is setup the methods below, should be used to grab the information from the reference manager.
Get Methods:
int GetCountOfType()
IEnumerable GetEnumeratorOfType()
K GetFirstOfType()

Each class that implements the IReferenceable interface will have its own hashset of references. If a class instance is going to be destroyed a simple call to BreakAllConnections will clean up the references.

I will be working on implementing these changes in the rest of the code base. If you like where this is heading don't hesitate to ask questions. It would be great if someone else thought this was a beneficial addition.

Thank you,

David McDermott