### PR TITLE
Added reference to Contributing Guidelines in the Contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,9 @@
 [Best Practices for Contributing](#best-practices-for-contributing)  
 [Image & Sound File Formats](#file-formats)  
 
+# Note
 
+Please also read the [Contributor's Portal](../../wiki/Contributors'-Portal#important-links), mainly the [Contributing Guidelines](../../wiki/Contributing-Guidelines).
 
 # Contributing
 


### PR DESCRIPTION
A lot of people are creating their first PR with stylecop errors and other slight problems that is due to not reading the Contributing Guidelines, this just adds the link (as a relative so it should work with forks and locals).