### PR TITLE
fixes quests

### DIFF
--- a/Assets/Scripts/Models/Buildable/FurnitureManager.cs
+++ b/Assets/Scripts/Models/Buildable/FurnitureManager.cs
@@ -10,9 +10,11 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using MoonSharp.Interpreter;
 using Newtonsoft.Json.Linq;
 using UnityEngine;
 
+[MoonSharpUserData]
 public class FurnitureManager : IEnumerable<Furniture>
 {
     private List<Furniture> furnitures;

--- a/Assets/Scripts/Models/Quest/QuestReward.cs
+++ b/Assets/Scripts/Models/Quest/QuestReward.cs
@@ -12,6 +12,8 @@ using MoonSharp.Interpreter;
 [MoonSharpUserData]
 public class QuestReward
 {
+    private static System.Random rand = new System.Random();
+
     public string Description { get; set; }
 
     public string OnRewardLuaFunction { get; set; }
@@ -36,5 +38,52 @@ public class QuestReward
                     break;
             }
         }
+    }
+
+    /// <summary>
+    /// Will be used to find a tile near the center of the map that does not currently have any invetory or furniture.
+    /// </summary>
+    /// <param name="attempts"> The amount of attemps the function will try to find an empty tile.</param>
+    /// <returns> An empty tile near the center of the map.</returns>
+    public Tile GetEmptyTileNearCenter(int attempts)
+    {
+        Tile current = World.Current.GetCenterTile();
+
+        while (attempts > 0)
+        {
+            // make sure that we have an existing tile
+            if (current != null)
+            {
+                // make sure that we have a tile with no funiture
+                if (current.Furniture == null)
+                {
+                    // if theres no inventory here then we consider this tile empty.
+                    if (current.Inventory == null)
+                    {
+                        break;
+                    }
+
+                    // if the stack size of this inventory is zero then we consider it empty.
+                    if (current.Inventory.StackSize == 0)
+                    {
+                        break;
+                    }
+                }
+            }
+
+            /// TODO: search in a spiral around the center tile or something less likely to fail.
+            current = World.Current.GetTileAt(current.X + rand.Next(-1, 2), current.Y + rand.Next(-1, 2), current.Z);
+            attempts--;
+        }
+
+        // if we ran out of attempts then we haven't found an empty tile so return null
+        if (attempts <= 0)
+        {
+            return null;
+        }
+
+        Debug.ULogChannel("Quests", string.Format("Found empty tile at X:{0} Y:{1} Z:{2}", current.X, current.Y, current.Z));
+
+        return current;
     }
 }

--- a/Assets/StreamingAssets/LUA/Quest.lua
+++ b/Assets/StreamingAssets/LUA/Quest.lua
@@ -13,19 +13,33 @@
 ---------------------------- Quests Actions --------------------------------
 
 function Quest_Have_Furniture_Built(goal)
+
+	if(goal == nil) then
+		ModUtils.ULogErrorChannel("Quests","Quest_Have_Furniture_Built, goal was nil");
+		return
+	end
+
     goal.IsCompleted = false
     local type = goal.Parameters["type"].Value
     local amount = goal.Parameters["amount"].ToInt()
-    local amountFound = World.Current.CountFurnitureType(type)
+    local amountFound = World.Current.FurnitureManager.CountWithType(type)
     if (amountFound >= amount) then
         goal.IsCompleted = true
     end
 end
 
 function Quest_Spawn_Inventory(reward)
-    --tile = World.Current.GetCenterTile()
-    local tile = World.Current.GetFirstCenterTileWithNoInventory(6)
+
+	if(reward == nil) then
+		ModUtils.ULogErrorChannel("Quests","Quest_Spawn_Inventory, reward was nil");
+		return
+	end
+
+   --local tile = World.Current.GetCenterTile()
+   local tile = reward.GetEmptyTileNearCenter(10)
+
     if (tile == nil) then
+		ModUtils.ULogErrorChannel("Quests","Quest_Spawn_Inventory, tile was nil");
         return
     end
     local type = reward.Parameters["type"].Value
@@ -35,5 +49,5 @@ function Quest_Spawn_Inventory(reward)
     reward.IsCollected = true;
 end
 
-ModUtils.ULog("Quest.lua loaded")
+ModUtils.ULogChannel("Quests","Quest.lua loaded")
 return "LUA Script Parsed!"


### PR DESCRIPTION
### The issue this fixes

Currently the quest system is broken. Quests could not be compleated and the rewards could not be obtained

- Quests can not be compleated.
    Existing quests were attempting to access the FunitureManager Class to count the number of  a type of funiture. The caused errors becuse the FunitureManager Class was not exposed to LUA.
- Rewards can be Obtained
    Now that Quests can be compeated it became apparent that rewards were all being placed on the center tile. This caused errors when more than one reward was being placed as a single tile can not have more than one type of item in it.

### What this PR does

- The existing quests can now be compleated.
    This was fixed by exposing the FunitureManager to LUA.
- Rewards can now be obtained.
   This was fixed by looking at tiles adjecent to the center tile until an empty tile is found.
