### PR TITLE
Change TestDB xml encoding to utf-8

### DIFF
--- a/Assets/StreamingAssets/UI/DialogBoxes/TestDB.xml
+++ b/Assets/StreamingAssets/UI/DialogBoxes/TestDB.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="Windows-1252"?>
+<?xml version="1.0" encoding="utf-8"?>
 <ModDialogBoxInformation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Title>Filter</Title>
   <Control name="Text1" type="Text">


### PR DESCRIPTION
Standalone build errors with `encoding="Windows-1252"`, causing only the construct button to be shown on standalone. Changing to ` encoding="utf-8"` fixes this.

Closes #1591