### PR TITLE
[Fix] Change dev mode setting name used by mouse controller

### DIFF
--- a/Assets/Scripts/Controllers/InputOutput/MouseController.cs
+++ b/Assets/Scripts/Controllers/InputOutput/MouseController.cs
@@ -452,7 +452,7 @@ public class MouseController
         }
 
         // In devmode, utilities don't build their network, and one of the utilities built needs UpdateGrid called explicitly after all are built.
-        if (bmc.buildMode == BuildMode.UTILITY && Settings.GetSetting("DialogBoxSettings_developerModeToggle", false))
+        if (bmc.buildMode == BuildMode.UTILITY && Settings.GetSetting("DialogBoxSettingsDevConsole_developerModeToggle", false))
         {
             Tile firstTile = World.Current.GetTileAt(dragParams.RawStartX, dragParams.RawStartY, WorldController.Instance.cameraController.CurrentLayer);
             Utility utility = firstTile.Utilities[PrototypeManager.Utility.Get(bmc.buildModeType).Name];


### PR DESCRIPTION
Dev mode setting name was changed but Mouse Controller used the old setting name, leading to an inability to queue utility jobs.