### PR TITLE
[WIP] Utilities connect to any part of furniture

### DIFF
--- a/Assets/Editor/UnitTests/Models/Power/PowerGridTest.cs
+++ b/Assets/Editor/UnitTests/Models/Power/PowerGridTest.cs
@@ -295,8 +295,6 @@ public class PowerGridTest
 
     private class MockConnection : IPlugable
     {
-        public event Action Reconnecting;
-
         public float AccumulatedAmount { get; set; }
 
         public float AccumulatorCapacity { get; set; }
@@ -329,6 +327,14 @@ public class PowerGridTest
         }
 
         public float OutputRate { get; set; }
+
+        public string Medium
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
 
         public void Reconnect()
         {

--- a/Assets/Editor/UnitTests/Models/Power/PowerGridTest.cs
+++ b/Assets/Editor/UnitTests/Models/Power/PowerGridTest.cs
@@ -295,6 +295,8 @@ public class PowerGridTest
 
     private class MockConnection : IPlugable
     {
+        public event Action Reconnecting;
+
         public float AccumulatedAmount { get; set; }
 
         public float AccumulatorCapacity { get; set; }

--- a/Assets/Editor/UnitTests/Models/Power/PowerNetworkTest.cs
+++ b/Assets/Editor/UnitTests/Models/Power/PowerNetworkTest.cs
@@ -122,6 +122,8 @@ public class PowerNetworkTest
 
     private class MockConnection : IPlugable
     {
+        public event Action Reconnecting;
+
         public float AccumulatedAmount { get; set; }
 
         public float AccumulatorCapacity { get; set; }

--- a/Assets/Editor/UnitTests/Models/Power/PowerNetworkTest.cs
+++ b/Assets/Editor/UnitTests/Models/Power/PowerNetworkTest.cs
@@ -122,8 +122,6 @@ public class PowerNetworkTest
 
     private class MockConnection : IPlugable
     {
-        public event Action Reconnecting;
-
         public float AccumulatedAmount { get; set; }
 
         public float AccumulatorCapacity { get; set; }
@@ -156,6 +154,14 @@ public class PowerNetworkTest
         }
 
         public float OutputRate { get; set; }
+
+        public string Medium
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
 
         public void Reconnect()
         {

--- a/Assets/Scripts/Models/Buildable/Furniture.cs
+++ b/Assets/Scripts/Models/Buildable/Furniture.cs
@@ -422,7 +422,7 @@ public class Furniture : ISelectable, IPrototypable, IContextActionProvider, IBu
             // (It will be garbage collected.)
             return null;
         }
-
+        
         // need to update reference to furniture and call Initialize (so components can place hooks on events there)
         foreach (BuildableComponent component in furnObj.components)
         {
@@ -466,6 +466,17 @@ public class Furniture : ISelectable, IPrototypable, IContextActionProvider, IBu
         World.Current.temperature.SetThermalDiffusivity(tile.X, tile.Y, tile.Z, thermalDiffusivity);
 
         return furnObj;
+    }
+
+    public static IEnumerable<Tile> GetFurnitureTiles(Tile startTile, Furniture furniture)
+    {
+        for (int x_off = startTile.X; x_off < startTile.X + furniture.Width; x_off++)
+        {
+            for (int y_off = startTile.Y; y_off < startTile.Y + furniture.Height; y_off++)
+            {
+                yield return World.Current.GetTileAt(x_off, y_off, startTile.Z);
+            }
+        }
     }
 
     #region Update and Animation
@@ -1098,6 +1109,23 @@ public class Furniture : ISelectable, IPrototypable, IContextActionProvider, IBu
         }
 
         yield return GetProgressInfo();
+    }
+
+    public IPlugable GetPlugable(HashSet<string> utilityTags)
+    {
+        if (components != null)
+        {
+            foreach (BuildableComponent component in components)
+            {
+                IPlugable plugable = component as IPlugable;
+                if (plugable != null && utilityTags.Contains(plugable.Medium))
+                {
+                    return plugable;
+                }
+            }
+        }
+
+        return null;
     }
 
     /// <summary>

--- a/Assets/Scripts/Models/Buildable/Tile.cs
+++ b/Assets/Scripts/Models/Buildable/Tile.cs
@@ -206,15 +206,11 @@ public class Tile : ISelectable, IContextActionProvider, IComparable, IEquatable
             return false;
         }
 
-        for (int x_off = X; x_off < X + objInstance.Width; x_off++)
+        foreach (Tile t in Furniture.GetFurnitureTiles(this, objInstance))
         {
-            for (int y_off = Y; y_off < Y + objInstance.Height; y_off++)
-            {
-                Tile t = World.Current.GetTileAt(x_off, y_off, Z);
-                t.Furniture = objInstance;
-            }
+            t.Furniture = objInstance;
         }
-
+        
         return true;
     }
 

--- a/Assets/Scripts/Models/Buildable/Utility.cs
+++ b/Assets/Scripts/Models/Buildable/Utility.cs
@@ -282,16 +282,11 @@ public class Utility : ISelectable, IPrototypable, IContextActionProvider, IBuil
             obj.Grid = new Grid();
             World.Current.PowerNetwork.RegisterGrid(obj.Grid);
         }
-        
-        // try to reconnect furniture if present and compatible     
-        if (obj.Tile != null && obj.Tile.Furniture != null)
+
+        if (obj.Tile != null && obj.Tile.Furniture != null && obj.Tile.Furniture.GetComponent<PowerConnection>("PowerConnection") != null)
         {
-            IPlugable plugableComponent = obj.Tile.Furniture.GetPlugable(proto.typeTags);
-            if (plugableComponent != null)
-            {
-                // plug in
-                plugableComponent.Reconnect();
-            }
+            // HACK: This will work for now, but needs expanded when we have other types of connections we'll want to plug in
+            obj.Tile.Furniture.GetComponent<PowerConnection>("PowerConnection").Reconnect();
         }
 
         // Call LUA install scripts

--- a/Assets/Scripts/Models/Buildable/Utility.cs
+++ b/Assets/Scripts/Models/Buildable/Utility.cs
@@ -282,11 +282,16 @@ public class Utility : ISelectable, IPrototypable, IContextActionProvider, IBuil
             obj.Grid = new Grid();
             World.Current.PowerNetwork.RegisterGrid(obj.Grid);
         }
-
-        if (obj.Tile != null && obj.Tile.Furniture != null && obj.Tile.Furniture.GetComponent<PowerConnection>("PowerConnection") != null)
+        
+        // try to reconnect furniture if present and compatible     
+        if (obj.Tile != null && obj.Tile.Furniture != null)
         {
-            // HACK: This will work for now, but needs expanded when we have other types of connections we'll want to plug in
-            obj.Tile.Furniture.GetComponent<PowerConnection>("PowerConnection").Reconnect();
+            IPlugable plugableComponent = obj.Tile.Furniture.GetPlugable(proto.typeTags);
+            if (plugableComponent != null)
+            {
+                // plug in
+                plugableComponent.Reconnect();
+            }
         }
 
         // Call LUA install scripts

--- a/Assets/Scripts/PowerNetwork/IPlugable.cs
+++ b/Assets/Scripts/PowerNetwork/IPlugable.cs
@@ -13,7 +13,7 @@ namespace ProjectPorcupine.PowerNetwork
 {
     public interface IPlugable
     {
-        event Action Reconnecting;
+        string Medium { get; }
 
         float InputRate { get; }
 

--- a/Assets/Scripts/PowerNetwork/IPlugable.cs
+++ b/Assets/Scripts/PowerNetwork/IPlugable.cs
@@ -13,6 +13,8 @@ namespace ProjectPorcupine.PowerNetwork
 {
     public interface IPlugable
     {
+        event Action Reconnecting;
+    
         string Medium { get; }
 
         float InputRate { get; }


### PR DESCRIPTION
Solves problem where utilities (power cable) had to be placed exactly at origin position of multi-tile furniture - only then furniture was powered.
Now any tile of furniture will do
![image](https://cloud.githubusercontent.com/assets/12616499/20869521/6034971c-ba74-11e6-9b5c-2253ba922c51.png)
Also removed the hack implementation for more cleaner usage.
Please test scenarios with connecting cables to furniture. Placing cable first, then furniture and other way around.
Issues:
- [ ] problem when reconnecting broken cable (furniture not powered unless more connections to furniture are made)