### PR TITLE
Fix crash on world gen

### DIFF
--- a/Assets/Scripts/Models/Area/World.cs
+++ b/Assets/Scripts/Models/Area/World.cs
@@ -51,6 +51,7 @@ public class World
         // Creates an empty world.
         SetupWorld(width, height, depth);
         int seed = UnityEngine.Random.Range(0, int.MaxValue);
+        Debug.LogWarning("World Seed: " + seed);
         WorldGenerator.Instance.Generate(this, seed);
         Debug.ULogChannel("World", "Generated World");
 

--- a/Assets/Scripts/Models/Area/WorldGenerator.cs
+++ b/Assets/Scripts/Models/Area/WorldGenerator.cs
@@ -166,7 +166,7 @@ public class WorldGenerator
     private bool IsStartArea(int x, int y, World world)
     {
         int boundX = (world.Width / 2) - startAreaCenterX;
-        int boundY = (world.Height / 2) + startAreaCenterY;
+        int boundY = (world.Height / 2) + startAreaCenterY + 1;
 
         if (x >= boundX && x < (boundX + startAreaWidth) && y >= (boundY - startAreaHeight) && y < boundY)
         {


### PR DESCRIPTION
World gen was crashing due to trying it trying remove the floor under a wall, because IsStartArea had an off by one error in the Y direction. This adjusts the Y bounds. 

Additionally the World Seed in now logged to the console to aid in future debugging of anything that is inconsistent based on world generation.