### PR TITLE
Remove MinEdgeDistance

### DIFF
--- a/Assets/Scripts/Models/Area/WorldGenerator.cs
+++ b/Assets/Scripts/Models/Area/WorldGenerator.cs
@@ -57,7 +57,7 @@ public class WorldGenerator
         int offsetX = Random.Range(0, 10000);
         int offsetY = Random.Range(0, 10000);
 
-        int minEdgeDistance = 5;
+        int minEdgeDistance = 0;
         
         int sumOfAllWeightedChances = asteroidInfo.Resources.Select(x => x.WeightedChance).Sum();
 

--- a/Assets/Scripts/Models/Area/WorldGenerator.cs
+++ b/Assets/Scripts/Models/Area/WorldGenerator.cs
@@ -56,8 +56,6 @@ public class WorldGenerator
         int depth = world.Depth;
         int offsetX = Random.Range(0, 10000);
         int offsetY = Random.Range(0, 10000);
-
-        int minEdgeDistance = 0;
         
         int sumOfAllWeightedChances = asteroidInfo.Resources.Select(x => x.WeightedChance).Sum();
 
@@ -102,13 +100,6 @@ public class WorldGenerator
                     if (noiseValue >= asteroidInfo.NoiseThreshhold && !IsStartArea(x, y, world))
                     {
                         Tile tile = world.GetTileAt(x, y, z);
-
-                        if (tile.X < minEdgeDistance || tile.Y < minEdgeDistance ||
-                              World.Current.Width - tile.X <= minEdgeDistance ||
-                              World.Current.Height - tile.Y <= minEdgeDistance)
-                        {
-                            continue;
-                        }
 
                         tile.SetTileType(asteroidFloorType);
 

--- a/Assets/Scripts/Models/Buildable/Furniture.cs
+++ b/Assets/Scripts/Models/Buildable/Furniture.cs
@@ -1214,7 +1214,8 @@ public class Furniture : ISelectable, IPrototypable, IContextActionProvider, IBu
     /// <param name="t">The base tile.</param>
     /// <returns>True if the tile is valid for the placement of the furniture.</returns>
     public bool IsValidPosition(Tile tile)
-    {if (HasTypeTag("OutdoorOnly"))
+    {
+        if (HasTypeTag("OutdoorOnly"))
         {
             if (tile.Room == null || !tile.Room.IsOutsideRoom())
             {

--- a/Assets/Scripts/Models/Buildable/Furniture.cs
+++ b/Assets/Scripts/Models/Buildable/Furniture.cs
@@ -28,7 +28,7 @@ public class Furniture : ISelectable, IPrototypable, IContextActionProvider, IBu
 {
     #region Private Variables
     // Prevent construction too close to the world's edge
-    private const int MinEdgeDistance = 5;
+    private const int MinEdgeDistance = 0;
 
     private string isEnterableAction;
     

--- a/Assets/Scripts/Models/Buildable/Furniture.cs
+++ b/Assets/Scripts/Models/Buildable/Furniture.cs
@@ -27,9 +27,6 @@ using UnityEngine;
 public class Furniture : ISelectable, IPrototypable, IContextActionProvider, IBuildable
 {
     #region Private Variables
-    // Prevent construction too close to the world's edge
-    private const int MinEdgeDistance = 0;
-
     private string isEnterableAction;
     
     /// <summary>
@@ -1217,17 +1214,7 @@ public class Furniture : ISelectable, IPrototypable, IContextActionProvider, IBu
     /// <param name="t">The base tile.</param>
     /// <returns>True if the tile is valid for the placement of the furniture.</returns>
     public bool IsValidPosition(Tile tile)
-    {
-        bool tooCloseToEdge = tile.X < MinEdgeDistance || tile.Y < MinEdgeDistance ||
-                              World.Current.Width - tile.X <= MinEdgeDistance ||
-                              World.Current.Height - tile.Y <= MinEdgeDistance;
-
-        if (tooCloseToEdge)
-        {
-            return false;
-        }
-
-        if (HasTypeTag("OutdoorOnly"))
+    {if (HasTypeTag("OutdoorOnly"))
         {
             if (tile.Room == null || !tile.Room.IsOutsideRoom())
             {

--- a/Assets/Scripts/Models/Buildable/Utility.cs
+++ b/Assets/Scripts/Models/Buildable/Utility.cs
@@ -25,7 +25,7 @@ using UnityEngine;
 public class Utility : ISelectable, IPrototypable, IContextActionProvider, IBuildable
 {
     // Prevent construction too close to the world's edge
-    private const int MinEdgeDistance = 5;
+    private const int MinEdgeDistance = 0;
 
     private bool gridUpdatedThisFrame = false;
 

--- a/Assets/Scripts/Models/Buildable/Utility.cs
+++ b/Assets/Scripts/Models/Buildable/Utility.cs
@@ -24,9 +24,6 @@ using UnityEngine;
 [MoonSharpUserData]
 public class Utility : ISelectable, IPrototypable, IContextActionProvider, IBuildable
 {
-    // Prevent construction too close to the world's edge
-    private const int MinEdgeDistance = 0;
-
     private bool gridUpdatedThisFrame = false;
 
     /// <summary>
@@ -645,15 +642,6 @@ public class Utility : ISelectable, IPrototypable, IContextActionProvider, IBuil
     /// <returns>True if the tile is valid for the placement of the utility.</returns>
     public bool IsValidPosition(Tile tile)
     {
-        bool tooCloseToEdge = tile.X < MinEdgeDistance || tile.Y < MinEdgeDistance ||
-                              World.Current.Width - tile.X <= MinEdgeDistance ||
-                              World.Current.Height - tile.Y <= MinEdgeDistance;
-
-        if (tooCloseToEdge)
-        {
-            return false;
-        }
-
         if (HasTypeTag("OutdoorOnly"))
         {
             if (tile.Room == null || !tile.Room.IsOutsideRoom())


### PR DESCRIPTION
Closes #1660

This removes MinEdgeDistance, which I don't believe is needed any more.

Verbatim copy of text in #1660 as to why I believe MinEdgeDistance is no longer needed:
Currently we have MinEdgeDistance of 5, which prevents you from building within 5 of the edge of the map, this was originally instituted to solve a bug related to building right along the border. However, preliminary tests suggest that even with MinEdgeDistance set to 0, no errors are caused by building near the edge of the map (there is an error if you try to build tiles off of the map, but that isn't related to setting MinEdgeDistance to 0 and is present in master).

Update: Since this has not seemed to create any unforeseen bugs, I've now fully removed MinEdgeDistance, and consider this viable for merging.