### PR TITLE
[Fix] Prevent Building Tiles off the map

### DIFF
--- a/Assets/Scripts/Controllers/InputOutput/MouseController.cs
+++ b/Assets/Scripts/Controllers/InputOutput/MouseController.cs
@@ -421,6 +421,7 @@ public class MouseController
                     // Trying to build off the map, bail out of this cycle.
                     continue;
                 }
+
                 if (bmc.buildMode == BuildMode.FURNITURE)
                 {
                     // Check for furniture dragType.

--- a/Assets/Scripts/Controllers/InputOutput/MouseController.cs
+++ b/Assets/Scripts/Controllers/InputOutput/MouseController.cs
@@ -415,19 +415,21 @@ public class MouseController
 
             for (int y = begin; y != stop; y += increment)
             {
-                Tile t = WorldController.Instance.World.GetTileAt(x, y, WorldController.Instance.cameraController.CurrentLayer);
+                Tile tile = WorldController.Instance.World.GetTileAt(x, y, WorldController.Instance.cameraController.CurrentLayer);
+                if (tile == null)
+                {
+                    // Trying to build off the map, bail out of this cycle.
+                    continue;
+                }
                 if (bmc.buildMode == BuildMode.FURNITURE)
                 {
                     // Check for furniture dragType.
                     Furniture proto = PrototypeManager.Furniture.Get(bmc.buildModeType);
 
-                    if (IsPartOfDrag(t, dragParams, proto.DragType))
+                    if (IsPartOfDrag(tile, dragParams, proto.DragType))
                     {
-                        if (t != null)
-                        {
-                            // Call BuildModeController::DoBuild().
-                            bmc.DoBuild(t);
-                        }
+                        // Call BuildModeController::DoBuild().
+                        bmc.DoBuild(tile);
                     }
                 }
                 else if (bmc.buildMode == BuildMode.UTILITY)
@@ -435,18 +437,15 @@ public class MouseController
                     // Check for furniture dragType.
                     Utility proto = PrototypeManager.Utility.Get(bmc.buildModeType);
 
-                    if (IsPartOfDrag(t, dragParams, proto.DragType))
+                    if (IsPartOfDrag(tile, dragParams, proto.DragType))
                     {
-                        if (t != null)
-                        {
-                            // Call BuildModeController::DoBuild().
-                            bmc.DoBuild(t);
-                        }
+                        // Call BuildModeController::DoBuild().
+                        bmc.DoBuild(tile);
                     }
                 }
                 else
                 {
-                    bmc.DoBuild(t);
+                    bmc.DoBuild(tile);
                 }
             }
         }


### PR DESCRIPTION
Currently there is a bug where you can attempt to build tiles off of the map, this causes an error due to the null tile (only BuildMode.Furniture and BuildMode.Utility check for null). This fixes that bug by moving the null check outside of the code for BuildMode.Furniture and BuildMode.Utility, instead skipping the entire tile if it is null, regardless of the BuildMode.