### PR TITLE
Add z level to mouse cursor text

### DIFF
--- a/Assets/Scripts/Models/Keyboard/KeyboardManager.cs
+++ b/Assets/Scripts/Models/Keyboard/KeyboardManager.cs
@@ -105,6 +105,8 @@ public class KeyboardManager
 
         RegisterInputMapping("DevMode", KeyboardInputModifier.None, KeyCode.F12);
         RegisterInputMapping("DevConsole", KeyboardInputModifier.Control, KeyCode.BackQuote);
+
+        RegisterInputMapping("ToggleCursorTextBox", KeyboardInputModifier.Control, KeyCode.M);
     }
 
     /// <summary>

--- a/Assets/Scripts/UI/CursorInfoDisplay.cs
+++ b/Assets/Scripts/UI/CursorInfoDisplay.cs
@@ -1,4 +1,4 @@
-﻿#region License
+#region License
 // ====================================================
 // Project Porcupine Copyright(C) 2016 Team Porcupine
 // This program comes with ABSOLUTELY NO WARRANTY; This is free software, 
@@ -25,20 +25,12 @@ public class CursorInfoDisplay
 
     public string MousePosition(Tile t)
     {
-        string x = string.Empty;
-        string y = string.Empty;
-
-        if (t != null)
-        {
-            x = t.X.ToString();
-            y = t.Y.ToString();
-
-            return "X:" + x + " Y:" + y;
-        }
-        else
+        if (t == null)
         {
             return string.Empty;
         }
+
+        return string.Format("X:{0} Y:{1} Z:{2}", t.X.ToString(), t.Y.ToString(), t.Z.ToString());
     }
 
     public void GetPlacementValidationCounts()

--- a/Assets/Scripts/UI/MouseCursor.cs
+++ b/Assets/Scripts/UI/MouseCursor.cs
@@ -50,24 +50,12 @@ public class MouseCursor
         
         LoadCursorTexture();
         BuildCursor();
+
+        KeyboardManager.Instance.RegisterInputAction("ToggleCursorTextBox", KeyboardMappedInputType.KeyUp, () => { cursorOverride = !cursorOverride; });
     }
 
     public void Update()
     {
-        // Hold Ctrl and press M to activate.
-        if ((Input.GetKey(KeyCode.LeftControl) || Input.GetKey(KeyCode.RightControl)) && Input.GetKeyDown(KeyCode.M))
-        {
-            // Toggle cursorOverride.
-            if (cursorOverride == false)
-            {
-                cursorOverride = true;
-            }
-            else
-            {
-                cursorOverride = false;
-            }                
-        }
-
         ShowCursor();
 
         if (cursorOverride == true)
@@ -114,8 +102,6 @@ public class MouseCursor
         upperRight = new CursorTextBox(cursorGO, TextAnchor.MiddleLeft, style, upperRightPostion, cursorTextBoxSize);
         lowerLeft = new CursorTextBox(cursorGO, TextAnchor.MiddleRight, style, lowerLeftPostion, cursorTextBoxSize);
         lowerRight = new CursorTextBox(cursorGO, TextAnchor.MiddleLeft, style, lowerRightPostion, cursorTextBoxSize);        
-
-        Debug.ULogChannel("MouseCursor", "Cursor Built");
     }
 
     private void UpdateCursor()


### PR DESCRIPTION
### The issue this fixes
There is no real indication of what the z index of the tile under the mouse is. This makes it hard to test other PRs and use dev console commands.


### What this PR does
Adds the Z level of the tile that the mouses is over. (toggled by Ctrl + M as before)
I also re implemented the toggling of this behavior to use the Keyboard Manager as opposed to unity's default input system.