### PR TITLE
Remove unnecessary uninit code from dev console

### DIFF
--- a/Assets/Scripts/UI/InGameUI/DevConsole/DevConsole.cs
+++ b/Assets/Scripts/UI/InGameUI/DevConsole/DevConsole.cs
@@ -575,30 +575,6 @@ namespace DeveloperConsole
         }
 
         /// <summary>
-        /// Uninitialisation.
-        /// </summary>
-        private void UnInit()
-        {
-            Debug.ULogWarningChannel("DevConsole", "Unitilising DevConsole: Bye Bye.");
-            if (instance == this)
-            {
-                // If this isn't true then its trying to unitialise another instance, it shouldn't happen but this is just incase if it does.
-                instance = null;
-            }
-        }
-
-        /// <summary>
-        /// To make sure we uninit properly.
-        /// </summary>
-        private void OnDestroy()
-        {
-            if (instance == this)
-            {
-                instance.UnInit();
-            }
-        }
-
-        /// <summary>
         /// Raises the enable event.  It just does some instance checking.
         /// </summary>
         private void OnEnable()


### PR DESCRIPTION
Removes the UnInit Method from dev console, since it serves no purpose.