### PR TITLE
[Fix] Separate TileTypeChanged Event

### DIFF
--- a/Assets/Scripts/Controllers/InputOutput/SoundController.cs
+++ b/Assets/Scripts/Controllers/InputOutput/SoundController.cs
@@ -25,7 +25,7 @@ public class SoundController
         if (world != null)
         {
             world.FurnitureManager.Created += OnFurnitureCreated;
-            world.OnTileChanged += OnTileChanged;
+            world.OnTileTypeChanged += OnTileTypeChanged;
         }
 
         TimeManager.Instance.EveryFrame += Update;
@@ -72,19 +72,16 @@ public class SoundController
         PlaySoundAt(clip.Get(), furniture.Tile, "gameSounds");
     }
 
-    public void OnTileChanged(Tile tileData)
+    public void OnTileTypeChanged(Tile tileData)
     {
-        if (tileData.ForceTileUpdate)
-        {  
-            SoundClip clip = AudioManager.GetAudio("Sound", "Floor_OnCreated");
-            if (cooldowns.ContainsKey(clip) && cooldowns[clip] > 0)
-            {
-                return;
-            }
-
-            cooldowns[clip] = 0.1f;
-            PlaySoundAt(clip.Get(), tileData, "gameSounds", 1);
+        SoundClip clip = AudioManager.GetAudio("Sound", "Floor_OnCreated");
+        if (cooldowns.ContainsKey(clip) && cooldowns[clip] > 0)
+        {
+            return;
         }
+
+        cooldowns[clip] = 0.1f;
+        PlaySoundAt(clip.Get(), tileData, "gameSounds", 1);
     }
 
     /// <summary>

--- a/Assets/Scripts/Controllers/Sprites/TileSpriteController.cs
+++ b/Assets/Scripts/Controllers/Sprites/TileSpriteController.cs
@@ -17,6 +17,7 @@ public class TileSpriteController : BaseSpriteController<Tile>
     public TileSpriteController(World world) : base(world, "Tiles")
     {
         world.OnTileChanged += OnChanged;
+        world.OnTileTypeChanged += OnChanged;
 
         for (int x = 0; x < world.Width; x++)
         {

--- a/Assets/Scripts/Models/Area/World.cs
+++ b/Assets/Scripts/Models/Area/World.cs
@@ -91,6 +91,8 @@ public class World
 
     public event Action<Tile> OnTileChanged;
 
+    public event Action<Tile> OnTileTypeChanged;
+
     public static World Current { get; protected set; }
 
     // The tile width of the world.
@@ -360,6 +362,7 @@ public class World
                 {
                     tiles[x, y, z] = new Tile(x, y, z);
                     tiles[x, y, z].TileChanged += OnTileChangedCallback;
+                    tiles[x, y, z].TileTypeChanged += OnTileTypeChangedCallback;
                     tiles[x, y, z].Room = RoomManager.OutsideRoom; // Rooms 0 is always going to be outside, and that is our default room
                 }
             }
@@ -483,6 +486,17 @@ public class World
         }
 
         OnTileChanged(t);
+    }
+
+    // Gets called whenever ANY tile changes type
+    private void OnTileTypeChangedCallback(Tile t)
+    {
+        if (OnTileTypeChanged == null)
+        {
+            return;
+        }
+
+        OnTileTypeChanged(t);
 
         if (tileGraph != null)
         {

--- a/Assets/Scripts/Models/Buildable/Tile.cs
+++ b/Assets/Scripts/Models/Buildable/Tile.cs
@@ -48,6 +48,9 @@ public class Tile : ISelectable, IContextActionProvider, IComparable, IEquatable
     // The function we callback any time our tile's data changes
     public event Action<Tile> TileChanged;
 
+    // The function we callback any time our tile's type changes
+    public event Action<Tile> TileTypeChanged;
+
     #region Accessors
     public TileType Type
     {
@@ -170,6 +173,11 @@ public class Tile : ISelectable, IContextActionProvider, IComparable, IEquatable
         }
 
         OnTileClean();
+
+        if (TileTypeChanged != null)
+        {
+            TileTypeChanged(this);
+        }
     }
 
     public bool UnplaceFurniture()

--- a/Assets/Scripts/Models/InputOutput/AudioManager.cs
+++ b/Assets/Scripts/Models/InputOutput/AudioManager.cs
@@ -83,6 +83,7 @@ public class AudioManager
 
         string audioNameAndCategory = categoryName + "/" + audioName;
 
+        Debug.LogWarning("Audio called: " + audioNameAndCategory, null);
         if (audioClips.ContainsKey(audioNameAndCategory))
         {
             clip = audioClips[audioNameAndCategory];


### PR DESCRIPTION
Currently on master, when a save file is loaded all tiles loaded from the save file will have ForceTileUpdate set to true, which means when they are walked on, they will end up triggering their Tile Built sound, because walking on a tile updates the walk count, which triggers the TileChanged event.  I'm uncertain as to why this doesn't seem to happen at other times when tile data is forced to change (perhaps it isn't regularly forced on walking on it, I haven't investigated deeply).

However, just no setting ForceTileUpdate to false causes any worn tiles to not display properly on file load.

To solve this I have created a separate TileTypeChanged event, which is subscribed to by the SoundController rather than TileChanged, so that sounds will only be made when a tile's type is changed.