### PR TITLE
[Small] Claim inventory

### DIFF
--- a/Assets/Scripts/Models/Inventory/Inventory.cs
+++ b/Assets/Scripts/Models/Inventory/Inventory.cs
@@ -17,7 +17,9 @@ using Newtonsoft.Json.Linq;
 [System.Diagnostics.DebuggerDisplay("Inventory {ObjectType} {StackSize}/{MaxStackSize}")]
 public class Inventory : ISelectable, IContextActionProvider
 {
+    
     private int stackSize = 1;
+    private DateTime claim;
 
     public Inventory()
     {
@@ -81,6 +83,29 @@ public class Inventory : ISelectable, IContextActionProvider
         return new Inventory(this);
     }
 
+    public bool Claim()
+    {
+        // FIXME: The various Claim related functions should most likely track claim time in an in game time increment.
+        DateTime requestTime = DateTime.Now;
+        if (claim == null || (requestTime - claim).TotalSeconds > 5)
+        {
+            claim = requestTime;
+            return true;
+        }
+
+        return false;
+    }
+
+    public void ReleaseClaim()
+    {
+        claim = new DateTime();
+    }
+
+    public bool CanClaim()
+    {
+        DateTime requestTime = DateTime.Now;
+        return claim == null || (requestTime - claim).TotalSeconds > 5;
+    }
     public string GetName()
     {
         return Type;
@@ -152,7 +177,7 @@ public class Inventory : ISelectable, IContextActionProvider
     public bool CanBePickedUp(bool canTakeFromStockpile)
     {
         // You can't pick up stuff that isn't on a tile or if it's locked
-        if (Tile == null || Locked)
+        if (Tile == null || Locked || !CanClaim())
         {
             return false;
         }

--- a/Assets/Scripts/Models/Inventory/Inventory.cs
+++ b/Assets/Scripts/Models/Inventory/Inventory.cs
@@ -17,7 +17,6 @@ using Newtonsoft.Json.Linq;
 [System.Diagnostics.DebuggerDisplay("Inventory {ObjectType} {StackSize}/{MaxStackSize}")]
 public class Inventory : ISelectable, IContextActionProvider
 {
-    
     private int stackSize = 1;
     private DateTime claim;
 
@@ -106,6 +105,7 @@ public class Inventory : ISelectable, IContextActionProvider
         DateTime requestTime = DateTime.Now;
         return claim == null || (requestTime - claim).TotalSeconds > 5;
     }
+
     public string GetName()
     {
         return Type;

--- a/Assets/Scripts/Models/Inventory/Inventory.cs
+++ b/Assets/Scripts/Models/Inventory/Inventory.cs
@@ -86,7 +86,7 @@ public class Inventory : ISelectable, IContextActionProvider
     {
         // FIXME: The various Claim related functions should most likely track claim time in an in game time increment.
         DateTime requestTime = DateTime.Now;
-        if (claim == null || (requestTime - claim).TotalSeconds > 5)
+        if ((requestTime - claim).TotalSeconds > 5)
         {
             claim = requestTime;
             return true;
@@ -102,8 +102,7 @@ public class Inventory : ISelectable, IContextActionProvider
 
     public bool CanClaim()
     {
-        DateTime requestTime = DateTime.Now;
-        return claim == null || (requestTime - claim).TotalSeconds > 5;
+        return (DateTime.Now - claim).TotalSeconds > 5;
     }
 
     public string GetName()

--- a/Assets/Scripts/Models/Inventory/InventoryManager.cs
+++ b/Assets/Scripts/Models/Inventory/InventoryManager.cs
@@ -173,7 +173,7 @@ public class InventoryManager
     public bool PlaceInventory(Character character, Inventory sourceInventory, int amount = -1)
     {
         amount = amount < 0 ? sourceInventory.StackSize : Math.Min(amount, sourceInventory.StackSize);
-
+        sourceInventory.ReleaseClaim();
         if (character.inventory == null)
         {
             character.inventory = sourceInventory.Clone();

--- a/Assets/Scripts/State/HaulState.cs
+++ b/Assets/Scripts/State/HaulState.cs
@@ -56,6 +56,7 @@ namespace ProjectPorcupine.State
                     path = World.Current.InventoryManager.GetPathToClosestInventoryOfType(inventoryTypes, character.CurrTile, Job.canTakeFromStockpile);
                     if (path != null && path.Count > 0)
                     {
+                        path.Last().Inventory.Claim();
                         character.SetState(new MoveState(character, Pathfinder.GoalTileEvaluator(path.Last(), false), path, this));
                     }
                     else if (character.inventory == null)


### PR DESCRIPTION
Presently characters will all try to go after the same inventory, this PR simply stores a claim in the form of a DateTime object, and will prevent a character from finding an inventory with a claim more recent than 5 seconds, and resets the claim time on pickup so that if they don't pick up the full stack it is now available for another character. DateTime is used rather than a boolean or the character with a claim so that it autoexpires, without needing any event to be subscribed to or an update sent to inventory. Optimally we will, in the future, implement a form of in game time that can be used to track claims (along with many other uses of such a system), however, as is, using DateTime, a claim will expire if the game is paused right after a character claims an inventory, allowing another character to claim the same inventory, and there is little point in saving the claim time, as it will definitely be expired by the time the game is loaded again.

The expire time could perhaps use some tweaking, and could maybe even be made significantly longer, since a character *should* release the claim upon picking up the inventory (more accurately, the act of picking up an inventory releases the claim), with the expiration present only as a failsafe.