### PR TITLE
Atmosphere control dev commands

### DIFF
--- a/Assets/Scripts/Models/Area/Room.cs
+++ b/Assets/Scripts/Models/Area/Room.cs
@@ -225,6 +225,16 @@ namespace ProjectPorcupine.Rooms
             }
         }
 
+        public void SetGas(string name, float amount)
+        {
+            if (IsOutsideRoom())
+            {
+                return;
+            }
+
+            atmosphericGasses[name] = amount;
+        }
+
         public string ChangeInGas(string name)
         {
             if (deltaGas.ContainsKey(name))

--- a/Assets/Scripts/UI/InGameUI/DevConsole/DevConsole.cs
+++ b/Assets/Scripts/UI/InGameUI/DevConsole/DevConsole.cs
@@ -815,7 +815,14 @@ namespace DeveloperConsole
                 new Command("GetRoomIDs", CoreCommands.GetAllRoomIDs, "Logs all the room IDs"),
                 new Command<int, string, Vector3>("DoBuild", CoreCommands.DoBuild, CoreCommands.DoBuildHelp),
                 new Command("DirtyTileGraph", CoreCommands.InvalidateTileGraph, "Invalidates the tile graph"),
-                new Command("GetCharNames", CoreCommands.GetCharacterNames, "Logs all the character names"));
+                new Command("GetCharNames", CoreCommands.GetCharacterNames, "Logs all the character names"),
+                new Command<int, string, float>("SetRoomGas", CoreCommands.SetRoomGas, "Sets the gas in the room"),
+                new Command<string, float>("SetAllRoomsGas", CoreCommands.SetAllRoomsGas, "Sets the gas in all rooms"),
+                new Command<int>("FillRoomWithAir", CoreCommands.FillRoomWithAir, "Set's the room's gasses to standard atmosphere (20/80 O2/N2 mix)"),
+                new Command("FillAllRoomsWithAir", CoreCommands.FillAllRoomsWithAir, "Set's all rooms' gasses to standard atmosphere (20/80 O2/N2 mix)"),
+                new Command<int>("EmptyRoom", CoreCommands.EmptyRoom, "Empties the room's atmosphere"),
+                new Command("EmptyAllRooms", CoreCommands.EmptyAllRooms, "Empties all rooms' atmosphere")
+            );
 
             // Load Commands from XML (will be changed to JSON AFTER the current upgrade)
             // Covers both CSharp and LUA

--- a/Assets/Scripts/UI/InGameUI/DevConsole/DevConsole.cs
+++ b/Assets/Scripts/UI/InGameUI/DevConsole/DevConsole.cs
@@ -821,8 +821,7 @@ namespace DeveloperConsole
                 new Command<int>("FillRoomWithAir", CoreCommands.FillRoomWithAir, "Set's the room's gasses to standard atmosphere (20/80 O2/N2 mix)"),
                 new Command("FillAllRoomsWithAir", CoreCommands.FillAllRoomsWithAir, "Set's all rooms' gasses to standard atmosphere (20/80 O2/N2 mix)"),
                 new Command<int>("EmptyRoom", CoreCommands.EmptyRoom, "Empties the room's atmosphere"),
-                new Command("EmptyAllRooms", CoreCommands.EmptyAllRooms, "Empties all rooms' atmosphere")
-            );
+                new Command("EmptyAllRooms", CoreCommands.EmptyAllRooms, "Empties all rooms' atmosphere"));
 
             // Load Commands from XML (will be changed to JSON AFTER the current upgrade)
             // Covers both CSharp and LUA

--- a/Assets/Scripts/UI/InGameUI/DevConsole/DevConsoleCoreCommands.cs
+++ b/Assets/Scripts/UI/InGameUI/DevConsole/DevConsoleCoreCommands.cs
@@ -280,7 +280,7 @@ namespace DeveloperConsole
         public static void EmptyRoom(int roomId)
         {
             Room room = World.Current.RoomManager[roomId];
-            foreach (string gas in room.GetGasNames)
+            foreach (string gas in room.GetGasNames())
             {
                 room.SetGas(gas, 0);
             }
@@ -292,7 +292,7 @@ namespace DeveloperConsole
             {
                 if (room.ID > 0)
                 {
-                    foreach (string gas in room.GetGasNames)
+                    foreach (string gas in room.GetGasNames())
                     {
                         room.SetGas(gas, 0);
                     }

--- a/Assets/Scripts/UI/InGameUI/DevConsole/DevConsoleCoreCommands.cs
+++ b/Assets/Scripts/UI/InGameUI/DevConsole/DevConsoleCoreCommands.cs
@@ -260,6 +260,11 @@ namespace DeveloperConsole
         {
             // Adding air to room
             Room room = World.Current.RoomManager[roomID];
+            foreach (string gas in room.GetGasNames())
+            {
+                room.SetGas(gas, 0);
+            }
+
             room.SetGas("O2", 0.2f * room.TileCount);
             room.SetGas("N2", 0.8f * room.TileCount);
         }
@@ -269,6 +274,11 @@ namespace DeveloperConsole
             // Adding air to all rooms
             foreach (Room room in World.Current.RoomManager)
             {
+                foreach (string gas in room.GetGasNames())
+                {
+                    room.SetGas(gas, 0);
+                }
+
                 if (room.ID > 0)
                 {
                     room.SetGas("O2", 0.2f * room.TileCount);

--- a/Assets/Scripts/UI/InGameUI/DevConsole/DevConsoleCoreCommands.cs
+++ b/Assets/Scripts/UI/InGameUI/DevConsole/DevConsoleCoreCommands.cs
@@ -299,7 +299,5 @@ namespace DeveloperConsole
                 }
             }
         }
-
-
     }
 }

--- a/Assets/Scripts/UI/InGameUI/DevConsole/DevConsoleCoreCommands.cs
+++ b/Assets/Scripts/UI/InGameUI/DevConsole/DevConsoleCoreCommands.cs
@@ -236,5 +236,70 @@ namespace DeveloperConsole
         {
             return GetCurrentWorld().GetTileAt((int)pos.x, (int)pos.y, (int)pos.z);
         }
+
+        public static void SetRoomGas(int roomID, string gas, float pressure)
+        {
+            // Adding gas to room
+            Room room = World.Current.RoomManager[roomID];
+            room.SetGas(gas, pressure * room.TileCount);
+        }
+
+        public static void SetAllRoomsGas(string gas, float pressure)
+        {
+            // Adding gas to all rooms
+            foreach (Room room in World.Current.RoomManager)
+            {
+                if (room.ID > 0)
+                {
+                    room.SetGas(gas, pressure * room.TileCount);
+                }
+            }
+        }
+
+        public static void FillRoomWithAir(int roomID)
+        {
+            // Adding air to room
+            Room room = World.Current.RoomManager[roomID];
+            room.SetGas("O2", 0.2f * room.TileCount);
+            room.SetGas("N2", 0.8f * room.TileCount);
+        }
+
+        public static void FillAllRoomsWithAir()
+        {
+            // Adding air to all rooms
+            foreach (Room room in World.Current.RoomManager)
+            {
+                if (room.ID > 0)
+                {
+                    room.SetGas("O2", 0.2f * room.TileCount);
+                    room.SetGas("N2", 0.8f * room.TileCount);
+                }
+            }
+        }
+
+        public static void EmptyRoom(int roomId)
+        {
+            Room room = World.Current.RoomManager[roomId];
+            foreach (string gas in room.GetGasNames)
+            {
+                room.SetGas(gas, 0);
+            }
+        }
+
+        public static void EmptyAllRooms()
+        {
+            foreach (Room room in World.Current.RoomManager)
+            {
+                if (room.ID > 0)
+                {
+                    foreach (string gas in room.GetGasNames)
+                    {
+                        room.SetGas(gas, 0);
+                    }
+                }
+            }
+        }
+
+
     }
 }


### PR DESCRIPTION
Adds dev console commands to control atmosphere, either of individual rooms (by roomID) or all rooms, also by individual gas or standard human breathable atmosphere mix, and finally commands to empty the atmosphere of rooms. Includes SetGas command in Room.cs (used in the DevConsole commands), to directly set the gas mixture in a room, rather than changing the already present gasses.