### PR TITLE
Reload debug channel controller via context menu

### DIFF
--- a/Assets/Editor/DebuggerChannelControl.cs
+++ b/Assets/Editor/DebuggerChannelControl.cs
@@ -1,4 +1,4 @@
-﻿#region License
+#region License
 // ====================================================
 // Project Porcupine Copyright(C) 2016 Team Porcupine
 // This program comes with ABSOLUTELY NO WARRANTY; This is free software, 
@@ -12,7 +12,7 @@ using System.Linq;
 using UnityEditor;
 using UnityEngine;
 
-public class DebuggerChannelControl : EditorWindow
+public class DebuggerChannelControl : EditorWindow, IHasCustomMenu
 {
     private EditorWindow window;
 
@@ -20,6 +20,7 @@ public class DebuggerChannelControl : EditorWindow
     private bool allPreveState;
     private ChannelSettingsSO channelSettings;
     private Vector2 scrollViewVector = Vector2.down;
+    const string channelSettingsPath = "Assets/Resources/ChannelSettings.asset";
 
     [MenuItem("Window/Debugger Channel Control")]
     public static void ShowWindow()
@@ -33,7 +34,7 @@ public class DebuggerChannelControl : EditorWindow
         if (channelSettings == null)
         {
             channelSettings = ScriptableObject.CreateInstance<ChannelSettingsSO>();
-            AssetDatabase.CreateAsset(channelSettings, "Assets/Resources/ChannelSettings.asset");
+            AssetDatabase.CreateAsset(channelSettings, channelSettingsPath);
             AssetDatabase.SaveAssets();
         }
 
@@ -100,5 +101,13 @@ public class DebuggerChannelControl : EditorWindow
 
         EditorGUILayout.EndVertical();
         GUILayout.EndScrollView();
+    }
+
+    public void AddItemsToMenu(GenericMenu menu)
+    {
+        menu.AddItem(new GUIContent("Reload"), false, new GenericMenu.MenuFunction( ()=> {
+            AssetDatabase.DeleteAsset(channelSettingsPath);
+            Repaint();
+        }));
     }
 }

--- a/Assets/Editor/DebuggerChannelControl.cs
+++ b/Assets/Editor/DebuggerChannelControl.cs
@@ -13,19 +13,30 @@ using UnityEditor;
 using UnityEngine;
 
 public class DebuggerChannelControl : EditorWindow, IHasCustomMenu
-{
+{ 
     private EditorWindow window;
-
     private bool allState;
     private bool allPreveState;
     private ChannelSettingsSO channelSettings;
     private Vector2 scrollViewVector = Vector2.down;
-    const string channelSettingsPath = "Assets/Resources/ChannelSettings.asset";
+    private string channelSettingsPath = "Assets/Resources/ChannelSettings.asset";
 
     [MenuItem("Window/Debugger Channel Control")]
     public static void ShowWindow()
     {
         GetWindow(typeof(DebuggerChannelControl));
+    }
+
+    public void AddItemsToMenu(GenericMenu menu)
+    {
+        menu.AddItem(
+            new GUIContent("Reload"),
+            false,
+            new GenericMenu.MenuFunction(() =>
+            {
+                AssetDatabase.DeleteAsset(channelSettingsPath);
+                Repaint();
+            }));
     }
 
     private void Awake()
@@ -101,13 +112,5 @@ public class DebuggerChannelControl : EditorWindow, IHasCustomMenu
 
         EditorGUILayout.EndVertical();
         GUILayout.EndScrollView();
-    }
-
-    public void AddItemsToMenu(GenericMenu menu)
-    {
-        menu.AddItem(new GUIContent("Reload"), false, new GenericMenu.MenuFunction( ()=> {
-            AssetDatabase.DeleteAsset(channelSettingsPath);
-            Repaint();
-        }));
-    }
+    }    
 }


### PR DESCRIPTION

### The issue this fixes

Sometimes the debugger channel control window can have wierd bugs after changing to and from PR branches: 
![capture](https://cloud.githubusercontent.com/assets/7608114/21073845/6c0b15d2-beb8-11e6-811e-c800bb058fd1.PNG)

This can be fixed by deleting ChannelSettings.asset and then reloading the window, but requires a manual restart of unity.

### What this PR does
adds a nifty option in the right click menu of the DebuggerChannelWindow tab that allows you to reload the window without quiting unity.
