### PR TITLE
Bugfixes (Area Deconstruction, Character Inventory Saving/Loading

### DIFF
--- a/Assets/Scripts/Controllers/InputOutput/BuildModeController.cs
+++ b/Assets/Scripts/Controllers/InputOutput/BuildModeController.cs
@@ -322,7 +322,7 @@ public class BuildModeController
 
                 tile.Furniture.SetDeconstructJob();
             }
-            else if (tile.PendingBuildJobs != null)
+            else if (tile.PendingBuildJobs != null && tile.PendingBuildJobs.Count > 0)
             {
                 tile.PendingBuildJobs.Last().CancelJob();
             }

--- a/Assets/Scripts/Models/Character/CharacterManager.cs
+++ b/Assets/Scripts/Models/Character/CharacterManager.cs
@@ -151,6 +151,13 @@ public class CharacterManager : IEnumerable<Character>
                 character = Create(World.Current.GetTileAt(x, y, z));
             }
 
+            foreach (JToken inventoryToken in characterToken["Inventories"])
+            {
+                Inventory inventory = new Inventory();
+                inventory.FromJson(inventoryToken);
+                World.Current.InventoryManager.PlaceInventory(character, inventory);
+            }
+
             character.name = (string)characterToken["Name"];
         }
     }

--- a/Assets/Scripts/Models/Character/CharacterManager.cs
+++ b/Assets/Scripts/Models/Character/CharacterManager.cs
@@ -151,6 +151,7 @@ public class CharacterManager : IEnumerable<Character>
                 character = Create(World.Current.GetTileAt(x, y, z));
             }
 
+            // While it's not strictly necessary to use a foreach here, it *is* an array structure, so it should be treated as such
             foreach (JToken inventoryToken in characterToken["Inventories"])
             {
                 Inventory inventory = new Inventory();

--- a/Assets/Scripts/Models/Inventory/InventoryManager.cs
+++ b/Assets/Scripts/Models/Inventory/InventoryManager.cs
@@ -312,6 +312,11 @@ public class InventoryManager
         JArray inventoriesJson = new JArray();
         foreach (Inventory inventory in Inventories.SelectMany(pair => pair.Value))
         {
+            // Skip any inventory without a tile, these are inventories in a character or elsewhere that will handle it itself.
+            if (inventory.Tile == null)
+            {
+                continue;
+            }
             inventoriesJson.Add(inventory.ToJSon());
         }
 

--- a/Assets/Scripts/Models/Inventory/InventoryManager.cs
+++ b/Assets/Scripts/Models/Inventory/InventoryManager.cs
@@ -317,6 +317,7 @@ public class InventoryManager
             {
                 continue;
             }
+
             inventoriesJson.Add(inventory.ToJSon());
         }
 


### PR DESCRIPTION
Just a trio of quick bugfixes.

Fixes the error on doing a deconstruction where no object to deconstruct exists.

Fixes inventoryManager incorrectly saving inventory with no tile (and therefore somewhere other than a tile, and appropriately handled elsewhere).

Fixes character not loading inventory saved under it.