### PR TITLE
Fix Wall Deconstruction

### DIFF
--- a/Assets/StreamingAssets/Data/Furniture.xml
+++ b/Assets/StreamingAssets/Data/Furniture.xml
@@ -17,10 +17,10 @@
             <Inventory type="Steel Plate" amount="5" />
         </OrderAction>
 
-        <DeconstructJob jobTime="1">
+        <OrderAction type="Deconstruct">
             <Job time="1" />
             <Inventory type="Steel Plate" amount="3" />
-        </DeconstructJob>
+        </OrderAction>
 
         <Params>
             <!-- Temperature stuff  example -->


### PR DESCRIPTION
Walls still had DeconstructJob rather than OrderAction, just simply swapped it over to OrderAction.