### PR TITLE
Fix inventory spawn overlaying orders

### DIFF
--- a/Assets/Scripts/Controllers/InputOutput/BuildModeController.cs
+++ b/Assets/Scripts/Controllers/InputOutput/BuildModeController.cs
@@ -156,7 +156,8 @@ public class BuildModeController
                 if (orderAction != null)
                 {
                     job = orderAction.CreateJob(tile, furnitureType);
-                    //// this is here so OrderAction can be used for utility as well as furniture
+
+                    // this is here so OrderAction can be used for utility as well as furniture
                     job.OnJobCompleted += (theJob) => World.Current.FurnitureManager.ConstructJobCompleted(theJob);
                 }
                 else
@@ -232,7 +233,8 @@ public class BuildModeController
                 if (orderAction != null)
                 {
                     job = orderAction.CreateJob(tile, utilityType);
-                    //// this is here so OrderAction can be used for utility as well as furniture
+
+                    // this is here so OrderAction can be used for utility as well as furniture
                     job.OnJobCompleted += (theJob) => World.Current.UtilityManager.ConstructJobCompleted(theJob);
                 }
                 else

--- a/Assets/Scripts/UI/InGameUI/MenuLeft/MenuLeft.cs
+++ b/Assets/Scripts/UI/InGameUI/MenuLeft/MenuLeft.cs
@@ -38,7 +38,7 @@ public class MenuLeft : MonoBehaviour
 
         WorldController.Instance.soundController.OnButtonSFX();
 
-        if (CurrentlyOpen.name == "ConstructionMenu")
+        if (CurrentlyOpen.name == "ConstructionMenu" || CurrentlyOpen.name == "OrderMenu" )
         {
             WorldController.Instance.spawnInventoryController.SetUIVisibility(false);
         }
@@ -50,7 +50,7 @@ public class MenuLeft : MonoBehaviour
         {
             CurrentlyOpen.SetActive(false);
 
-            if (CurrentlyOpen.name == "ConstructionMenu")
+            if (CurrentlyOpen.name == "ConstructionMenu" || CurrentlyOpen.name == "OrderMenu" )
             {
                 WorldController.Instance.spawnInventoryController.SetUIVisibility(Settings.GetSetting("DialogBoxSettingsDevConsole_developerModeToggle", false));
             }

--- a/Assets/Scripts/UI/InGameUI/MenuLeft/MenuLeft.cs
+++ b/Assets/Scripts/UI/InGameUI/MenuLeft/MenuLeft.cs
@@ -38,7 +38,7 @@ public class MenuLeft : MonoBehaviour
 
         WorldController.Instance.soundController.OnButtonSFX();
 
-        if (CurrentlyOpen.name == "ConstructionMenu" || CurrentlyOpen.name == "OrderMenu" )
+        if (CurrentlyOpen.name == "ConstructionMenu" || CurrentlyOpen.name == "OrderMenu")
         {
             WorldController.Instance.spawnInventoryController.SetUIVisibility(false);
         }
@@ -50,7 +50,7 @@ public class MenuLeft : MonoBehaviour
         {
             CurrentlyOpen.SetActive(false);
 
-            if (CurrentlyOpen.name == "ConstructionMenu" || CurrentlyOpen.name == "OrderMenu" )
+            if (CurrentlyOpen.name == "ConstructionMenu" || CurrentlyOpen.name == "OrderMenu")
             {
                 WorldController.Instance.spawnInventoryController.SetUIVisibility(Settings.GetSetting("DialogBoxSettingsDevConsole_developerModeToggle", false));
             }


### PR DESCRIPTION
Just applying the same fix to the OrdersMenu that is used by ConstructionMenu to close the InventorySpawning Menu when it's opened.