### PR TITLE
[Tiny] in/visible furniture to HashSet

### DIFF
--- a/Assets/Scripts/Models/Buildable/FurnitureManager.cs
+++ b/Assets/Scripts/Models/Buildable/FurnitureManager.cs
@@ -20,10 +20,10 @@ public class FurnitureManager : IEnumerable<Furniture>
     private List<Furniture> furnitures;
 
     // A temporary list of all visible furniture. Gets updated when camera moves.
-    private List<Furniture> furnituresVisible;
+    private HashSet<Furniture> furnituresVisible;
 
     // A temporary list of all invisible furniture. Gets updated when camera moves.
-    private List<Furniture> furnituresInvisible;
+    private HashSet<Furniture> furnituresInvisible;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="FurnitureManager"/> class.
@@ -31,8 +31,8 @@ public class FurnitureManager : IEnumerable<Furniture>
     public FurnitureManager()
     {
         furnitures = new List<Furniture>();
-        furnituresVisible = new List<Furniture>();
-        furnituresInvisible = new List<Furniture>();
+        furnituresVisible = new HashSet<Furniture>();
+        furnituresInvisible = new HashSet<Furniture>();
     }
 
     /// <summary>


### PR DESCRIPTION
Any time the camera is moved, furniture is shuffled from an invisible list to a visible list and back, so that updates are ran slower on furniture that is out of frame. However, this can take 100+-20 ms to complete, which leads to a bit of stuttery movement. However, simply changing it to use HashSets drops it to somewhere between 8 and 20 (not exactly sure, as it doesn't create a visible spike as it does in master, so it's not as easy to pick out).

In more extreme cases (such as a world with more/larger asteroids, and thereby a lot more furniture), this can drop a 400-800 ms process to around 200, which, while still high, still leaves a playable framerate. 

This is partially to alleviate the loss of frames when scrolling presently on master, but also in preparation for larger more regular asteroids. More than likely more will have to be done in the future, but this makes master run more smoothly, and coming changes more playable.