### PR TITLE
[Tiny] Don't Pathfind to adjacent tiles in Idle

### DIFF
--- a/Assets/Scripts/State/IdleState.cs
+++ b/Assets/Scripts/State/IdleState.cs
@@ -35,7 +35,7 @@ namespace ProjectPorcupine.State
             {
                 Tile[] neighbors = character.CurrTile.GetNeighbours();
                 Tile endTile = neighbors[Random.Range(0, 4)];
-                List<Tile> path = Pathfinder.FindPathToTile(character.CurrTile, endTile);
+                List<Tile> path = new List<Tile>() { character.CurrTile, endTile };
 
                 if (endTile.MovementCost != 0)
                 {


### PR DESCRIPTION
Another small optimization, with an appreciable effect.

Currently crew in an idle state select one adjacent tile, and pathfind to it. This is done with a fair amount of regularity, and even though it is pathfinding to an adjacent tile, it can take a reasonable amount of time and this causes the game to have fairly regular fps drops, with the occasional very large spike (400ms spent in pathfinder, though I don't know why it does this only occasionally).

Since crew are only walking to an adjacent tile, and they already check if it is walkable, the pathfinding can be skipped, instead creating a list containing the current tile and the end tile, and feeding that directly to moveState. This makes the regular usage of idle state negligible (in the range of .05 ms), and eliminates the spikes (or at least the parts of spikes contributed to by IdleState). Resulting behavior of crew is unchanged, and logic isn't made more complex.