### PR TITLE
Removal of the Character state list for a hashset

### DIFF
--- a/Assets/Scripts/Models/Character/Character.cs
+++ b/Assets/Scripts/Models/Character/Character.cs
@@ -81,7 +81,7 @@ public class Character : ISelectable, IContextActionProvider
     private State state;
 
     // List of global states that always run
-    private List<State> globalStates;
+    private HashSet<State> globalStates;
 
     // Queue of states that aren't important enough to interrupt, but should run soon
     private Queue<State> stateQueue;
@@ -101,7 +101,7 @@ public class Character : ISelectable, IContextActionProvider
         characterSkinColor = skinColor;
         InitializeCharacterValues();
         stateQueue = new Queue<State>();
-        globalStates = new List<State>
+        globalStates = new HashSet<State>
         {
             new NeedState(this)
         };
@@ -338,7 +338,7 @@ public class Character : ISelectable, IContextActionProvider
                 else
                 {
                     // TODO: Lack of job states should be more interesting. Maybe go to the pub and have a pint?
-                    SetState(new IdleState(this));            
+                    SetState(new IdleState(this));
                 }
             }
         }


### PR DESCRIPTION
Just what the title says removes a list in the Character class for a hashset, it doesn't have grand results but I do notice about a 2-3 frame difference on dips (like every 5-12 seconds it dips to ~35 now it dips to around ~37+.  It also just doesn't need to be a list since there isn't any need for order :D.