### PR TITLE
Failsafes for pathfinding from null room

### DIFF
--- a/Assets/Scripts/Models/Buildable/Tile.cs
+++ b/Assets/Scripts/Models/Buildable/Tile.cs
@@ -6,12 +6,14 @@
 // file LICENSE, which is part of this source code package, for details.
 // ====================================================
 #endregion
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using MoonSharp.Interpreter;
 using Newtonsoft.Json.Linq;
 using ProjectPorcupine.Localization;
+using ProjectPorcupine.Pathfinding;
 using ProjectPorcupine.Rooms;
 using UnityEngine;
 
@@ -515,7 +517,11 @@ public class Tile : ISelectable, IContextActionProvider, IComparable, IEquatable
         return World.Current.GetTileAt(X, Y, Z + 1);
     }
 
-    public Room GetNearestAdjacentRoom()
+    /// <summary>
+    /// Gets the nearest room.
+    /// </summary>
+    /// <returns>The nearest room. If this tile has a room, it will return this tile's room.</returns>
+    public Room GetNearestRoom()
     {
         if (Room != null)
         {
@@ -531,7 +537,7 @@ public class Tile : ISelectable, IContextActionProvider, IComparable, IEquatable
             }
         }
 
-        return null;
+        return Pathfinder.FindNearestRoom(this);
     }
 
     public Enterability IsEnterable()

--- a/Assets/Scripts/Pathfinding/Pathfinder.cs
+++ b/Assets/Scripts/Pathfinding/Pathfinder.cs
@@ -142,7 +142,6 @@ namespace ProjectPorcupine.Pathfinding
             RoomPath_AStar roomResolver = new RoomPath_AStar(World.Current, start.GetNearestRoom(), RoomGoalInventoryEvaluator(type, canTakeFromStockpile), RoomHeuristic());
             List<Room> roomPath = roomResolver.GetList();
 
-
             if (roomPath.Count >= 1)
             {
                 Tile nearestExit;
@@ -210,7 +209,6 @@ namespace ProjectPorcupine.Pathfinding
 
             RoomPath_AStar roomResolver = new RoomPath_AStar(World.Current, start.GetNearestRoom(), RoomGoalFurnitureEvaluator(type), RoomHeuristic());
             List<Room> roomPath = roomResolver.GetList();
-
 
             if (roomPath.Count >= 1)
             {

--- a/Assets/Scripts/Pathfinding/Pathfinder.cs
+++ b/Assets/Scripts/Pathfinding/Pathfinder.cs
@@ -86,37 +86,47 @@ namespace ProjectPorcupine.Pathfinding
                 return null;
             }
 
-            RoomPath_AStar roomResolver = new RoomPath_AStar(World.Current, start.Room, RoomGoalInventoryEvaluator(types, canTakeFromStockpile), RoomHeuristic());
+            RoomPath_AStar roomResolver = new RoomPath_AStar(World.Current, start.GetNearestRoom(), RoomGoalInventoryEvaluator(types, canTakeFromStockpile), RoomHeuristic());
             List<Room> roomPath = roomResolver.GetList();
 
-            Tile nearestExit;
-            if (roomPath.Count == 1)
+            if (roomPath.Count >= 1)
             {
-                nearestExit = start;
+                Tile nearestExit;
+                if (roomPath.Count == 1)
+                {
+                    nearestExit = start;
+                }
+                else
+                {
+                    nearestExit = GetNearestExit(roomPath);
+                }
+
+                Tile targetTile = null;
+                float distance = 0f;
+
+                foreach (Inventory inventory in World.Current.InventoryManager.Inventories.Where(dictEntry => types.Contains(dictEntry.Key)).SelectMany(dictEntry => dictEntry.Value))
+                {
+                    if (inventory.Tile == null)
+                    {
+                        continue;
+                    }
+
+                    if (targetTile == null || Vector3.Distance(nearestExit.Vector3, inventory.Tile.Vector3) < distance)
+                    {
+                        distance = Vector3.Distance(nearestExit.Vector3, inventory.Tile.Vector3);
+                        targetTile = inventory.Tile;
+                    }
+                }
+
+                return FindPathToTile(start, targetTile);
             }
             else
             {
-                nearestExit = GetNearestExit(roomPath);
+                // Since we don't have a roomPath, someone's done something weird, like a room of doors, so just use Dijkstra to find our way
+                Path_AStar resolver = new Path_AStar(World.Current, start, GoalInventoryEvaluator(types, canTakeFromStockpile), DijkstraDistance());
+                List<Tile> path = resolver.GetList();
+                return path;
             }
-
-            Tile targetTile = null;
-            float distance = 0f;
-
-            foreach (Inventory inventory in World.Current.InventoryManager.Inventories.Where(dictEntry => types.Contains(dictEntry.Key)).SelectMany(dictEntry => dictEntry.Value))
-            {
-                if (inventory.Tile == null)
-                {
-                    continue;
-                }
-
-                if (targetTile == null || Vector3.Distance(nearestExit.Vector3, inventory.Tile.Vector3) < distance)
-                {
-                    distance = Vector3.Distance(nearestExit.Vector3, inventory.Tile.Vector3);
-                    targetTile = inventory.Tile;
-                }
-            }
-
-            return FindPathToTile(start, targetTile);
         }
 
         /// <summary>
@@ -129,36 +139,60 @@ namespace ProjectPorcupine.Pathfinding
                 return null;
             }
 
-            RoomPath_AStar roomResolver = new RoomPath_AStar(World.Current, start.Room, RoomGoalInventoryEvaluator(type, canTakeFromStockpile), RoomHeuristic());
+            RoomPath_AStar roomResolver = new RoomPath_AStar(World.Current, start.GetNearestRoom(), RoomGoalInventoryEvaluator(type, canTakeFromStockpile), RoomHeuristic());
             List<Room> roomPath = roomResolver.GetList();
 
-            Tile nearestExit;
-            if (roomPath.Count == 1)
+
+            if (roomPath.Count >= 1)
             {
-                nearestExit = start;
+                Tile nearestExit;
+                if (roomPath.Count == 1)
+                {
+                    nearestExit = start;
+                }
+                else
+                {
+                    nearestExit = GetNearestExit(roomPath);
+                }
+
+                Tile targetTile = null;
+                float distance = 0f;
+                foreach (Inventory inventory in World.Current.InventoryManager.Inventories[type])
+                {
+                    if (inventory.Tile == null)
+                    {
+                        continue;
+                    }
+
+                    if (targetTile == null || Vector3.Distance(nearestExit.Vector3, inventory.Tile.Vector3) < distance)
+                    {
+                        distance = Vector3.Distance(nearestExit.Vector3, inventory.Tile.Vector3);
+                        targetTile = inventory.Tile;
+                    }
+                }
+
+                return FindPathToTile(start, targetTile);
             }
             else
             {
-                nearestExit = GetNearestExit(roomPath);
+                // Since we don't have a roomPath, someone's done something weird, like a room of doors, so just use Dijkstra to find our way
+                Path_AStar resolver = new Path_AStar(World.Current, start, GoalInventoryEvaluator(type, canTakeFromStockpile), DijkstraDistance());
+                List<Tile> path = resolver.GetList();
+                return path;
             }
+        }
 
-            Tile targetTile = null;
-            float distance = 0f;
-            foreach (Inventory inventory in World.Current.InventoryManager.Inventories[type])
+        public static Room FindNearestRoom(Tile start)
+        {
+            Path_AStar tileResolver = new Path_AStar(World.Current, start, GoalHasRoomEvaluator(), DijkstraDistance());
+            List<Tile> pathToRoom = tileResolver.GetList();
+
+            if (tileResolver.Length() >= 1)
             {
-                if (inventory.Tile == null)
-                {
-                    continue;
-                }
-
-                if (targetTile == null || Vector3.Distance(nearestExit.Vector3, inventory.Tile.Vector3) < distance)
-                {
-                    distance = Vector3.Distance(nearestExit.Vector3, inventory.Tile.Vector3);
-                    targetTile = inventory.Tile;
-                }
+                return tileResolver.EndTile().Room;
             }
 
-            return FindPathToTile(start, targetTile);
+            return null;
         }
 
         /// <summary>
@@ -174,31 +208,42 @@ namespace ProjectPorcupine.Pathfinding
                 return null;
             }
 
-            RoomPath_AStar roomResolver = new RoomPath_AStar(World.Current, start.Room, RoomGoalFurnitureEvaluator(type), RoomHeuristic());
+            RoomPath_AStar roomResolver = new RoomPath_AStar(World.Current, start.GetNearestRoom(), RoomGoalFurnitureEvaluator(type), RoomHeuristic());
             List<Room> roomPath = roomResolver.GetList();
 
-            Tile nearestExit;
-            if (roomPath.Count == 1)
+
+            if (roomPath.Count >= 1)
             {
-                nearestExit = start;
+                Tile nearestExit;
+                if (roomPath.Count == 1)
+                {
+                    nearestExit = start;
+                }
+                else
+                {
+                    nearestExit = GetNearestExit(roomPath);
+                }
+
+                Tile targetTile = null;
+                float distance = 0f;
+                foreach (Furniture furniture in World.Current.FurnitureManager.Where(furniture => furniture.Type == type))
+                {
+                    if (targetTile == null || Vector3.Distance(nearestExit.Vector3, furniture.Tile.Vector3) < distance)
+                    {
+                        distance = Vector3.Distance(nearestExit.Vector3, furniture.Tile.Vector3);
+                        targetTile = furniture.Tile;
+                    }
+                }
+
+                return FindPathToTile(start, targetTile);
             }
             else
             {
-                nearestExit = GetNearestExit(roomPath);
+                // Since we don't have a roomPath, someone's done something weird, like a room of doors, so just use Dijkstra to find our way
+                Path_AStar resolver = new Path_AStar(World.Current, start, GoalFurnitureEvaluator(type), DijkstraDistance());
+                List<Tile> path = resolver.GetList();
+                return path;
             }
-
-            Tile targetTile = null;
-            float distance = 0f;
-            foreach (Furniture furniture in World.Current.FurnitureManager.Where(furniture => furniture.Type == type))
-            {
-                if (targetTile == null || Vector3.Distance(nearestExit.Vector3, furniture.Tile.Vector3) < distance)
-                {
-                    distance = Vector3.Distance(nearestExit.Vector3, furniture.Tile.Vector3);
-                    targetTile = furniture.Tile;
-                }
-            }
-
-            return FindPathToTile(start, targetTile);
         }
 
         /// <summary>
@@ -289,6 +334,11 @@ namespace ProjectPorcupine.Pathfinding
             return current => current.Furniture != null && current.Furniture.Type == type;
         }
 
+        public static GoalEvaluator GoalHasRoomEvaluator()
+        {
+            return current => current.Room != null;
+        }
+
         /// <summary>
         /// Evaluates if it is an appropriate place to dump inventory of type <paramref name="type"/> and <paramref name="amount"/>.
         /// </summary>
@@ -318,17 +368,17 @@ namespace ProjectPorcupine.Pathfinding
         public static RoomGoalEvaluator RoomGoalInventoryEvaluator(string[] types, bool canTakeFromStockpile = true)
         {
             return room =>
-                World.Current.InventoryManager.Inventories.Where(dictEntry => types.Contains(dictEntry.Key)).SelectMany(dictEntry => dictEntry.Value).Any(inv => inv != null && inv.CanBePickedUp(canTakeFromStockpile) && inv.Tile != null && inv.Tile.GetNearestAdjacentRoom() == room);
+                World.Current.InventoryManager.Inventories.Where(dictEntry => types.Contains(dictEntry.Key)).SelectMany(dictEntry => dictEntry.Value).Any(inv => inv != null && inv.CanBePickedUp(canTakeFromStockpile) && inv.Tile != null && inv.Tile.GetNearestRoom() == room);
         }
 
         public static RoomGoalEvaluator RoomGoalInventoryEvaluator(string type, bool canTakeFromStockpile = true)
         {
-            return room => World.Current.InventoryManager.Inventories.Keys.Contains(type) && World.Current.InventoryManager.Inventories[type].Any(inv => inv.Tile.GetNearestAdjacentRoom() == room && inv.CanBePickedUp(canTakeFromStockpile));
+            return room => World.Current.InventoryManager.Inventories.Keys.Contains(type) && World.Current.InventoryManager.Inventories[type].Any(inv => inv.Tile.GetNearestRoom() == room && inv.CanBePickedUp(canTakeFromStockpile));
         }
 
         public static RoomGoalEvaluator RoomGoalFurnitureEvaluator(string type)
         {
-            return currentRoom => World.Current.FurnitureManager.Any(furniture => furniture.Type == type && furniture.Tile.GetNearestAdjacentRoom() == currentRoom);
+            return currentRoom => World.Current.FurnitureManager.Any(furniture => furniture.Type == type && furniture.Tile.GetNearestRoom() == currentRoom);
         }
 
         public static Tile GetNearestExit(List<Room> roomList)

--- a/Assets/Scripts/Pathfinding/RoomPath_AStar.cs
+++ b/Assets/Scripts/Pathfinding/RoomPath_AStar.cs
@@ -35,6 +35,12 @@ public class RoomPath_AStar
         // Set path to empty Queue so that there always is something to check count on
         path = new Queue<Room>();
 
+        if (roomStart == null)
+        {
+            // We don't have a room so just bail with an empty path.
+            return;
+        }
+
         // if tileEnd is null, then we are simply scanning for the nearest objectType.
         // We can do this by ignoring the heuristic component of AStar, which basically
         // just turns this into an over-engineered Dijkstra's algo


### PR DESCRIPTION
Currently, in master, any pathfinding that uses room pathfinding will fail if starting from a null room (such as a door. This first has it use GetNearestRoom, so that it will look for an adjacent room, failing that it will now also try to get the nearest room via pathfinding, and for the worst case scenario (room filled with doors, and not connected to any other areas, so there are no room objects accessible, it should just try to dijkstra pathfind to what it is looking for. I feel this worse case is going to be exceedingly rare, and further if it does happen will be unlikely to be a large room, so dijkstra shouldn't be a big performance hit, and if it is, this is a player trying to push the edge of what is reasonable and likely is doing it for no reason other than to break the system, this shouldn't break in that situation, it will just drop frames while it pathfinds in the most inefficient way possible (since it can't make use of room pathfinding due to there not being any rooms)