### PR TITLE
Escape always exists the settings menu

### DIFF
--- a/Assets/Scripts/UI/InGameUI/SettingsMenu/SettingsMenu.cs
+++ b/Assets/Scripts/UI/InGameUI/SettingsMenu/SettingsMenu.cs
@@ -290,7 +290,7 @@ public class SettingsMenu : MonoBehaviour
 
     private void Update()
     {
-        if (Input.GetKey(KeyCode.Escape))
+        if (Input.GetKey(KeyCode.Escape) && mainRoot.activeInHierarchy == true)
         {
             Cancel();
         }


### PR DESCRIPTION
Just me being a little stupid and forgetting to do a check so it'll only escape the menu if its open.  This way you don't have weird inconsistencies with it trying to close and it's already closed.