### PR TITLE
[Fix] Reconnect FilterField to FilterFunction

### DIFF
--- a/Assets/Scripts/UI/InGameUI/MenuLeft/ConstructionMenu.cs
+++ b/Assets/Scripts/UI/InGameUI/MenuLeft/ConstructionMenu.cs
@@ -92,6 +92,7 @@ public class ConstructionMenu : MonoBehaviour
         RenderUtilityButtons();
 
         InputField filterField = GetComponentInChildren<InputField>();
+        filterField.onValueChanged.AddListener (delegate {FilterTextChanged(filterField.text);});
         KeyboardManager.Instance.RegisterModalInputField(filterField);
     }
 

--- a/Assets/Scripts/UI/InGameUI/MenuLeft/ConstructionMenu.cs
+++ b/Assets/Scripts/UI/InGameUI/MenuLeft/ConstructionMenu.cs
@@ -92,7 +92,7 @@ public class ConstructionMenu : MonoBehaviour
         RenderUtilityButtons();
 
         InputField filterField = GetComponentInChildren<InputField>();
-        filterField.onValueChanged.AddListener (delegate {FilterTextChanged(filterField.text);});
+        filterField.onValueChanged.AddListener(delegate { FilterTextChanged(filterField.text); });
         KeyboardManager.Instance.RegisterModalInputField(filterField);
     }
 

--- a/Assets/Scripts/UI/InGameUI/MenuLeft/OrderMenu.cs
+++ b/Assets/Scripts/UI/InGameUI/MenuLeft/OrderMenu.cs
@@ -66,6 +66,7 @@ public class OrderMenu : MonoBehaviour
         RenderMineButton();
 
         InputField filterField = GetComponentInChildren<InputField>();
+        filterField.onValueChanged.AddListener (delegate {FilterTextChanged(filterField.text);});
         KeyboardManager.Instance.RegisterModalInputField(filterField);
     }    
 

--- a/Assets/Scripts/UI/InGameUI/MenuLeft/OrderMenu.cs
+++ b/Assets/Scripts/UI/InGameUI/MenuLeft/OrderMenu.cs
@@ -66,7 +66,7 @@ public class OrderMenu : MonoBehaviour
         RenderMineButton();
 
         InputField filterField = GetComponentInChildren<InputField>();
-        filterField.onValueChanged.AddListener (delegate {FilterTextChanged(filterField.text);});
+        filterField.onValueChanged.AddListener(delegate { FilterTextChanged(filterField.text); });
         KeyboardManager.Instance.RegisterModalInputField(filterField);
     }    
 


### PR DESCRIPTION
Fixes #1700

Due to changes in ConstructionMenu the Filter was no longer working. This simply adds the Listener through code. It also adds the listener to the similar Filter in the order menu, which while not strictly needed at this time, due to the small size of the order menu, it does have the Filter field present and may be needed in the future.