### PR TITLE
Remove Utility's Update functions

### DIFF
--- a/Assets/Scripts/Models/Area/World.cs
+++ b/Assets/Scripts/Models/Area/World.cs
@@ -511,7 +511,6 @@ public class World
     {
         CharacterManager.Update(deltaTime);
         FurnitureManager.TickEveryFrame(deltaTime);
-        UtilityManager.TickEveryFrame(deltaTime);
         GameEventManager.Update(deltaTime);
         ShipManager.Update(deltaTime);
     }
@@ -523,7 +522,6 @@ public class World
     private void TickFixedFrequency(float deltaTime)
     {
         FurnitureManager.TickFixedFrequency(deltaTime);
-        UtilityManager.TickFixedFrequency(deltaTime);
 
         // Progress temperature modelling
         temperature.Update();

--- a/Assets/Scripts/Models/Buildable/Utility.cs
+++ b/Assets/Scripts/Models/Buildable/Utility.cs
@@ -305,30 +305,6 @@ public class Utility : ISelectable, IPrototypable, IContextActionProvider, IBuil
     }
 
     /// <summary>
-    /// This function is called to update the utility. This will also trigger EventsActions.
-    /// This checks if the utility is a PowerConsumer, and if it does not have power it cancels its job.
-    /// </summary>
-    /// <param name="deltaTime">The time since the last update was called.</param>
-    public void EveryFrameUpdate(float deltaTime)
-    {
-        gridUpdatedThisFrame = false;
-    }
-
-    /// <summary>
-    /// This function is called to update the utility. This will also trigger EventsActions.
-    /// This checks if the utility is a PowerConsumer, and if it does not have power it cancels its job.
-    /// </summary>
-    /// <param name="deltaTime">The time since the last update was called.</param>
-    public void FixedFrequencyUpdate(float deltaTime)
-    {
-        if (EventActions != null)
-        {
-            // updateActions(this, deltaTime);
-            EventActions.Trigger("OnUpdate", this, deltaTime);
-        }
-    }
-
-    /// <summary>
     /// Check if the utility has a function to determine the sprite name and calls that function.
     /// </summary>
     /// <returns>Name of the sprite.</returns>

--- a/Assets/Scripts/Models/Buildable/UtilityManager.cs
+++ b/Assets/Scripts/Models/Buildable/UtilityManager.cs
@@ -77,34 +77,6 @@ public class UtilityManager : IEnumerable<Utility>
     }
 
     /// <summary>
-    /// Calls the utilities update function on every frame.
-    /// The list needs to be copied temporarily in case utilities are added or removed during the update.
-    /// </summary>
-    /// <param name="deltaTime">Delta time.</param>
-    public void TickEveryFrame(float deltaTime)
-    {
-        List<Utility> tempUtilities = Utilities;
-        foreach (Utility utility in tempUtilities)
-        {
-            utility.EveryFrameUpdate(deltaTime);
-        }
-    }
-
-    /// <summary>
-    /// Calls the utilities update function on every frame.
-    /// The list needs to be copied temporarily in case utilities are added or removed during the update.
-    /// </summary>
-    /// <param name="deltaTime">Delta time.</param>
-    public void TickFixedFrequency(float deltaTime)
-    {
-        List<Utility> tempUtilities = Utilities;
-        foreach (Utility utility in tempUtilities)
-        {
-            utility.FixedFrequencyUpdate(deltaTime);
-        }
-    }
-
-    /// <summary>
     /// When a construction job is completed, place the utility.
     /// </summary>
     /// <param name="job">The completed job.</param>


### PR DESCRIPTION
When I created Utility.cs off the basis of Furniture.cs, I left in the update functions, because at the time I was uncertain exactly how various aspects of the actual networks would be implemented, and wanted to leave them in in case they were applicable, however, now that I've started integrating the appropriate systems, I can see they're not going to be used. This removes the update functions, and the various calls to them that did nothing but waste a bit of time.