### PR TITLE
[Experimental] Spread Furniture Slow update across frames

### DIFF
--- a/Assets/Scripts/Models/Buildable/FurnitureManager.cs
+++ b/Assets/Scripts/Models/Buildable/FurnitureManager.cs
@@ -172,6 +172,10 @@ public class FurnitureManager : IEnumerable<Furniture>
         return furnitures.Where(filterFunc).ToList();
     }
 
+    private int invisibleFurnitureProgress = 0;
+    private int furnitureProgress = 0;
+    private float[] accumulatedTime = new float[10];
+    private int timePos = 0;
     /// <summary>
     /// Calls the furnitures update function on every frame.
     /// The list needs to be copied temporarily in case furnitures are added or removed during the update.
@@ -179,11 +183,40 @@ public class FurnitureManager : IEnumerable<Furniture>
     /// <param name="deltaTime">Delta time.</param>
     public void TickEveryFrame(float deltaTime)
     {
+        Profiler.BeginSample("TEF");
         List<Furniture> tempFurnituresVisible = new List<Furniture>(furnituresVisible);
         foreach (Furniture furniture in tempFurnituresVisible)
         {
             furniture.EveryFrameUpdate(deltaTime);
         }
+
+        accumulatedTime[timePos] = deltaTime;
+        float accumulatedDeltaTime = accumulatedTime.Sum();
+
+        // Update furniture outside of the camera view
+        List<Furniture> tempFurnituresInvisible = new List<Furniture>(furnituresInvisible);
+        //        int totalFurnCount = tempFurnituresInvisible.Count;
+        int invFurnToProcess = Mathf.CeilToInt((float)tempFurnituresInvisible.Count / 10);
+        for (int i = invisibleFurnitureProgress; i < invisibleFurnitureProgress + invFurnToProcess && i < tempFurnituresInvisible.Count; i++)
+        {
+            tempFurnituresInvisible[i].EveryFrameUpdate(accumulatedDeltaTime);
+        }
+        invisibleFurnitureProgress += invFurnToProcess;
+
+        List<Furniture> tempFurnitures = new List<Furniture>(furnitures);
+        int furnToProcess = Mathf.CeilToInt((float)tempFurnitures.Count / 10);
+        for (int i = furnitureProgress; i < furnitureProgress + furnToProcess && i < tempFurnitures.Count; i++)
+        {
+            tempFurnitures[i].FixedFrequencyUpdate(accumulatedDeltaTime);
+        }
+        furnitureProgress += furnToProcess;
+
+        timePos++;
+        if (timePos >= accumulatedTime.Length)
+        {
+            timePos = 0;
+        }
+        Profiler.EndSample();
     }
 
     /// <summary>
@@ -197,19 +230,13 @@ public class FurnitureManager : IEnumerable<Furniture>
         //       and update one of the lists each frame.
         //       FixedFrequencyUpdate on invisible furniture could also be even slower.
 
-        // Update furniture outside of the camera view
-        List<Furniture> tempFurnituresInvisible = new List<Furniture>(furnituresInvisible);
-        foreach (Furniture furniture in tempFurnituresInvisible)
-        {
-            furniture.EveryFrameUpdate(deltaTime);
-        }
 
         // Update all furniture with EventActions
-        List<Furniture> tempFurnitures = new List<Furniture>(furnitures);
-        foreach (Furniture furniture in tempFurnitures)
-        {
-            furniture.FixedFrequencyUpdate(deltaTime);
-        }
+        //        List<Furniture> tempFurnitures = new List<Furniture>(furnitures);
+        //        foreach (Furniture furniture in tempFurnitures)
+        //        {
+        //            furniture.FixedFrequencyUpdate(deltaTime);
+        //        }
     }
 
     /// <summary>

--- a/Assets/Scripts/Models/Buildable/FurnitureManager.cs
+++ b/Assets/Scripts/Models/Buildable/FurnitureManager.cs
@@ -215,6 +215,8 @@ public class FurnitureManager : IEnumerable<Furniture>
         if (timePos >= accumulatedTime.Length)
         {
             timePos = 0;
+            invisibleFurnitureProgress = 0;
+            furnitureProgress = 0;
         }
         Profiler.EndSample();
     }


### PR DESCRIPTION
This is an experiment to alleviate the spikes in performance, where 5 times every second, all slow updates and fast updates of all off-screen furnitures are ran. Roughly it divides the relevant collections into 10 parts and runs the updates for that 10th on the fast update, moving to the next 10th on the next frame, keeping a rolling count of the deltatime. This greatly smooths the performance (a very smooth 60fps, and smooth enough that it could potentially hit 120fps with no v-sync), but I'm unsure about some of the implementation details, most particularly, if a furniture is added in the middle of an update cycle (as in during 1 of the 10 frames rather than at the beginning), it could cause a furniture to be missed (since we're using hashsets), or possibly ran twice. Also I'm not fond of the slow update being implemented outside of the TImeManager, and no longer having an connection to the update time set in there, but I don't see how it can be done that way, since it needs to be called every frame (or nearly every frame) and has to be aware of the details of the furniture to properly dispatch calls.

I am looking for input on ways to improve this, and if any one has any ideas how this could be handled more in TimeManager, rather than FurnitureManager handling all the implementation details.

As this is Experimental and will need more work to be merge ready (and will likely have to be completely retooled when/if #1695 is merged), I will likely not be worrying about details like stylecop, or other style related things, and am just looking for input on how to improve the mechanics of the system. 

Whatever is submitted for final merging is likely to be an entirely new branch just using the concepts from this branch.

Paging: @BraedonWooding , @dusho 