### PR TITLE
Less Object Creation in Functions.cs

### DIFF
--- a/Assets/Scripts/Models/Events/EventAction.cs
+++ b/Assets/Scripts/Models/Events/EventAction.cs
@@ -5,6 +5,9 @@
 // and you are welcome to redistribute it under certain conditions; See
 // file LICENSE, which is part of this source code package, for details.
 // ====================================================
+using UnityEngine;
+
+
 #endregion
 using System.Collections.Generic;
 using System.Xml;
@@ -102,11 +105,10 @@ public class EventActions
     {
         if (!actionsList.ContainsKey(actionName) || actionsList[actionName] == null)
         {
-            return;
         }
         else
         {
-            FunctionsManager.Get(target.GetType().Name).CallWithInstance(actionsList[actionName].ToArray(), target, parameters);
+            FunctionsManager.Get(target.GetType().Name).CallWithInstance(actionsList[actionName], target, parameters);
         }
     }
 

--- a/Assets/Scripts/Models/Events/EventAction.cs
+++ b/Assets/Scripts/Models/Events/EventAction.cs
@@ -5,10 +5,8 @@
 // and you are welcome to redistribute it under certain conditions; See
 // file LICENSE, which is part of this source code package, for details.
 // ====================================================
-using UnityEngine;
-
-
 #endregion
+
 using System.Collections.Generic;
 using System.Xml;
 using MoonSharp.Interpreter;

--- a/Assets/Scripts/Models/Events/GameEvent.cs
+++ b/Assets/Scripts/Models/Events/GameEvent.cs
@@ -133,7 +133,7 @@ public class GameEvent : IPrototypable
         if (executionActions != null)
         {
             // Execute Lua code like in Furniture ( FurnitureActions ) 
-            FunctionsManager.GameEvent.CallWithInstance(executionActions.ToArray(), this);
+            FunctionsManager.GameEvent.CallWithInstance(executionActions, this);
         }
 
         if (!Repeat)

--- a/Assets/Scripts/Models/Functions/Functions.cs
+++ b/Assets/Scripts/Models/Functions/Functions.cs
@@ -6,6 +6,7 @@
 // file LICENSE, which is part of this source code package, for details.
 // ====================================================
 #endregion
+
 using System;
 using System.Collections.Generic;
 using MoonSharp.Interpreter;
@@ -16,7 +17,7 @@ public class Functions
 
     public Functions()
     {
-        FunctionsSets = new HashSet<IFunctions>();
+        FunctionsSets = new List<IFunctions>();
     }
 
     public enum Type
@@ -25,7 +26,7 @@ public class Functions
         CSharp
     }
 
-    public HashSet<IFunctions> FunctionsSets { get; private set; }
+    public List<IFunctions> FunctionsSets { get; private set; }
 
     public bool HasFunction(string name)
     {
@@ -86,22 +87,23 @@ public class Functions
         }
     }
 
-    public void CallWithInstance(string[] functionNames, object instance, params object[] parameters)
+    public void CallWithInstance(List<string> functionNames, object instance, params object[] parameters)
     {
-        foreach (string fn in functionNames)
+        DynValue result;
+        object[] instanceAndParams;
+        instanceAndParams = new object[parameters.Length + 1];
+        instanceAndParams[0] = instance;
+        parameters.CopyTo(instanceAndParams, 1);
+
+        for (int i = 0; i < functionNames.Count; i++)
         {
-            if (fn == null)
+            if (functionNames[i] == null)
             {
-                UnityDebugger.Debugger.LogError(ModFunctionsLogChannel, "'" + fn + "'  is not a LUA nor CSharp function!");
-                return;
+                UnityDebugger.Debugger.LogError(ModFunctionsLogChannel, "'" + functionNames[i] + "'  is not a LUA nor CSharp function!");
+                continue;;
             }
 
-            DynValue result;
-            object[] instanceAndParams = new object[parameters.Length + 1];
-            instanceAndParams[0] = instance;
-            parameters.CopyTo(instanceAndParams, 1);
-
-            result = Call(fn, instanceAndParams);
+            result = Call(functionNames[i], instanceAndParams);
 
             if (result != null && result.Type == DataType.String)
             {
@@ -140,11 +142,11 @@ public class Functions
 
     private IFunctions GetFunctions(string name)
     {
-        foreach (IFunctions functionsSet in FunctionsSets)
+        for (int i = 0; i < FunctionsSets.Count; i++)
         {
-            if (functionsSet.HasFunction(name))
+            if (FunctionsSets[i].HasFunction(name))
             {
-                return functionsSet;
+                return FunctionsSets[i];
             }
         }
 

--- a/Assets/Scripts/Models/Functions/Functions.cs
+++ b/Assets/Scripts/Models/Functions/Functions.cs
@@ -100,7 +100,7 @@ public class Functions
             if (functionNames[i] == null)
             {
                 UnityDebugger.Debugger.LogError(ModFunctionsLogChannel, "'" + functionNames[i] + "'  is not a LUA nor CSharp function!");
-                continue;;
+                continue;
             }
 
             result = Call(functionNames[i], instanceAndParams);


### PR DESCRIPTION
While profiling in my experiments to improve TimeManager and our general usage of UpdateFunctions, I narrowed in on a fair amount of GC allocation coming from EventActions (and in turn from Functions.cs). 

So I've went through the class (Functions.cs) and tried to minimize object creation and Foreach loops. Most notably, CallWithInstance is now passed a List, rather than an array as in both instances where it is called the object stored by the caller is a list, requiring it to be converted to an array, and creating another object to be garbage collected. Additionally FunctionSets is changed to a list, since, while order doesn't matter, it is small and isn't frequently added to/removed from, which means difference in function between the two is negligible, but changing it to a List allows it to easily be converted to a for loop rather than a foreach loop (which is notorious for creating a lot of garbage in Unity).

While Garbage collection is still more frequent than I'd like, this does seem to reduce the frequency and severity of garbage collection, and I'm not able to delve deeper due to oddities in the Profiler while attempting to Profile deeper, making it appear that some of the calls are nesting (though reviewing the relevant code doesn't seem to support that happening), this may simply be an error on my part in setting up the sampling. Cursory examination suggests that some of the changes I'm experimenting with in smoothing out updates further increases the effect of this PR.