### PR TITLE
Optimize temperature

### DIFF
--- a/Assets/Scripts/Models/Area/Temperature.cs
+++ b/Assets/Scripts/Models/Area/Temperature.cs
@@ -44,9 +44,9 @@ public class Temperature
     /// <summary>
     /// Size of map.
     /// </summary>
-    private int sizeX = World.Current.Width;
-    private int sizeY = World.Current.Height;
-    private int sizeZ = World.Current.Depth;
+    private int sizeX;
+    private int sizeY;
+    private int sizeZ;
 
     /// <summary>
     /// Time since last update.
@@ -63,6 +63,10 @@ public class Temperature
     /// </summary>
     public Temperature()
     {
+        sizeX = World.Current.Width;
+        sizeY = World.Current.Height;
+        sizeZ = World.Current.Depth;
+
         temperature = new float[2][]
         {
             new float[sizeX * sizeY * sizeZ],
@@ -269,6 +273,9 @@ public class Temperature
     /// </summary>
     private void ForwardTemp(float deltaTime)
     {
+        Debug.LogWarning("###" + sizeX);
+        Debug.LogWarning("###" + sizeY);
+        Debug.LogWarning("###" + sizeZ);
         // Store references.
         float[] temp_curr = temperature[1 - offset];
         float[] temp_old = temperature[offset];
@@ -282,6 +289,7 @@ public class Temperature
         // Calculates for all tiles.
         for (int z = 0; z < sizeZ; z++)
         {
+            Debug.LogWarning(z + "$$$");
             for (int y = 0; y < sizeY; y++)
             {
                 for (int x = 0; x < sizeX; x++)

--- a/Assets/Scripts/Models/Area/Temperature.cs
+++ b/Assets/Scripts/Models/Area/Temperature.cs
@@ -88,16 +88,9 @@ public class Temperature
     /// <summary>
     /// If needed, progress physics.
     /// </summary>
-    public void Update()
+    public void Update(float deltaTime)
     {
-        // Progress physical time (should me linked to TIme.dt at some point)
-        elapsed += updateInterval;
-
-        if (elapsed >= updateInterval)
-        {
-            ProgressTemperature(updateInterval);
-            elapsed = elapsed - updateInterval;
-        }
+        ProgressTemperature(deltaTime);
     }
 
     public void RegisterSinkOrSource(Furniture provider)
@@ -258,7 +251,7 @@ public class Temperature
     /// </summary>
     private void ProgressTemperature(float deltaT)
     {
-        Thread thread = new Thread(ForwardTemp);
+        Thread thread = new Thread(() => ForwardTemp(deltaT));
         thread.Start();
 
         // TODO: Compute temperature sources.
@@ -274,7 +267,7 @@ public class Temperature
     /// <summary>
     /// Update temperature using a forward method.
     /// </summary>
-    private void ForwardTemp()
+    private void ForwardTemp(float deltaTime)
     {
         // Store references.
         float[] temp_curr = temperature[1 - offset];
@@ -284,7 +277,7 @@ public class Temperature
         // delta.Time * magic_coefficient * 0.5 (avg for thermalDiffusivity).
         // Make sure c is always between 0 and 0.5*0.25 (not included) or things will blow up
         // in your face.
-        float c = 0.23f * 0.5f;
+        float c = deltaTime * 0.23f * 0.5f;
 
         // Calculates for all tiles.
         for (int z = 0; z < sizeZ; z++)
@@ -362,7 +355,7 @@ public class Temperature
                     float value = temp_curr[index];
 
                     // FINE tune the below number. ".005" has a huge effect.
-                    value += 0.065f * value;
+                    value += value;
 
                     float[] list =
                     {

--- a/Assets/Scripts/Models/Area/Temperature.cs
+++ b/Assets/Scripts/Models/Area/Temperature.cs
@@ -101,12 +101,10 @@ public class Temperature
 
     public void RegisterSinkOrSource(Furniture provider)
     {
-        
         // TODO: This need to be implemented.
         sinksAndSources[provider] = (float deltaTime) =>
         {
                 UpdateTemperature(provider, deltaTime);
-//                provider.EventActions.Trigger("OnUpdateTemperature", provider, deltaTime);
         };
     }
 
@@ -135,11 +133,11 @@ public class Temperature
         return GetTemperature(x, y, z) - 273.15f;
     }
 
-    // 1.8
     public float GetTemperatureInF(int x, int y, int z)
     {
-        return GetTemperature(x, y, z) * 1.8f - 459.67f;
+        return (GetTemperature(x, y, z) * 1.8f) - 459.67f;
     }
+
     /// <summary>
     /// Public interface to setting temperature, set temperature at (x,y) to temp.
     /// </summary>
@@ -254,7 +252,6 @@ public class Temperature
 
     public void Resize()
     {
-
         sizeX = World.Current.Width;
         sizeY = World.Current.Height;
         sizeZ = World.Current.Depth;
@@ -302,17 +299,10 @@ public class Temperature
         // TODO: Compute temperature sources.
         if (sinksAndSources != null)
         {
-            Debug.LogWarning("----------------");
             foreach (Action<float> act in sinksAndSources.Values)
             {
                 act(deltaT);
             }
-
-//            Furniture[] sinksAndSourcesArray = sinksAndSources.Keys.ToArray();
-//            for (int i = 0; i < sinksAndSourcesArray.Length; i++)
-//            {
-//                UpdateTemperature(sinksAndSourcesArray[i], deltaT);
-//            }
         }
     }
 
@@ -430,13 +420,12 @@ public class Temperature
         offset = 1 - offset;
     }
 
-    private void UpdateTemperature(Furniture furniture, float deltaTime )
+    private void UpdateTemperature(Furniture furniture, float deltaTime)
     {
         if (furniture.Tile.Room.IsOutsideRoom() == true)
         {
             return;
         }
-
 
         Tile tile = furniture.Tile;
         float pressure = tile.Room.GetTotalGasPressure();
@@ -452,6 +441,5 @@ public class Temperature
         temperatureChange = temperatureChange * 10;
 
         World.Current.temperature.SetTemperature(tile.X, tile.Y, tile.Z, temperatureChange);
-//                --ModUtils.ULogChannel("Temperature", "Heat change: " .. temperatureChangePerSecond .. " => " .. World.current.temperature.GetTemperature(tile.X, tile.Y))}
     }
 }

--- a/Assets/Scripts/Models/Area/World.cs
+++ b/Assets/Scripts/Models/Area/World.cs
@@ -390,7 +390,7 @@ public class World
         roomGraph = null;
 
         // Reset temperature, so it properly sizes arrays to the new world size
-        temperature = new Temperature();
+        temperature.Resize();
 
         for (int x = 0; x < oldWidth; x++)
         {

--- a/Assets/Scripts/Models/Area/World.cs
+++ b/Assets/Scripts/Models/Area/World.cs
@@ -524,7 +524,7 @@ public class World
         FurnitureManager.TickFixedFrequency(deltaTime);
 
         // Progress temperature modelling
-        temperature.Update();
+        temperature.Update(deltaTime);
         PowerNetwork.Update(deltaTime);
         FluidNetwork.Update(deltaTime);
     }

--- a/Assets/Scripts/UI/MouseOverRoomDetails.cs
+++ b/Assets/Scripts/UI/MouseOverRoomDetails.cs
@@ -27,7 +27,7 @@ public class MouseOverRoomDetails : MouseOver
         string roomDetails = string.Empty;
 
         roomDetails += World.Current.temperature.GetTemperatureInF(tile.X, tile.Y, tile.Z) + "F";
-        roomDetails +=  " (" + World.Current.temperature.GetTemperatureInC(tile.X, tile.Y, tile.Z) + "C)\n";
+        roomDetails += " (" + World.Current.temperature.GetTemperatureInC(tile.X, tile.Y, tile.Z) + "C)\n";
         foreach (string gasName in tile.Room.GetGasNames())
         {
             roomDetails += string.Format("{0}: ({1}) {2:0.000} atm ({3:0.0}%)\n", gasName, tile.Room.ChangeInGas(gasName), tile.Room.GetGasPressure(gasName), tile.Room.GetGasFraction(gasName) * 100);

--- a/Assets/Scripts/UI/MouseOverRoomDetails.cs
+++ b/Assets/Scripts/UI/MouseOverRoomDetails.cs
@@ -26,6 +26,8 @@ public class MouseOverRoomDetails : MouseOver
 
         string roomDetails = string.Empty;
 
+        roomDetails += World.Current.temperature.GetTemperatureInF(tile.X, tile.Y, tile.Z) + "F";
+        roomDetails +=  " (" + World.Current.temperature.GetTemperatureInC(tile.X, tile.Y, tile.Z) + "C)\n";
         foreach (string gasName in tile.Room.GetGasNames())
         {
             roomDetails += string.Format("{0}: ({1}) {2:0.000} atm ({3:0.0}%)\n", gasName, tile.Room.ChangeInGas(gasName), tile.Room.GetGasPressure(gasName), tile.Room.GetGasFraction(gasName) * 100);

--- a/Assets/Scripts/UI/Overlay/OverlayMap.cs
+++ b/Assets/Scripts/UI/Overlay/OverlayMap.cs
@@ -272,14 +272,19 @@ public class OverlayMap : MonoBehaviour
             }
 
             bool loggedOnce = false;
-            valueAt = (x, y, z) =>
-            {
+            valueAt = (x, y, z) => {
                 if (WorldController.Instance == null)
                 {
                     return 0;
                 }
 
+
                 Tile tile = WorldController.Instance.GetTileAtWorldCoord(new Vector3(x, y, z));
+//                if (tile == null)
+//                {
+//                    return 0;
+//                }
+
                 DynValue result = FunctionsManager.Overlay.Call(descr.LuaFunctionName, new object[] { tile, World.Current });
                 double? value = result.CastToNumber();
                 if (value == null)

--- a/Assets/Scripts/UI/Overlay/OverlayMap.cs
+++ b/Assets/Scripts/UI/Overlay/OverlayMap.cs
@@ -272,18 +272,14 @@ public class OverlayMap : MonoBehaviour
             }
 
             bool loggedOnce = false;
-            valueAt = (x, y, z) => {
+            valueAt = (x, y, z) => 
+            {
                 if (WorldController.Instance == null)
                 {
                     return 0;
                 }
 
-
                 Tile tile = WorldController.Instance.GetTileAtWorldCoord(new Vector3(x, y, z));
-//                if (tile == null)
-//                {
-//                    return 0;
-//                }
 
                 DynValue result = FunctionsManager.Overlay.Call(descr.LuaFunctionName, new object[] { tile, World.Current });
                 double? value = result.CastToNumber();

--- a/Assets/StreamingAssets/LUA/Furniture.lua
+++ b/Assets/StreamingAssets/LUA/Furniture.lua
@@ -428,20 +428,14 @@ end
 -- This function gets called once, when the furniture is installed
 function Heater_InstallAction( furniture, deltaTime)
     -- TODO: find elegant way to register heat source and sinks to Temperature
-	furniture.EventActions.Register("OnUpdateTemperature", "Heater_UpdateTemperature")
 	World.Current.temperature.RegisterSinkOrSource(furniture)
 end
 
 -- This function gets called once, when the furniture is uninstalled
 function Heater_UninstallAction( furniture, deltaTime)
-    furniture.EventActions.Deregister("OnUpdateTemperature", "Heater_UpdateTemperature")
 	World.Current.temperature.DeregisterSinkOrSource(furniture)
 	-- TODO: find elegant way to unregister previous register
 end
-
-function Heater_UpdateTemperature( furniture, deltaTime)
-    UpdateTemperature(furniture, deltaTime)
-  end
 
 -- Should maybe later be integrated with GasGenerator function by
 -- someone who knows how that would work in this case
@@ -685,20 +679,14 @@ end
 -- This function gets called once, when the furniture is installed
 function Rtg_InstallAction( furniture, deltaTime)
     -- TODO: find elegant way to register heat source and sinks to Temperature
-	furniture.EventActions.Register("OnUpdateTemperature", "Rtg_UpdateTemperature")
 	World.Current.temperature.RegisterSinkOrSource(furniture)
 end
 
 -- This function gets called once, when the furniture is uninstalled
 function Rtg_UninstallAction( furniture, deltaTime)
-    furniture.EventActions.Deregister("OnUpdateTemperature", "Rtg_UpdateTemperature")
 	World.Current.temperature.DeregisterSinkOrSource(furniture)
 	-- TODO: find elegant way to unregister previous register
 end
-
-function Rtg_UpdateTemperature( furniture, deltaTime)
-    UpdateTemperature(furniture, deltaTime)
-    end
 
 function Berth_TestSummoning(furniture, deltaTime)
     if (furniture.Parameters["occupied"].ToFloat() <= 0) then
@@ -728,24 +716,6 @@ function Berth_DismissShip(furniture, character)
         shipManager.DeberthShip(furniture)
         ship.SetDestination(0, 0)
     end
-end
-
-function UpdateTemperature( furniture, deltaTime )
-    if (furniture.tile.Room.IsOutsideRoom() == true) then
-        return
-    end
-
-    tile = furniture.tile
-    pressure = tile.Room.GetTotalGasPressure()
-    efficiency = ModUtils.Clamp01(pressure / furniture.Parameters["pressure_threshold"].ToFloat())
-    temperatureChangePerSecond = furniture.Parameters["base_heating"].ToFloat() * efficiency
-    temperatureChange = temperatureChangePerSecond * deltaTime
-    -- Multiply by this just to make the game make sense.
-    temperatureChange = temperatureChange * 10
-
-    World.Current.temperature.SetTemperature(tile.X, tile.Y, tile.Z, temperatureChange)
-    --ModUtils.ULogChannel("Temperature", "Heat change: " .. temperatureChangePerSecond .. " => " .. World.current.temperature.GetTemperature(tile.X, tile.Y))
-
 end
 
 ModUtils.ULog("Furniture.lua loaded")


### PR DESCRIPTION
Temperature.cs has a few issues, this fixes some of them.

Temperature progression does not take delta time into account, so as best I can tell it functions as though 1 second has passed every update cycle (presently 1/5 second), this includes delta time in the calculations in the place that the comments imply it should be.

The two objects that update temperature both call the same function eventually, and furthermore I don't see a reason that things would do any different and heat things with some other calculations, this moves that function into C#, preventing a large number of heat sources from bogging the game down quite so bad.

The Temperature update event action for heat sources was being registered twice, once automatically via the xml, and again manually in the install event action. This removes that extra registration.

Finally, it adds a simple mouse over text to show the temperature in more commonly understood units (both fahrenheit and celsius)

Displaying the temperature in more understandable terms exposes some other issues preexisting with temperature, most particularly it heats tiles up insanely fast at the heat source but doesn't dissipate that heat to surrounding tiles nearly fast enough, so the heat source will end up at around 1000F, the next tile over at 256F and the next out will be around -256F. Even doing it on a faster timer (everyframe) it doesn't work in any vaguely realistic way (and bogs the game down horribly, as one might expect).