### PR TITLE
[Fix] building utility network  -- reset updated this frame

### DIFF
--- a/Assets/Scripts/Models/Buildable/Utility.cs
+++ b/Assets/Scripts/Models/Buildable/Utility.cs
@@ -644,6 +644,7 @@ public class Utility : ISelectable, IPrototypable, IContextActionProvider, IBuil
         }
 
         gridUpdatedThisFrame = true;
+        TimeManager.Instance.RunNextFrame(() => gridUpdatedThisFrame = false);
         Grid oldGrid = utilityToUpdate.Grid;
 
         World.Current.PowerNetwork.RemoveGrid(utilityToUpdate.Grid);

--- a/Assets/Scripts/Models/Time/TimeManager.cs
+++ b/Assets/Scripts/Models/Time/TimeManager.cs
@@ -6,8 +6,10 @@
 // file LICENSE, which is part of this source code package, for details.
 // ====================================================
 #endregion
+
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using UnityEngine;
 
 public class TimeManager
@@ -15,6 +17,8 @@ public class TimeManager
     private static TimeManager instance;
 
     private float gameTickPerSecond = 5;
+
+    private List<Action> nextFrameActions = new List<Action>();
 
     // An array of possible time multipliers.
     private float[] possibleTimeScales = new float[6] { 0.1f, 0.5f, 1f, 2f, 4f, 8f };
@@ -130,6 +134,16 @@ public class TimeManager
         // Systems that update every frame.
         InvokeEvent(EveryFrame, time);
 
+        if (nextFrameActions.Count > 0)
+        {
+            for (int i = 0; i < nextFrameActions.Count; i++)
+            {
+                nextFrameActions[i].Invoke();
+            }
+
+            nextFrameActions.Clear();
+        }
+
         // Systems that update every frame not in Modal.
         if (GameController.Instance.IsModal == false)
         {
@@ -195,6 +209,11 @@ public class TimeManager
     public void Destroy()
     {
         instance = null;
+    }
+
+    public void RunNextFrame(Action action)
+    {
+        nextFrameActions.Add(action);
     }
 
     /// <summary>

--- a/Assets/Scripts/Models/Time/TimeManager.cs
+++ b/Assets/Scripts/Models/Time/TimeManager.cs
@@ -212,7 +212,7 @@ public class TimeManager
     }
 
     /// <summary>
-    /// Runs the next frame before any updates are ran.
+    /// Runs the action in the next frame before any updates are ran.
     /// </summary>
     /// <param name="action">Action with no parameters.</param>
     public void RunNextFrame(Action action)

--- a/Assets/Scripts/Models/Time/TimeManager.cs
+++ b/Assets/Scripts/Models/Time/TimeManager.cs
@@ -211,6 +211,10 @@ public class TimeManager
         instance = null;
     }
 
+    /// <summary>
+    /// Runs the next frame before any updates are ran.
+    /// </summary>
+    /// <param name="action">Action with no parameters.</param>
     public void RunNextFrame(Action action)
     {
         nextFrameActions.Add(action);


### PR DESCRIPTION
Previously I removed updates frame Utilities on the premise that they did nothing. However, I overlooked on thing, and that is resetting the boolean that says rather or not they had updated their network that frame, to prevent them from getting stuck in an endless loop, crawling up and down the network of wires trying to build the network.

I still stand by removing the update, because it was way too much just for one little thing that is only used for one maintenance level thing and only when utilities are built. 

To reimplement the reset, I implemented a method in TimeManager, RunNextFrame, which simply takes an action with no parameters, and runs it on the next frame before anything other updates are processed.