### PR TITLE
Try to connect to power utility in all tiles of furniture

### DIFF
--- a/Assets/Scripts/Models/Buildable/Components/PowerConnection.cs
+++ b/Assets/Scripts/Models/Buildable/Components/PowerConnection.cs
@@ -8,6 +8,7 @@
 #endregion
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Xml.Serialization;
 using MoonSharp.Interpreter;
 using Newtonsoft.Json;
@@ -268,9 +269,14 @@ namespace ProjectPorcupine.Buildable.Components
 
         private void OnReconnecting()
         {
-            foreach (Utility util in ParentFurniture.Tile.Utilities.Values)
+            foreach (Utility util in ParentFurniture.GetAllTiles().SelectMany(tile => tile.Utilities.Values))
             {
-                util.Grid.PlugIn(this);
+                if (util.Grid.PlugIn(this))
+                {
+                    // For now it's meaningless to connect to multiple utilities, and behavior isn't well defined, so break out of all loops
+//                    breakLoop = true;
+                    break;
+                }
             }
         }
 

--- a/Assets/Scripts/Models/Buildable/Components/PowerConnection.cs
+++ b/Assets/Scripts/Models/Buildable/Components/PowerConnection.cs
@@ -273,6 +273,7 @@ namespace ProjectPorcupine.Buildable.Components
             {
                 if (util.Grid.PlugIn(this))
                 {
+                    // For now it's meaningless to connect to multiple utilities, and behavior isn't well defined, so bail
                     break;
                 }
             }

--- a/Assets/Scripts/Models/Buildable/Components/PowerConnection.cs
+++ b/Assets/Scripts/Models/Buildable/Components/PowerConnection.cs
@@ -273,8 +273,6 @@ namespace ProjectPorcupine.Buildable.Components
             {
                 if (util.Grid.PlugIn(this))
                 {
-                    // For now it's meaningless to connect to multiple utilities, and behavior isn't well defined, so break out of all loops
-//                    breakLoop = true;
                     break;
                 }
             }

--- a/Assets/Scripts/Models/Buildable/Furniture.cs
+++ b/Assets/Scripts/Models/Buildable/Furniture.cs
@@ -1306,6 +1306,20 @@ public class Furniture : ISelectable, IPrototypable, IContextActionProvider, IBu
         Rotation = rotation;
     }
 
+    public Tile[] GetAllTiles()
+    {
+        Tile[] tiles = new Tile[Height * Width];
+        for (int x = 0; x < Width; x++)
+        {
+            for (int y = 0; y < Height; y++)
+            {
+                tiles[x + (y * Width)] = World.Current.GetTileAt(Tile.X + x, Tile.Y + y, Tile.Z);
+            }
+        }
+
+        return tiles;
+    }
+
     // Make a copy of the current furniture.  Sub-classed should
     // override this Clone() if a different (sub-classed) copy
     // constructor should be run.

--- a/Assets/Scripts/Models/Buildable/Utility.cs
+++ b/Assets/Scripts/Models/Buildable/Utility.cs
@@ -262,17 +262,7 @@ public class Utility : ISelectable, IPrototypable, IContextActionProvider, IBuil
             // If we're skipping the update, we need a temporary grid for furniture in the same tile to connect to.
             obj.Grid = new Grid();
             World.Current.PowerNetwork.RegisterGrid(obj.Grid);
-        }
-
-        // try to reconnect furniture if present and compatible     
-        if (obj.Tile != null && obj.Tile.Furniture != null)
-        {
-            IPluggable pluggableComponent = obj.Tile.Furniture.GetPluggable(proto.typeTags);
-            if (pluggableComponent != null)
-            {
-                // plug in
-                pluggableComponent.Reconnect();
-            }
+            obj.SeekConnection();
         }
 
         // Call LUA install scripts
@@ -666,6 +656,8 @@ public class Utility : ISelectable, IPrototypable, IContextActionProvider, IBuil
                 }
             }
         }
+
+        SeekConnection();
     }
 
     public object ToJSon()
@@ -691,6 +683,20 @@ public class Utility : ISelectable, IPrototypable, IContextActionProvider, IBuil
         if (utilityJObject.Children().Contains("Parameters"))
         {
             Parameters.FromJson(utilityJObject["Parameters"]);
+        }
+    }
+
+    private void SeekConnection()
+    {
+        // try to reconnect furniture if present and compatible     
+        if (Tile != null && Tile.Furniture != null)
+        {
+            IPluggable pluggableComponent = Tile.Furniture.GetPluggable(typeTags);
+            if (pluggableComponent != null)
+            {
+                // plug in
+                pluggableComponent.Reconnect();
+            }
         }
     }
 


### PR DESCRIPTION
Connects Power consuming/generating furniture to cables in any of its tiles (both when the furniture is placed, and when a utility is placed). 

Also adds a utility function to furniture to support, `Tile[] GetAllTiles()` so that a loop doesn't have to be recoded every time all tiles of a furniture are needed, and to simplify breaking out of looping once a utility is found to connect to.

As the Fluid Network is still Universal at this time, the same logic isn't applied to the Fluid Connection, but should be easy to implement when Fluids through pipes is implemented.