### PR TITLE
[Fix] Properly return a path to an inventory that can actually be picked up

### DIFF
--- a/Assets/Scripts/Models/Job/JobQueue.cs
+++ b/Assets/Scripts/Models/Job/JobQueue.cs
@@ -131,14 +131,14 @@ public class JobQueue
             {
                 if (CharacterCantReachHelper(job, character))
                 {
-                    UnityDebugger.Debugger.LogError("Character could not find a path to the job site.");
+                    UnityDebugger.Debugger.LogError("JobQueue", "Character could not find a path to the job site.");
                     ReInsertHelper(job);
                     continue;
                 }
                 else if ((job.RequestedItems.Count > 0) && !job.CanGetToInventory(character))
                 {
                     job.AddCharCantReach(character);
-                    UnityDebugger.Debugger.LogError("Character could not find a path to any inventory available.");
+                    UnityDebugger.Debugger.LogError("JobQueue", "Character could not find a path to any inventory available.");
                     ReInsertHelper(job);
                     continue;
                 }

--- a/Assets/Scripts/Pathfinding/Pathfinder.cs
+++ b/Assets/Scripts/Pathfinding/Pathfinder.cs
@@ -106,7 +106,7 @@ namespace ProjectPorcupine.Pathfinding
 
                 foreach (Inventory inventory in World.Current.InventoryManager.Inventories.Where(dictEntry => types.Contains(dictEntry.Key)).SelectMany(dictEntry => dictEntry.Value))
                 {
-                    if (inventory.Tile == null)
+                    if (inventory.Tile == null || !inventory.CanBePickedUp(canTakeFromStockpile))
                     {
                         continue;
                     }

--- a/Assets/Scripts/State/HaulState.cs
+++ b/Assets/Scripts/State/HaulState.cs
@@ -52,7 +52,6 @@ namespace ProjectPorcupine.State
                     string[] inventoryTypes = character.inventory != null ?
                         new string[] { character.inventory.Type } :
                         Job.RequestedItems.Keys.ToArray();
-
                     path = World.Current.InventoryManager.GetPathToClosestInventoryOfType(inventoryTypes, character.CurrTile, Job.canTakeFromStockpile);
                     if (path != null && path.Count > 0)
                     {
@@ -71,7 +70,6 @@ namespace ProjectPorcupine.State
                     {
                         noMoreMaterialFound = true;
                     }
-
                     break;
 
                 case HaulAction.PickupMaterial:
@@ -80,6 +78,7 @@ namespace ProjectPorcupine.State
                     int amount = Mathf.Min(Job.AmountDesiredOfInventoryType(tileInventory.Type) - amountCarried, tileInventory.StackSize);
                     DebugLog(" - Picked up {0} {1}", amount, tileInventory.Type);
                     World.Current.InventoryManager.PlaceInventory(character, tileInventory, amount);
+                    Profiler.EndSample();
                     break;
 
                 case HaulAction.DeliverMaterial:

--- a/Assets/Scripts/State/HaulState.cs
+++ b/Assets/Scripts/State/HaulState.cs
@@ -70,6 +70,7 @@ namespace ProjectPorcupine.State
                     {
                         noMoreMaterialFound = true;
                     }
+
                     break;
 
                 case HaulAction.PickupMaterial:


### PR DESCRIPTION
I made a mistake when implementing RoomPathfinding,  I missed an inventory.CanBePickedUp, so it was pathing to the stockpile, and being told it can't pick it up, and therefore requesting a new path, and being told about the same inventory so they get stuck in a loop of that, so all crew eventually end up stuck in stockpiles, hammering the pathfinding.

This properly adds a check that the inventory can be picked up before pathing to it.