### PR TITLE
Varying input/output (power/fluid) for components

### DIFF
--- a/Assets/Editor/UnitTests/Models/BuildableComponentTest.cs
+++ b/Assets/Editor/UnitTests/Models/BuildableComponentTest.cs
@@ -108,6 +108,7 @@ public class BuildableComponentTest
 
         Assert.NotNull(deserializedWorkshop);
         Assert.AreEqual("Raw Iron", deserializedWorkshop.PossibleProductions[0].Input[0].ObjectType);
+        Assert.IsNotNull(deserializedWorkshop.RunConditions);
     }
 
     [Test]
@@ -117,7 +118,6 @@ public class BuildableComponentTest
 
         //// serialize
         string workshopJson = SerializeObjectToJson(workshop);
-        StringReader sr = new StringReader(workshopJson);
 
         // if you want to dump file to disk for visual check, uncomment this
         ////File.WriteAllText("Workshop.json", workshopJson);
@@ -161,7 +161,6 @@ public class BuildableComponentTest
 
         // serialize
         string gasConnectionJson = SerializeObjectToJson(gasConnection);
-        StringReader sr = new StringReader(gasConnectionJson);
 
         // if you want to dump file to disk for visual check, uncomment this
         ////File.WriteAllText("GasConnection.json", gasConnectionJson);
@@ -197,8 +196,8 @@ public class BuildableComponentTest
         Assert.NotNull(deserializedPowerConnection);
 
         Assert.AreEqual(10f, deserializedPowerConnection.Provides.Rate);
-        Assert.AreEqual(0f, deserializedPowerConnection.Requires.Rate);
-        Assert.AreEqual(1, deserializedPowerConnection.Requires.ParamConditions.Count);
+        Assert.AreEqual("cur_processed_inv", deserializedPowerConnection.RunConditions.ParamConditions[0].ParameterName);
+        Assert.AreEqual(1, deserializedPowerConnection.RunConditions.ParamConditions.Count);
     }
 
     [Test]
@@ -218,8 +217,8 @@ public class BuildableComponentTest
         Assert.NotNull(deserializedPowerConnection);
 
         Assert.AreEqual(10f, deserializedPowerConnection.Provides.Rate);
-        Assert.AreEqual(0f, deserializedPowerConnection.Requires.Rate);
-        Assert.AreEqual(1, deserializedPowerConnection.Requires.ParamConditions.Count);
+        Assert.AreEqual("cur_processed_inv", deserializedPowerConnection.RunConditions.ParamConditions[0].ParameterName);
+        Assert.AreEqual(1, deserializedPowerConnection.RunConditions.ParamConditions.Count);
     }
 
     [Test]
@@ -281,7 +280,7 @@ public class BuildableComponentTest
                 new BuildableComponent.UseAnimation()
                 {
                     Name = "idle",
-                    Requires = new BuildableComponent.ParameterConditions()
+                    RunConditions = new BuildableComponent.Conditions()
                     {
                         ParamConditions = new System.Collections.Generic.List<BuildableComponent.ParameterCondition>()
                         {
@@ -296,7 +295,7 @@ public class BuildableComponentTest
                 new BuildableComponent.UseAnimation()
                 {
                     Name = "running",
-                    Requires = new BuildableComponent.ParameterConditions()
+                    RunConditions = new BuildableComponent.Conditions()
                     {
                         ParamConditions = new System.Collections.Generic.List<BuildableComponent.ParameterCondition>()
                         {
@@ -364,6 +363,17 @@ public class BuildableComponentTest
 
         workshop.PossibleProductions.Add(chain2);
 
+        workshop.RunConditions = new BuildableComponent.Conditions()
+        {
+            ParamConditions = new System.Collections.Generic.List<BuildableComponent.ParameterCondition>()
+            {
+                new BuildableComponent.ParameterCondition()
+                {
+                    ParameterName = "test", Condition = BuildableComponent.ConditionType.IsTrue
+                }
+            }
+        };
+
         workshop.ParamsDefinitions = new Workshop.WorkShopParameterDefinitions();
         return workshop;
     }
@@ -394,8 +404,8 @@ public class BuildableComponentTest
     {
         return new PowerConnection
         {
-            Provides = new PowerConnection.Info() { Rate = 10.0f, Capacity = 100.0f },
-            Requires = new PowerConnection.Info()
+            Provides = new PowerConnection.Info() { Rate = 10.0f, Capacity = 100.0f },            
+            RunConditions = new BuildableComponent.Conditions()
             {
                 ParamConditions = new System.Collections.Generic.List<BuildableComponent.ParameterCondition>()
                 {

--- a/Assets/Editor/UnitTests/Models/Power/PowerGridTest.cs
+++ b/Assets/Editor/UnitTests/Models/Power/PowerGridTest.cs
@@ -352,6 +352,12 @@ public class PowerGridTest
 
         public bool InputCanVary { get; set; }
 
+        public bool OutputCanVary { get; set; }
+
+        public bool OutputIsNeeded { get; set; }
+
+        public bool AllRequirementsFulfilled { get; set; }
+
         public void Reconnect()
         {
             throw new NotImplementedException();

--- a/Assets/Editor/UnitTests/Models/Power/PowerGridTest.cs
+++ b/Assets/Editor/UnitTests/Models/Power/PowerGridTest.cs
@@ -350,6 +350,8 @@ public class PowerGridTest
 
         public float OutputRate { get; set; }
 
+        public bool InputCanVary { get; set; }
+
         public void Reconnect()
         {
             throw new NotImplementedException();

--- a/Assets/Editor/UnitTests/Models/Power/PowerGridTest.cs
+++ b/Assets/Editor/UnitTests/Models/Power/PowerGridTest.cs
@@ -356,7 +356,10 @@ public class PowerGridTest
 
         public bool OutputIsNeeded { get; set; }
 
-        public bool AllRequirementsFulfilled { get; set; }
+        public bool AllRequirementsFulfilled
+        {
+            get { return true; }
+        }
 
         public void Reconnect()
         {

--- a/Assets/Editor/UnitTests/Models/Power/PowerNetworkTest.cs
+++ b/Assets/Editor/UnitTests/Models/Power/PowerNetworkTest.cs
@@ -183,7 +183,10 @@ public class PowerNetworkTest
 
         public bool OutputIsNeeded { get; set; }
 
-        public bool AllRequirementsFulfilled { get; set; }
+        public bool AllRequirementsFulfilled
+        {
+            get { return true; }
+        }
 
         public void Reconnect()
         {

--- a/Assets/Editor/UnitTests/Models/Power/PowerNetworkTest.cs
+++ b/Assets/Editor/UnitTests/Models/Power/PowerNetworkTest.cs
@@ -179,6 +179,12 @@ public class PowerNetworkTest
 
         public bool InputCanVary { get; set; }
 
+        public bool OutputCanVary { get; set; }
+
+        public bool OutputIsNeeded { get; set; }
+
+        public bool AllRequirementsFulfilled { get; set; }
+
         public void Reconnect()
         {
             throw new NotImplementedException();

--- a/Assets/Editor/UnitTests/Models/Power/PowerNetworkTest.cs
+++ b/Assets/Editor/UnitTests/Models/Power/PowerNetworkTest.cs
@@ -177,6 +177,8 @@ public class PowerNetworkTest
 
         public float OutputRate { get; set; }
 
+        public bool InputCanVary { get; set; }
+
         public void Reconnect()
         {
             throw new NotImplementedException();

--- a/Assets/Scripts/Models/Buildable/Components/BuildableComponent.cs
+++ b/Assets/Scripts/Models/Buildable/Components/BuildableComponent.cs
@@ -12,10 +12,10 @@ using System.Linq;
 using System.Reflection;
 using System.Xml;
 using System.Xml.Serialization;
+using MoonSharp.Interpreter;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Linq;
-using MoonSharp.Interpreter;
 
 namespace ProjectPorcupine.Buildable.Components
 {
@@ -334,17 +334,9 @@ namespace ProjectPorcupine.Buildable.Components
             [XmlAttribute("valuebasedParamerName")]
             public string ValueBasedParamerName { get; set; }
 
-            public ParameterConditions Requires { get; set; }
+            public Conditions RunConditions { get; set; }
         }
-
-        [Serializable]
-        [JsonObject(MemberSerialization.OptOut)]
-        public class ParameterConditions
-        {
-            [XmlElement("Param")]
-            public List<ParameterCondition> ParamConditions { get; set; }
-        }
-
+        
         [Serializable]
         [JsonObject(MemberSerialization.OptOut)]
         public class ParameterCondition
@@ -404,9 +396,14 @@ namespace ProjectPorcupine.Buildable.Components
             [XmlAttribute("capacityThresholds")]
             public int CapacityThresholds { get; set; }
 
-            [XmlAttribute("canFluctuate")]
-            public bool CanFluctuate { get; set; }
+            [XmlAttribute("canUseVariableEffiency")]
+            public bool CanUseVariableEfficiency { get; set; }            
+        }
 
+        [Serializable]
+        [JsonObject(MemberSerialization.OptOut)]
+        public class Conditions
+        {
             [XmlElement("Param")]
             public List<ParameterCondition> ParamConditions { get; set; }
         }

--- a/Assets/Scripts/Models/Buildable/Components/BuildableComponent.cs
+++ b/Assets/Scripts/Models/Buildable/Components/BuildableComponent.cs
@@ -54,6 +54,7 @@ namespace ProjectPorcupine.Buildable.Components
         public enum ConditionType
         {
             IsGreaterThanZero,
+            IsLessThanOne,
             IsZero,
             IsTrue,
             IsFalse
@@ -236,6 +237,9 @@ namespace ProjectPorcupine.Buildable.Components
                         case ConditionType.IsGreaterThanZero:
                             partialEval = FurnitureParams[condition.ParameterName].ToFloat() > 0f;
                             break;
+                        case ConditionType.IsLessThanOne:
+                            partialEval = FurnitureParams[condition.ParameterName].ToFloat() < 1f;
+                            break;
                         case ConditionType.IsTrue:
                             partialEval = FurnitureParams[condition.ParameterName].ToBool() == true;
                             break;
@@ -385,6 +389,26 @@ namespace ProjectPorcupine.Buildable.Components
 
             [XmlAttribute("fromFunction")]
             public string FromFunction { get; set; }
+        }
+
+        [Serializable]
+        [JsonObject(MemberSerialization.OptOut)]
+        public class Info
+        {
+            [XmlAttribute("rate")]
+            public float Rate { get; set; }
+
+            [XmlAttribute("capacity")]
+            public float Capacity { get; set; }
+
+            [XmlAttribute("capacityThresholds")]
+            public int CapacityThresholds { get; set; }
+
+            [XmlAttribute("canFluctuate")]
+            public bool CanFluctuate { get; set; }
+
+            [XmlElement("Param")]
+            public List<ParameterCondition> ParamConditions { get; set; }
         }
     }
 }

--- a/Assets/Scripts/Models/Buildable/Components/BuildableComponent.cs
+++ b/Assets/Scripts/Models/Buildable/Components/BuildableComponent.cs
@@ -15,6 +15,7 @@ using System.Xml.Serialization;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Linq;
+using MoonSharp.Interpreter;
 
 namespace ProjectPorcupine.Buildable.Components
 {
@@ -250,6 +251,52 @@ namespace ProjectPorcupine.Buildable.Components
             return conditionsFulFilled;
         }
 
+        protected string RetrieveStringFor(SourceDataInfo sourceDataInfo, Furniture furniture)
+        {
+            string retString = null;
+            if (sourceDataInfo != null)
+            {
+                if (!string.IsNullOrEmpty(sourceDataInfo.Value))
+                {
+                    retString = sourceDataInfo.Value;
+                }
+                else if (!string.IsNullOrEmpty(sourceDataInfo.FromFunction))
+                {
+                    DynValue ret = FunctionsManager.Furniture.Call(sourceDataInfo.FromFunction, furniture);
+                    retString = ret.String;
+                }
+                else if (!string.IsNullOrEmpty(sourceDataInfo.FromParameter))
+                {
+                    retString = furniture.Parameters[sourceDataInfo.FromParameter].ToString();
+                }
+            }
+
+            return retString;
+        }
+
+        protected float RetrieveFloatFor(SourceDataInfo sourceDataInfo, Furniture furniture)
+        {
+            float retFloat = 0f;
+            if (sourceDataInfo != null)
+            {
+                if (!string.IsNullOrEmpty(sourceDataInfo.Value))
+                {
+                    retFloat = float.Parse(sourceDataInfo.Value);
+                }
+                else if (!string.IsNullOrEmpty(sourceDataInfo.FromFunction))
+                {
+                    DynValue ret = FunctionsManager.Furniture.Call(sourceDataInfo.FromFunction, furniture);
+                    retFloat = (float)ret.Number;
+                }
+                else if (!string.IsNullOrEmpty(sourceDataInfo.FromParameter))
+                {
+                    retFloat = furniture.Parameters[sourceDataInfo.FromParameter].ToFloat();
+                }
+            }
+
+            return retFloat;
+        }
+
         private static Dictionary<string, System.Type> FindComponentsInAssembly()
         {
             componentTypes = new Dictionary<string, System.Type>();
@@ -324,6 +371,20 @@ namespace ProjectPorcupine.Buildable.Components
 
             [XmlAttribute("type")]
             public string Type { get; set; }
+        }
+
+        [Serializable]
+        [JsonObject(MemberSerialization.OptOut)]
+        public class SourceDataInfo
+        {
+            [XmlAttribute("value")]
+            public string Value { get; set; }
+
+            [XmlAttribute("fromParameter")]
+            public string FromParameter { get; set; }
+
+            [XmlAttribute("fromFunction")]
+            public string FromFunction { get; set; }
         }
     }
 }

--- a/Assets/Scripts/Models/Buildable/Components/FluidConnection.cs
+++ b/Assets/Scripts/Models/Buildable/Components/FluidConnection.cs
@@ -155,6 +155,11 @@ namespace ProjectPorcupine.Buildable.Components
             get { return IsStorage ? Provides.Capacity : 0f; }
         }
 
+        public bool InputCanVary
+        {
+            get { return false; }
+        }
+
         public override bool RequiresSlowUpdate
         {
             get

--- a/Assets/Scripts/Models/Buildable/Components/FluidConnection.cs
+++ b/Assets/Scripts/Models/Buildable/Components/FluidConnection.cs
@@ -168,6 +168,26 @@ namespace ProjectPorcupine.Buildable.Components
             }
         }
 
+        public bool OutputCanVary
+        {
+            get
+            {
+                // TODO: implement for fluids
+                return false;
+            }
+        }
+
+        public bool OutputIsNeeded { get; set; }
+       
+        public bool AllRequirementsFulfilled
+        {
+            get
+            {
+                // TODO: implement for fluids
+                return true;
+            }
+        }
+
         public override BuildableComponent Clone()
         {
             return new FluidConnection(this);
@@ -273,24 +293,7 @@ namespace ProjectPorcupine.Buildable.Components
             // TODO: Make this not a Universal Connection
             World.Current.FluidNetwork.PlugIn(this);
         }
-
-        [Serializable]
-        [JsonObject(MemberSerialization.OptOut)]
-        public class Info
-        {
-            [XmlAttribute("rate")]
-            public float Rate { get; set; }
-
-            [XmlAttribute("capacity")]
-            public float Capacity { get; set; }
-
-            [XmlAttribute("capacityThresholds")]
-            public int CapacityThresholds { get; set; }
-
-            [XmlElement("Param")]
-            public List<ParameterCondition> ParamConditions { get; set; }            
-        }
-
+        
         [Serializable]
         [JsonObject(MemberSerialization.OptOut)]
         public class FluidConnectionParameterDefinitions

--- a/Assets/Scripts/Models/Buildable/Components/FluidConnection.cs
+++ b/Assets/Scripts/Models/Buildable/Components/FluidConnection.cs
@@ -33,6 +33,7 @@ namespace ProjectPorcupine.Buildable.Components
             ParamsDefinitions = other.ParamsDefinitions;
             Provides = other.Provides;
             Requires = other.Requires;
+            RunConditions = other.RunConditions;
             SubType = other.SubType;
 
             Reconnecting += OnReconnecting;
@@ -81,6 +82,10 @@ namespace ProjectPorcupine.Buildable.Components
         [XmlElement("Requires")]
         [JsonProperty("Requires")]
         public Info Requires { get; set; }
+
+        [XmlElement("RunConditions")]
+        [JsonProperty("RunConditions")]
+        public Conditions RunConditions { get; set; }
 
         [XmlIgnore]
         public float StoredAmount
@@ -207,9 +212,9 @@ namespace ProjectPorcupine.Buildable.Components
         public override void FixedFrequencyUpdate(float deltaTime)
         {
             bool areAllParamReqsFulfilled = true;
-            if (Requires != null)
+            if (RunConditions != null)
             {
-                areAllParamReqsFulfilled = AreParameterConditionsFulfilled(Requires.ParamConditions);
+                areAllParamReqsFulfilled = AreParameterConditionsFulfilled(RunConditions.ParamConditions);
             }
 
             if (IsStorage)

--- a/Assets/Scripts/Models/Buildable/Components/GasConnection.cs
+++ b/Assets/Scripts/Models/Buildable/Components/GasConnection.cs
@@ -38,6 +38,10 @@ namespace ProjectPorcupine.Buildable.Components
         [JsonProperty("Requires")]
         public List<GasInfo> Requires { get; set; }
 
+        [XmlElement("Efficiency")]
+        [JsonProperty("Efficiency")]
+        public SourceDataInfo Efficiency { get; set; }
+
         public override bool RequiresSlowUpdate
         {
             get
@@ -75,6 +79,12 @@ namespace ProjectPorcupine.Buildable.Components
 
         public override void FixedFrequencyUpdate(float deltaTime)
         {
+            float efficiency = 1f;
+            if (Efficiency != null)
+            {
+                efficiency = RetrieveFloatFor(Efficiency, ParentFurniture);
+            }
+
             if (Provides != null && Provides.Count > 0)
             {
                 Room room = ParentFurniture.Tile.Room;
@@ -85,7 +95,7 @@ namespace ProjectPorcupine.Buildable.Components
                     if ((provGas.Rate > 0 && curGasPressure < provGas.MaxLimit) ||
                         (provGas.Rate < 0 && curGasPressure > provGas.MinLimit))
                     {
-                        room.ChangeGas(provGas.Gas, provGas.Rate * deltaTime, provGas.MaxLimit);
+                        room.ChangeGas(provGas.Gas, provGas.Rate * deltaTime * efficiency, provGas.MaxLimit);
                     }
                 }
             }

--- a/Assets/Scripts/Models/Buildable/Components/PowerConnection.cs
+++ b/Assets/Scripts/Models/Buildable/Components/PowerConnection.cs
@@ -87,6 +87,20 @@ namespace ProjectPorcupine.Buildable.Components
             }
         }
 
+        [XmlIgnore]
+        public bool OutputIsNeeded
+        {
+            get
+            {
+                return FurnitureParams[ParamsDefinitions.OutputNeeded.ParameterName].ToBool();
+            }
+
+            set
+            {
+                FurnitureParams[ParamsDefinitions.OutputNeeded.ParameterName].SetValue(value);
+            }
+        }
+
         [XmlElement("Provides")]
         [JsonProperty("Provides")]
         public Info Provides { get; set; }
@@ -193,6 +207,28 @@ namespace ProjectPorcupine.Buildable.Components
             }
         }
 
+        public bool OutputCanVary
+        {
+            get { return Provides != null && Provides.CanFluctuate == true; }
+        }
+
+        public bool AllRequirementsFulfilled
+        {
+            get
+            {                
+                if (Requires != null)
+                {
+                    return AreParameterConditionsFulfilled(Requires.ParamConditions);
+                }
+                else
+                {
+                    return true;
+                }
+            }
+        }
+
+        //public bool OutputIsNeeded { get; set; }
+
         public override BuildableComponent Clone()
         {
             return new PowerConnection(this);
@@ -231,7 +267,9 @@ namespace ProjectPorcupine.Buildable.Components
             {
                 areAllParamReqsFulfilled &= StoredAmount > 0;
             }
-            
+
+            IsRunning = areAllParamReqsFulfilled;
+
             // store the actual efficiency for other components to use
             if (IsConsumer && Requires.CanFluctuate)
             {
@@ -324,26 +362,6 @@ namespace ProjectPorcupine.Buildable.Components
 
         [Serializable]
         [JsonObject(MemberSerialization.OptOut)]
-        public class Info
-        {
-            [XmlAttribute("rate")]
-            public float Rate { get; set; }
-
-            [XmlAttribute("capacity")]
-            public float Capacity { get; set; }
-
-            [XmlAttribute("capacityThresholds")]
-            public int CapacityThresholds { get; set; }
-
-            [XmlAttribute("canFluctuate")]
-            public bool CanFluctuate { get; set; }
-
-            [XmlElement("Param")]
-            public List<ParameterCondition> ParamConditions { get; set; }            
-        }
-
-        [Serializable]
-        [JsonObject(MemberSerialization.OptOut)]
         public class PowerConnectionParameterDefinitions
         {
             // constants for parameters
@@ -351,6 +369,7 @@ namespace ProjectPorcupine.Buildable.Components
             public const string CurAccumulatorIndexParamName = "pow_accumulator_index";
             public const string CurIsRunningParamName = "pow_is_running";
             public const string CurEfficiencyParamName = "pow_efficiency";
+            public const string CurPowerOutputNeededParamName = "pow_out_needed";
 
             public PowerConnectionParameterDefinitions()
             {
@@ -359,6 +378,7 @@ namespace ProjectPorcupine.Buildable.Components
                 CurrentAcumulatorChargeIndex = new ParameterDefinition(CurAccumulatorIndexParamName);
                 IsRunning = new ParameterDefinition(CurIsRunningParamName);
                 Efficiency = new ParameterDefinition(CurEfficiencyParamName);
+                OutputNeeded = new ParameterDefinition(CurPowerOutputNeededParamName);
             }
 
             public ParameterDefinition CurrentAcumulatorCharge { get; set; }
@@ -368,6 +388,8 @@ namespace ProjectPorcupine.Buildable.Components
             public ParameterDefinition IsRunning { get; set; }
 
             public ParameterDefinition Efficiency { get; set; }
+
+            public ParameterDefinition OutputNeeded { get; set; }
         }
     }
 }

--- a/Assets/Scripts/Models/Buildable/Components/PowerConnection.cs
+++ b/Assets/Scripts/Models/Buildable/Components/PowerConnection.cs
@@ -180,6 +180,11 @@ namespace ProjectPorcupine.Buildable.Components
             get { return IsStorage ? Provides.Capacity : 0f; }
         }
 
+        public bool InputCanVary
+        {
+            get { return Requires != null && Requires.CanFluctuate == true; }
+        }
+
         public override bool RequiresSlowUpdate
         {
             get
@@ -196,9 +201,10 @@ namespace ProjectPorcupine.Buildable.Components
         public override bool CanFunction()
         {
             bool hasPower = true;
+
             if (IsConsumer)
             {
-                if (Requires.CanFluctuate)
+                if (InputCanVary)
                 {
                     hasPower = World.Current.PowerNetwork.GetEfficiency(this) > 0f;
                 }
@@ -207,6 +213,8 @@ namespace ProjectPorcupine.Buildable.Components
                     hasPower = World.Current.PowerNetwork.HasPower(this);
                 }
             }
+
+            IsRunning = hasPower;
 
             return hasPower;
         }
@@ -223,14 +231,12 @@ namespace ProjectPorcupine.Buildable.Components
             {
                 areAllParamReqsFulfilled &= StoredAmount > 0;
             }
-
-            IsRunning = areAllParamReqsFulfilled;
-
+            
             // store the actual efficiency for other components to use
             if (IsConsumer && Requires.CanFluctuate)
             {
-                Efficiency = World.Current.PowerNetwork.GetEfficiency(this);
-            }
+                Efficiency = World.Current.PowerNetwork.GetEfficiency(this);                
+            }            
         }
         
         public override IEnumerable<string> GetDescription()
@@ -243,7 +249,7 @@ namespace ProjectPorcupine.Buildable.Components
             {
                 yield return LocalizationTable.GetLocalization("power_input_status", powerColor, Requires.Rate);
 
-                if (Requires.CanFluctuate)
+                if (Requires.CanFluctuate && IsRunning)
                 {
                     yield return string.Format("Electricity: {0:0}%", Efficiency * 100); // TODO: localization
                 }

--- a/Assets/Scripts/Models/Buildable/Components/Visuals.cs
+++ b/Assets/Scripts/Models/Buildable/Components/Visuals.cs
@@ -34,15 +34,15 @@ namespace ProjectPorcupine.Buildable.Components
 
         [XmlElement("DefaultSpriteName")]
         [JsonProperty("DefaultSpriteName")]
-        public SpriteNameInfo DefaultSpriteName { get; set; }
+        public SourceDataInfo DefaultSpriteName { get; set; }
 
         [XmlElement("SpriteName")]
         [JsonProperty("SpriteName")]
-        public SpriteNameInfo SpriteName { get; set; }
+        public SourceDataInfo SpriteName { get; set; }
 
         [XmlElement("OverlaySpriteName")]
         [JsonProperty("OverlaySpriteName")]
-        public SpriteNameInfo OverlaySpriteName { get; set; }
+        public SourceDataInfo OverlaySpriteName { get; set; }
 
         [XmlElement("UseAnimation")]
         [JsonProperty("UseAnimation")]
@@ -97,7 +97,7 @@ namespace ProjectPorcupine.Buildable.Components
         public override void InitializePrototype(Furniture protoFurniture)
         {
             // default sprite (used for showing sprite in menu)
-            protoFurniture.DefaultSpriteName = RetrieveSpriteNameFor(DefaultSpriteName, protoFurniture);
+            protoFurniture.DefaultSpriteName = RetrieveStringFor(DefaultSpriteName, protoFurniture);
         }
 
         protected override void Initialize()
@@ -115,33 +115,10 @@ namespace ProjectPorcupine.Buildable.Components
         private void FurnitureChanged(Furniture obj)
         {
             // regular sprite
-            ParentFurniture.SpriteName = RetrieveSpriteNameFor(SpriteName, ParentFurniture);
+            ParentFurniture.SpriteName = RetrieveStringFor(SpriteName, ParentFurniture);
 
             // overlay sprite, if any
-            ParentFurniture.OverlaySpriteName = RetrieveSpriteNameFor(OverlaySpriteName, ParentFurniture);
-        }
-
-        private string RetrieveSpriteNameFor(SpriteNameInfo spriteNameInfo, Furniture furniture)
-        {
-            string useSpriteName = null;
-            if (spriteNameInfo != null)
-            {
-                if (!string.IsNullOrEmpty(spriteNameInfo.UseName))
-                {
-                    useSpriteName = spriteNameInfo.UseName;
-                }
-                else if (!string.IsNullOrEmpty(spriteNameInfo.FromFunction))
-                {
-                    DynValue ret = FunctionsManager.Furniture.Call(spriteNameInfo.FromFunction, furniture);
-                    useSpriteName = ret.String;
-                }
-                else if (!string.IsNullOrEmpty(spriteNameInfo.FromParameter))
-                {
-                    useSpriteName = furniture.Parameters[spriteNameInfo.FromParameter].ToString();
-                }                
-            }
-
-            return useSpriteName;
+            ParentFurniture.OverlaySpriteName = RetrieveStringFor(OverlaySpriteName, ParentFurniture);
         }
 
         private void ChangeAnimation(string newAnimation)
@@ -159,20 +136,6 @@ namespace ProjectPorcupine.Buildable.Components
             {
                 ChangeAnimation(DefaultAnimationName);
             }
-        }       
-
-        [Serializable]
-        [JsonObject(MemberSerialization.OptOut)]
-        public class SpriteNameInfo
-        {
-            [XmlAttribute("useName")]
-            public string UseName { get; set; }
-
-            [XmlAttribute("fromParameter")]
-            public string FromParameter { get; set; }
-
-            [XmlAttribute("fromFunction")]
-            public string FromFunction { get; set; }
-        }
+        }   
     }
 }

--- a/Assets/Scripts/Models/Buildable/Components/Visuals.cs
+++ b/Assets/Scripts/Models/Buildable/Components/Visuals.cs
@@ -82,9 +82,9 @@ namespace ProjectPorcupine.Buildable.Components
                             ParentFurniture.Animation.SetFrameIndex(frmIdx);
                         }
                     }
-                    else if (anim.Requires.ParamConditions != null)
+                    else if (anim.RunConditions.ParamConditions != null)
                     {
-                        if (AreParameterConditionsFulfilled(anim.Requires.ParamConditions))
+                        if (AreParameterConditionsFulfilled(anim.RunConditions.ParamConditions))
                         {
                             ChangeAnimation(anim.Name);
                             break;

--- a/Assets/Scripts/Models/Buildable/Components/Workshop.cs
+++ b/Assets/Scripts/Models/Buildable/Components/Workshop.cs
@@ -30,6 +30,8 @@ namespace ProjectPorcupine.Buildable.Components
         {
             ParamsDefinitions = other.ParamsDefinitions;
             PossibleProductions = other.PossibleProductions;
+            RunConditions = other.RunConditions;
+            HaulConditions = other.HaulConditions;
         }
 
         [XmlElement("ParameterDefinitions")]
@@ -52,14 +54,31 @@ namespace ProjectPorcupine.Buildable.Components
             }
         }
         
-        public Parameter IsProcessing
+        /// <summary>
+        /// Means that there is input being processed (input was consumed and is inside machine).
+        /// </summary>
+        public Parameter InputProcessed
         {
             get
             {
-                return FurnitureParams[ParamsDefinitions.IsProcessing.ParameterName];
+                return FurnitureParams[ParamsDefinitions.InputProcessed.ParameterName];
             }
         }
         
+        [XmlIgnore]
+        public Parameter IsRunning
+        {
+            get
+            {
+                return FurnitureParams[ParamsDefinitions.IsRunning.ParameterName];
+            }
+
+            set 
+            {
+                FurnitureParams[ParamsDefinitions.IsRunning.ParameterName] = value;
+            }
+        }
+
         public Parameter CurrentProductionChainName
         { 
             get
@@ -68,13 +87,33 @@ namespace ProjectPorcupine.Buildable.Components
             }
         }
 
+        public Parameter InputHaulingJobsCount
+        {
+            get
+            {
+                return FurnitureParams[ParamsDefinitions.InputHaulingJobsCount.ParameterName];
+            }
+        }
+
+        public Parameter HasAllNeededInputInventory
+        {
+            get
+            {
+                return FurnitureParams[ParamsDefinitions.HasAllNeededInputInventory.ParameterName];
+            }
+        }
+
         [XmlElement("ProductionChain")]
         [JsonProperty("ProductionChain")]
         public List<ProductionChain> PossibleProductions { get; set; }
 
-        [XmlElement("Requires")]
-        [JsonProperty("Requires")]
-        public Info Requires { get; set; }
+        [XmlElement("RunConditions")]
+        [JsonProperty("RunConditions")]
+        public Conditions RunConditions { get; set; }
+
+        [XmlElement("HaulConditions")]
+        [JsonProperty("HaulConditions")]
+        public Conditions HaulConditions { get; set; }
 
         [XmlElement("Efficiency")]
         [JsonProperty("Efficiency")]
@@ -103,6 +142,29 @@ namespace ProjectPorcupine.Buildable.Components
                 StringBuilder sb = new StringBuilder();
                 string prodChain = CurrentProductionChainName.ToString();
                 sb.AppendLine(!string.IsNullOrEmpty(prodChain) ? string.Format("Production: {0}", prodChain) : "No selected production");
+                float curProcessingTime = CurrentProcessingTime.ToFloat();
+                if (!ParentFurniture.HasCustomProgressReport && curProcessingTime > 0f)
+                {
+                    float perc = 0f;
+                    float maxProcessingTime = MaxProcessingTime.ToFloat();
+                    if (maxProcessingTime != 0f)
+                    {
+                        perc = curProcessingTime * 100f / maxProcessingTime;
+                        if (perc > 100f)
+                        {
+                            perc = 100f;
+                        }
+                    }
+
+                    sb.AppendLine(string.Format("Progress: {0:0}%", perc));
+                }
+
+                int numHaulingJobs = InputHaulingJobsCount.ToInt();
+                if (numHaulingJobs > 0)
+                {
+                    sb.AppendLine(string.Format("Hauling jobs: {0}", numHaulingJobs));
+                }
+
                 yield return sb.ToString();
             }
             else
@@ -115,20 +177,24 @@ namespace ProjectPorcupine.Buildable.Components
         {
             bool canWork = false;
             string curSetupChainName = CurrentProductionChainName.ToString();
-
+            
             if (!string.IsNullOrEmpty(curSetupChainName))
             {
+                canWork = true;
                 ProductionChain prodChain = GetProductionChainByName(curSetupChainName);
                 //// create possible jobs for factory(hauling input)
-                HaulingJobForInputs(prodChain);
-
-                bool areAllParamReqsFulfilled = true;
-                if (Requires != null)
+                bool areAllHaulParamReqsFulfilled = true;
+                if (HaulConditions != null)
                 {
-                    areAllParamReqsFulfilled = AreParameterConditionsFulfilled(Requires.ParamConditions);
+                    areAllHaulParamReqsFulfilled = AreParameterConditionsFulfilled(RunConditions.ParamConditions);
                 }
 
-                canWork &= areAllParamReqsFulfilled;
+                if (areAllHaulParamReqsFulfilled)
+                {
+                    HaulingJobForInputs(prodChain);
+                    canWork = true;
+                }
+                
                 componentRequirements = Requirements.None;
             }
             else
@@ -152,6 +218,12 @@ namespace ProjectPorcupine.Buildable.Components
                 return;
             }
 
+            if (RunConditions != null && AreParameterConditionsFulfilled(RunConditions.ParamConditions) == false)
+            {
+                IsRunning.SetValue(false);
+                return;
+            }
+
             float efficiency = 1f;
             if (Efficiency != null)
             {
@@ -165,7 +237,7 @@ namespace ProjectPorcupine.Buildable.Components
                 ProductionChain prodChain = GetProductionChainByName(curSetupChainName);
 
                 // if there is no processing in progress
-                if (IsProcessing.ToInt() == 0)
+                if (InputProcessed.ToInt() == 0)
                 {
                     // check input slots for input inventory               
                     List<KeyValuePair<Tile, int>> flaggedForTaking = CheckForInventoryAtInput(prodChain);
@@ -176,17 +248,24 @@ namespace ProjectPorcupine.Buildable.Components
                         // consume input inventory
                         ConsumeInventories(flaggedForTaking);
 
-                        IsProcessing.SetValue(1); // check if it can be bool
+                        InputProcessed.SetValue(1); // check if it can be bool
+                        IsRunning.SetValue(true);
 
                         // reset processing timer and set max time for processing for this prod. chain
                         CurrentProcessingTime.SetValue(0f);
                         MaxProcessingTime.SetValue(prodChain.ProcessingTime);
-                    }                  
+                        HasAllNeededInputInventory.SetValue(true);
+                    }
+                    else
+                    {
+                        HasAllNeededInputInventory.SetValue(false);
+                    } 
                 }
                 else
                 {
                     // processing is in progress
                     CurrentProcessingTime.ChangeFloatValue(deltaTime * efficiency);
+                    IsRunning.SetValue(true);
 
                     if (CurrentProcessingTime.ToFloat() >=
                         MaxProcessingTime.ToFloat())
@@ -198,7 +277,9 @@ namespace ProjectPorcupine.Buildable.Components
                         {
                             PlaceInventories(outPlacement);
                             //// processing done, can fetch input for another processing
-                            IsProcessing.SetValue(0);
+                            InputProcessed.SetValue(0);
+                            IsRunning.SetValue(false);
+                            CurrentProcessingTime.SetValue(0f);
                         }
                     }                    
                 }
@@ -258,7 +339,7 @@ namespace ProjectPorcupine.Buildable.Components
             // add dynamic params here
             CurrentProcessingTime.SetValue(0);
             MaxProcessingTime.SetValue(0);
-            IsProcessing.SetValue(0);
+            InputProcessed.SetValue(0);
             
             ParentFurniture.Removed += WorkshopRemoved;
         }
@@ -330,7 +411,7 @@ namespace ProjectPorcupine.Buildable.Components
         private void ChangeCurrentProductionChain(Furniture furniture, string newProductionChainName)
         {
             string oldProductionChainName = furniture.Parameters[ParamsDefinitions.CurrentProductionChainName.ParameterName].Value;
-            bool isProcessing = furniture.Parameters[ParamsDefinitions.IsProcessing.ParameterName].ToInt() > 0;
+            bool isProcessing = furniture.Parameters[ParamsDefinitions.InputProcessed.ParameterName].ToInt() > 0;
 
             // if selected production really changes and nothing is being processed now
             if (isProcessing || newProductionChainName.Equals(oldProductionChainName))
@@ -347,19 +428,26 @@ namespace ProjectPorcupine.Buildable.Components
 
         private void HaulingJobForInputs(ProductionChain prodChain)
         {
-            bool isProcessing = IsProcessing.ToInt() > 0;
+            int numHaulingJobs = 0;
+            bool isProcessing = InputProcessed.ToInt() > 0;
             //// for all inputs in production chain
             foreach (Item reqInputItem in prodChain.Input)
-            {
+            {                
                 if (isProcessing && !reqInputItem.HasHopper)
                 {
                     continue;
                 }
-                //// if there is no hauling job for input object type, create one
+
+                //// if there is no hauling job for input object type, create one                
                 Job furnJob;
                 string requiredType = reqInputItem.ObjectType;
                 bool existingHaulingJob = ParentFurniture.Jobs.HasJobWithPredicate(x => x.RequestedItems.ContainsKey(requiredType), out furnJob);
-                if (!existingHaulingJob)
+
+                if (existingHaulingJob)
+                {
+                    numHaulingJobs++;
+                }
+                else
                 {
                     Tile inTile = World.Current.GetTileAt(
                                       ParentFurniture.Tile.X + reqInputItem.SlotPosX,
@@ -397,9 +485,12 @@ namespace ProjectPorcupine.Buildable.Components
                         job.Description = string.Format("Hauling '{0}' to '{1}'", desiredInv, ParentFurniture.GetName());
                         job.OnJobWorked += PlaceInventoryToWorkshopInput;
                         ParentFurniture.Jobs.Add(job);
+                        numHaulingJobs++;
                     }
                 }
             }
+
+            InputHaulingJobsCount.SetValue(numHaulingJobs);
         }
 
         private List<TileObjectTypeAmount> CheckForInventoryAtOutput(ProductionChain prodChain)
@@ -502,24 +593,36 @@ namespace ProjectPorcupine.Buildable.Components
             public const string CurProcessingTimeParamName = "cur_processing_time";
             public const string MaxProcessingTimeParamName = "max_processing_time";
             public const string CurProcessedInvParamName = "cur_processed_inv";
+            public const string CurIsRunningParamName = "workshop_is_running";
             public const string CurProductionChainParamName = "cur_production_chain";
+            public const string InputHaulingJobsCountParamName = "input_hauling_job_count";
+            public const string HasAllNeededInputInventoryParamName = "has_all_needed_input_inv";
             
             public WorkShopParameterDefinitions()
             {
                 // default values if not defined from outside
                 CurrentProcessingTime = new ParameterDefinition(CurProcessingTimeParamName);
                 MaxProcessingTime = new ParameterDefinition(MaxProcessingTimeParamName);
-                IsProcessing = new ParameterDefinition(CurProcessedInvParamName);
+                InputProcessed = new ParameterDefinition(CurProcessedInvParamName);
+                IsRunning = new ParameterDefinition(CurIsRunningParamName);
                 CurrentProductionChainName = new ParameterDefinition(CurProductionChainParamName);
+                InputHaulingJobsCount = new ParameterDefinition(InputHaulingJobsCountParamName);
+                HasAllNeededInputInventory = new ParameterDefinition(HasAllNeededInputInventoryParamName);
             }
 
             public ParameterDefinition CurrentProcessingTime { get; set; }
 
             public ParameterDefinition MaxProcessingTime { get; set; }
 
-            public ParameterDefinition IsProcessing { get; set; }
+            public ParameterDefinition InputProcessed { get; set; }
+
+            public ParameterDefinition IsRunning { get; set; }
 
             public ParameterDefinition CurrentProductionChainName { get; set; }
+
+            public ParameterDefinition InputHaulingJobsCount { get; set; }
+
+            public ParameterDefinition HasAllNeededInputInventory { get; set; }
         }
         
         private class TileObjectTypeAmount

--- a/Assets/Scripts/Models/Buildable/Components/Workshop.cs
+++ b/Assets/Scripts/Models/Buildable/Components/Workshop.cs
@@ -72,6 +72,10 @@ namespace ProjectPorcupine.Buildable.Components
         [JsonProperty("ProductionChain")]
         public List<ProductionChain> PossibleProductions { get; set; }
 
+        [XmlElement("Requires")]
+        [JsonProperty("Requires")]
+        public Info Requires { get; set; }
+
         [XmlElement("Efficiency")]
         [JsonProperty("Efficiency")]
         public SourceDataInfo Efficiency { get; set; }
@@ -117,7 +121,15 @@ namespace ProjectPorcupine.Buildable.Components
                 ProductionChain prodChain = GetProductionChainByName(curSetupChainName);
                 //// create possible jobs for factory(hauling input)
                 HaulingJobForInputs(prodChain);
-                canWork = true;
+
+                bool areAllParamReqsFulfilled = true;
+                if (Requires != null)
+                {
+                    areAllParamReqsFulfilled = AreParameterConditionsFulfilled(Requires.ParamConditions);
+                }
+
+                canWork &= areAllParamReqsFulfilled;
+                componentRequirements = Requirements.None;
             }
             else
             {

--- a/Assets/Scripts/Models/Buildable/Components/Workshop.cs
+++ b/Assets/Scripts/Models/Buildable/Components/Workshop.cs
@@ -32,6 +32,7 @@ namespace ProjectPorcupine.Buildable.Components
             PossibleProductions = other.PossibleProductions;
             RunConditions = other.RunConditions;
             HaulConditions = other.HaulConditions;
+            Efficiency = other.Efficiency;
         }
 
         [XmlElement("ParameterDefinitions")]

--- a/Assets/Scripts/Models/Buildable/Components/Workshop.cs
+++ b/Assets/Scripts/Models/Buildable/Components/Workshop.cs
@@ -72,6 +72,10 @@ namespace ProjectPorcupine.Buildable.Components
         [JsonProperty("ProductionChain")]
         public List<ProductionChain> PossibleProductions { get; set; }
 
+        [XmlElement("Efficiency")]
+        [JsonProperty("Efficiency")]
+        public SourceDataInfo Efficiency { get; set; }
+
         public override bool RequiresSlowUpdate
         {
             get
@@ -136,6 +140,12 @@ namespace ProjectPorcupine.Buildable.Components
                 return;
             }
 
+            float efficiency = 1f;
+            if (Efficiency != null)
+            {
+                efficiency = RetrieveFloatFor(Efficiency, ParentFurniture);
+            }
+            
             string curSetupChainName = CurrentProductionChainName.ToString();
 
             if (!string.IsNullOrEmpty(curSetupChainName))
@@ -164,7 +174,7 @@ namespace ProjectPorcupine.Buildable.Components
                 else
                 {
                     // processing is in progress
-                    CurrentProcessingTime.ChangeFloatValue(deltaTime);
+                    CurrentProcessingTime.ChangeFloatValue(deltaTime * efficiency);
 
                     if (CurrentProcessingTime.ToFloat() >=
                         MaxProcessingTime.ToFloat())

--- a/Assets/Scripts/Models/Buildable/Furniture.cs
+++ b/Assets/Scripts/Models/Buildable/Furniture.cs
@@ -207,6 +207,17 @@ public class Furniture : ISelectable, IPrototypable, IContextActionProvider, IBu
     public bool VerticalDoor { get; set; }
 
     /// <summary>
+    /// Checks whether furniturehas some custom progress info.
+    /// </summary>
+    public bool HasCustomProgressReport
+    {
+        get
+        {
+            return !string.IsNullOrEmpty(getProgressInfoNameAction);
+        }
+    }
+
+    /// <summary>
     /// Gets the EventAction for the current furniture.
     /// These actions are called when an event is called. They get passed the furniture
     /// they belong to, plus a deltaTime (which defaults to 0).

--- a/Assets/Scripts/UtilityNetwork/Grid.cs
+++ b/Assets/Scripts/UtilityNetwork/Grid.cs
@@ -178,7 +178,7 @@ namespace ProjectPorcupine.PowerNetwork
                 {
                     if (connection.InputCanVary)
                     {
-                        consumersVarying += connection.InputRate * Efficiency;
+                        consumersVarying += connection.InputRate;
                     }
                     else
                     {
@@ -238,27 +238,29 @@ namespace ProjectPorcupine.PowerNetwork
 
             producers = producersStable + producersVarying;
 
-            if (producers > 0)
+            Efficiency = 1f;
+
+            // calculate immediate efficiency
+            if (currentLevel < 0 && consumersVarying > 0)
             {
-                // for efficiency, take into account only connections with varying input
-                if (producers < consumersVarying)
+                float curLevelWithoutVary = currentLevel + consumersVarying;
+
+                // if there is enough power when discarting varying consumers, calculate efficiency for them 
+                if (curLevelWithoutVary > 0)
                 {
-                    Efficiency -= 0.1f;
+                    float efficiency = curLevelWithoutVary / consumersVarying;
+
+                    Efficiency = Mathf.Clamp(efficiency, 0, 1f);
+                    currentLevel = 0f;
                 }
                 else
                 {
-                    Efficiency += 0.1f;
+                    Efficiency = 0f;
                 }
-
-                Efficiency = Mathf.Clamp(Efficiency, 0, 1f);
             }
-            else
-            {
-                Efficiency = 0f;
-            }            
-
+            
             // Efficiency == 1f condition prevents flickering of machines without varying input
-            IsOperating = producers > 0f && currentLevel >= 0.0f && Efficiency == 1f;
+            IsOperating = currentLevel >= 0.0f && Efficiency == 1f;
         }
 
         /// <summary>

--- a/Assets/Scripts/UtilityNetwork/IPluggable.cs
+++ b/Assets/Scripts/UtilityNetwork/IPluggable.cs
@@ -38,23 +38,24 @@ namespace ProjectPorcupine.PowerNetwork
         string SubType { get; set; }
 
         /// <summary>
-        /// Input can be less than 100% for machine to work - efficiency
+        /// Input can be less than 100% for machine to work - efficiency.
         /// </summary>
         bool InputCanVary { get; }
 
         /// <summary>
-        /// Output varies depending on other conditions (fuel present, ... )
+        /// Output varies depending on other conditions (fuel present, ... ).
+        /// Output on demand.
         /// </summary>
         bool OutputCanVary { get; }
 
         /// <summary>
-        /// To inform component that its output is needed
+        /// To inform component that its output is needed.
         /// </summary>
         bool OutputIsNeeded { get; set; }
 
         /// <summary>
-        /// Flag to inform Pluggable system if can work - all conditions met (fuel present, ... )
-        /// Used in combination with OutputCanVary (InputCanVary) and OutputIsNeeded
+        /// Flag to inform Pluggable system if can work - all conditions met (fuel present, ... ).
+        /// Used in combination with OutputCanVary (InputCanVary) and OutputIsNeeded.
         /// </summary>
         bool AllRequirementsFulfilled { get; }
         

--- a/Assets/Scripts/UtilityNetwork/IPluggable.cs
+++ b/Assets/Scripts/UtilityNetwork/IPluggable.cs
@@ -37,6 +37,8 @@ namespace ProjectPorcupine.PowerNetwork
 
         string SubType { get; set; }
 
+        bool InputCanVary { get; }
+
         void Reconnect();
     }
 }

--- a/Assets/Scripts/UtilityNetwork/IPluggable.cs
+++ b/Assets/Scripts/UtilityNetwork/IPluggable.cs
@@ -37,8 +37,27 @@ namespace ProjectPorcupine.PowerNetwork
 
         string SubType { get; set; }
 
+        /// <summary>
+        /// Input can be less than 100% for machine to work - efficiency
+        /// </summary>
         bool InputCanVary { get; }
 
+        /// <summary>
+        /// Output varies depending on other conditions (fuel present, ... )
+        /// </summary>
+        bool OutputCanVary { get; }
+
+        /// <summary>
+        /// To inform component that its output is needed
+        /// </summary>
+        bool OutputIsNeeded { get; set; }
+
+        /// <summary>
+        /// Flag to inform Pluggable system if can work - all conditions met (fuel present, ... )
+        /// Used in combination with OutputCanVary (InputCanVary) and OutputIsNeeded
+        /// </summary>
+        bool AllRequirementsFulfilled { get; }
+        
         void Reconnect();
     }
 }

--- a/Assets/Scripts/UtilityNetwork/PowerNetwork.cs
+++ b/Assets/Scripts/UtilityNetwork/PowerNetwork.cs
@@ -143,6 +143,13 @@ namespace ProjectPorcupine.PowerNetwork
             grid.Unplug(connection);
         }
 
+        public bool IsConnected(IPluggable connection)
+        {
+            Grid grid;
+            IsPluggedIn(connection, out grid);
+            return grid != null && grid.HasAnyProducer();
+        }
+
         public bool HasPower(IPluggable connection)
         {
             Grid grid;
@@ -155,7 +162,7 @@ namespace ProjectPorcupine.PowerNetwork
             float efficiency = 0f;
             Grid grid;
             IsPluggedIn(connection, out grid);
-            if(grid != null)
+            if (grid != null)
             {
                 efficiency = grid.Efficiency;
             }

--- a/Assets/Scripts/UtilityNetwork/PowerNetwork.cs
+++ b/Assets/Scripts/UtilityNetwork/PowerNetwork.cs
@@ -150,6 +150,19 @@ namespace ProjectPorcupine.PowerNetwork
             return grid != null && grid.IsOperating;
         }
 
+        public float GetEfficiency(IPluggable connection)
+        {
+            float efficiency = 0f;
+            Grid grid;
+            IsPluggedIn(connection, out grid);
+            if(grid != null)
+            {
+                efficiency = grid.Efficiency;
+            }
+
+            return efficiency;
+        }
+
         public void Update(float deltaTime)
         {
             secondsPassed += deltaTime;

--- a/Assets/StreamingAssets/Data/Furniture.xml
+++ b/Assets/StreamingAssets/Data/Furniture.xml
@@ -688,10 +688,6 @@
             <Inventory type="steel_plate" amount="1" />
         </OrderAction>
 
-        <Component type="Visuals">
-            <DefaultSpriteName value="Heater" />
-        </Component>
-
         <OrderAction type="Uninstall">
             <Job time="1" />
         </OrderAction>

--- a/Assets/StreamingAssets/Data/Furniture.xml
+++ b/Assets/StreamingAssets/Data/Furniture.xml
@@ -589,7 +589,9 @@
         <JobWorkSpotOffset X="1" Y="0" />
 
         <Component type="PowerConnection">
-            <Requires rate="2" canFluctuate="true"/>
+            <Requires rate="2" canFluctuate="true">
+                <Param name="cur_processed_inv" condition="IsGreaterThanZero" />
+            </Requires>
         </Component>
 
         <Component type="GasConnection">

--- a/Assets/StreamingAssets/Data/Furniture.xml
+++ b/Assets/StreamingAssets/Data/Furniture.xml
@@ -31,7 +31,7 @@
         </Params>
         
         <Component type="Visuals">
-            <DefaultSpriteName useName="steel_wall_" />
+            <DefaultSpriteName value="steel_wall_" />
         </Component>
 
         <LocalizationCode>furn_steel_wall</LocalizationCode>
@@ -64,7 +64,7 @@
         </OrderAction>
                 
         <Component type="Visuals">
-            <DefaultSpriteName useName="door_horizontal_0" />
+            <DefaultSpriteName value="door_horizontal_0" />
             <SpriteName fromFunction="Door_GetSpriteName" />
         </Component>
 
@@ -119,7 +119,7 @@
         <CanReplaceFurniture typeTag="Door" />
                 
         <Component type="Visuals">
-            <DefaultSpriteName useName="airlock_door_horizontal_0" />
+            <DefaultSpriteName value="airlock_door_horizontal_0" />
             <SpriteName fromFunction="Door_GetSpriteName" />
         </Component>
 
@@ -187,7 +187,7 @@
         <DragType>area</DragType>
         
         <Component type="Visuals">
-            <DefaultSpriteName useName="stockpile_" />
+            <DefaultSpriteName value="stockpile_" />
         </Component>
 
         <ContextMenuAction FunctionName="Stockpile_SetNewFilter" LocalizationKey="set_filter" RequireCharacterSelected="false"/>
@@ -243,11 +243,12 @@
         </Component>
 		
         <Component type="PowerConnection">
-            <Requires rate="1"/>
+            <Requires rate="1" canFluctuate="true"/>
             <ParameterDefinitions>
                 <CurrentAcumulatorCharge name="pow_accumulator_charge" />
                 <CurrentAcumulatorChargeIndex name="pow_accumulator_index" />
                 <IsRunning name="pow_is_running" />
+                <Efficiency name="pow_efficiency" />
             </ParameterDefinitions>
         </Component>
 		
@@ -267,6 +268,7 @@
                  without hacking the GasComponent to pieces. -->
             <Provides gas="O2" rate="0.032" minLimit="0" maxLimit="0.2" />
             <Provides gas="N2" rate="0.128" minLimit="0" maxLimit="0.8" />
+            <Efficiency fromParameter="pow_efficiency" />
         </Component>
       
         <LocalizationCode>furn_oxygen_generator</LocalizationCode>
@@ -349,7 +351,7 @@
         </OrderAction>
         
         <Component type="Visuals">
-            <DefaultSpriteName useName="fission_reactor_1" />
+            <DefaultSpriteName value="fission_reactor_1" />
             <UseAnimation name="idle">
                 <Requires>
                     <Param name="cur_processed_inv" condition="IsZero" />
@@ -436,7 +438,7 @@
         </Component>    
 
         <Component type="Visuals">
-            <DefaultSpriteName useName="water_generator_off" />
+            <DefaultSpriteName value="water_generator_off" />
             <UseAnimation name="idle">
                 <Requires>
                     <Param name="cur_processed_inv" condition="IsZero" />
@@ -495,7 +497,7 @@
         </Animations>
        
         <Component type="Visuals">
-            <DefaultSpriteName useName="water_tank_0" />
+            <DefaultSpriteName value="water_tank_0" />
             <UseAnimation name="filling" valuebasedParamerName="fluid_storage_index"/>
         </Component>
 		
@@ -587,7 +589,7 @@
         <JobWorkSpotOffset X="1" Y="0" />
 
         <Component type="PowerConnection">
-            <Requires rate="2" />
+            <Requires rate="2" canFluctuate="true"/>
         </Component>
 
         <Component type="GasConnection">
@@ -617,6 +619,7 @@
                     <Item objectType="steel_plate" amount="1" slotPosX="2" slotPosY="0"/>
                 </Output>
             </ProductionChain>
+            <Efficiency fromParameter="pow_efficiency" />
         </Component>
 
         <Component type="Visuals">
@@ -668,7 +671,7 @@
         </OrderAction>
 
         <Component type="Visuals">
-            <DefaultSpriteName useName="Heater" />
+            <DefaultSpriteName value="Heater" />
         </Component>
 
         <OrderAction type="Uninstall">
@@ -907,7 +910,7 @@
         </Component>
         
         <Component type="Visuals">
-            <DefaultSpriteName useName="air_pump" />
+            <DefaultSpriteName value="air_pump" />
             <SpriteName fromFunction="AirPump_GetSpriteName" />
         </Component>
 

--- a/Assets/StreamingAssets/Data/Furniture.xml
+++ b/Assets/StreamingAssets/Data/Furniture.xml
@@ -231,19 +231,19 @@
         
         <Component type="Visuals">
             <UseAnimation name="idle">
-                <Requires>
+                <RunConditions>
                     <Param name="pow_is_running" condition="IsFalse" />
-                </Requires>
+                </RunConditions>
             </UseAnimation>
             <UseAnimation name="running">
-                <Requires>
+                <RunConditions>
                     <Param name="pow_is_running" condition="IsTrue" />
-                </Requires>
+                </RunConditions>
             </UseAnimation>
         </Component>
 		
         <Component type="PowerConnection">
-            <Requires rate="1" canFluctuate="true"/>
+            <Requires rate="1" canUseVariableEffiency="true"/>
             <ParameterDefinitions>
                 <CurrentAcumulatorCharge name="pow_accumulator_charge" />
                 <CurrentAcumulatorChargeIndex name="pow_accumulator_index" />
@@ -353,14 +353,14 @@
         <Component type="Visuals">
             <DefaultSpriteName value="fission_reactor_1" />
             <UseAnimation name="idle">
-                <Requires>
-                    <Param name="cur_processed_inv" condition="IsZero" />
-                </Requires>
+                <RunConditions>
+                    <Param name="workshop_is_running" condition="IsFalse" />
+                </RunConditions>
             </UseAnimation>
             <UseAnimation name="running">
-                <Requires>
-                    <Param name="cur_processed_inv" condition="IsGreaterThanZero" />
-                </Requires>
+                <RunConditions>
+                    <Param name="workshop_is_running" condition="IsTrue" />
+                </RunConditions>
             </UseAnimation>
         </Component>
 
@@ -368,7 +368,8 @@
             <ParameterDefinitions>
                 <CurrentProcessingTime name="cur_processing_time" />
                 <MaxProcessingTime name="max_processing_time" />
-                <IsProcessing name="cur_processed_inv" />
+                <InputProcessed name="cur_processed_inv" />
+                <IsRunning name="workshop_is_running" />
                 <CurrentProductionChainName name="cur_production_chain" />
             </ParameterDefinitions>
             <ProductionChain name="Power generation" processingTime="60">
@@ -376,16 +377,20 @@
                     <Item objectType="power_cell" amount="1" slotPosX="0" slotPosY="0" hasHopper="false" />
                 </Input>
             </ProductionChain>
-            <Requires>
+            <RunConditions>
                 <Param name="pow_out_needed" condition="IsTrue" />
-            </Requires> 
+            </RunConditions>
+            <HaulConditions>
+                <Param name="pow_out_needed" condition="IsTrue" />
+            </HaulConditions>
         </Component>
         
         <Component type="PowerConnection">
-            <Provides rate="5"/>            
-            <Requires>
-                <Param name="cur_processed_inv" condition="IsGreaterThanZero" />
-            </Requires>    
+            <Provides rate="5" canUseVariableEffiency="true">    
+            </Provides>  
+            <RunConditions>
+                <Param name="workshop_is_running" condition="IsTrue" />
+            </RunConditions>    
             <ParameterDefinitions>
                 <CurrentAcumulatorCharge name="pow_accumulator_charge" />
                 <CurrentAcumulatorChargeIndex name="pow_accumulator_index" />
@@ -437,7 +442,7 @@
             <ParameterDefinitions>
                 <CurrentProcessingTime name="cur_processing_time" />
                 <MaxProcessingTime name="max_processing_time" />
-                <IsProcessing name="cur_processed_inv" />
+                <InputProcessed name="cur_processed_inv" />
                 <CurrentProductionChainName name="cur_production_chain" />
             </ParameterDefinitions>
             <ProductionChain name="Ice melting" processingTime="60">
@@ -450,23 +455,23 @@
         <Component type="Visuals">
             <DefaultSpriteName value="water_generator_off" />
             <UseAnimation name="idle">
-                <Requires>
+                <RunConditions>
                     <Param name="cur_processed_inv" condition="IsZero" />
-                </Requires>
+                </RunConditions>
             </UseAnimation>
             <UseAnimation name="running">
-                <Requires>
+                <RunConditions>
                     <Param name="cur_processed_inv" condition="IsGreaterThanZero" />
-                </Requires>
+                </RunConditions>
             </UseAnimation>
         </Component>
         
         <Component type="FluidConnection">
 			<FluidType>water</FluidType>
             <Provides rate="5"/>
-            <Requires>
+            <RunConditions>
                 <Param name="cur_processed_inv" condition="IsGreaterThanZero" />
-            </Requires>
+            </RunConditions>
         </Component>
 
         <GetProgressInfo functionName="WaterGenerator_StatusInfo" />
@@ -599,7 +604,10 @@
         <JobWorkSpotOffset X="1" Y="0" />
 
         <Component type="PowerConnection">
-            <Requires rate="2" canFluctuate="true" />
+            <Requires rate="2" canUseVariableEffiency="true"/>  
+            <RunConditions>
+                <Param name="cur_processed_inv" condition="IsGreaterThanZero" /> 
+            </RunConditions>
         </Component>
 
         <Component type="GasConnection">
@@ -610,7 +618,7 @@
             <ParameterDefinitions>
                 <CurrentProcessingTime name="cur_processing_time" />
                 <MaxProcessingTime name="max_processing_time" />
-                <IsProcessing name="cur_processed_inv" />
+                <InputProcessed name="cur_processed_inv" />
                 <CurrentProductionChainName name="cur_production_chain" />
             </ParameterDefinitions>
             <ProductionChain name="Copper smelting" processingTime="3">
@@ -634,14 +642,14 @@
 
         <Component type="Visuals">
             <UseAnimation name="idle">
-                <Requires>
+                <RunConditions>
                     <Param name="cur_processed_inv" condition="IsZero" />
-                </Requires>
+                </RunConditions>
             </UseAnimation>
             <UseAnimation name="running">
-                <Requires>
+                <RunConditions>
                     <Param name="cur_processed_inv" condition="IsGreaterThanZero" />
-                </Requires>
+                </RunConditions>
             </UseAnimation>
         </Component>
 
@@ -732,7 +740,7 @@
             <ParameterDefinitions>
                 <CurrentProcessingTime name="cur_processing_time" />
                 <MaxProcessingTime name="max_processing_time" />
-                <IsProcessing name="cur_processed_inv" />
+                <InputProcessed name="cur_processed_inv" />
                 <CurrentProductionChainName name="cur_production_chain" />
             </ParameterDefinitions>
             <ProductionChain name="Power Cell Pressing" processingTime="5">
@@ -748,7 +756,7 @@
         </Component>
 
         <Component type="PowerConnection">
-            <Requires rate="2" canFluctuate="true" />
+            <Requires rate="2" canUseVariableEffiency="true" />
         </Component>
         
         <GetProgressInfo functionName="PowerCellPress_StatusInfo" />

--- a/Assets/StreamingAssets/Data/Furniture.xml
+++ b/Assets/StreamingAssets/Data/Furniture.xml
@@ -376,13 +376,23 @@
                     <Item objectType="power_cell" amount="1" slotPosX="0" slotPosY="0" hasHopper="false" />
                 </Input>
             </ProductionChain>
+            <Requires>
+                <Param name="pow_out_needed" condition="IsTrue" />
+            </Requires> 
         </Component>
         
         <Component type="PowerConnection">
             <Provides rate="5"/>            
             <Requires>
                 <Param name="cur_processed_inv" condition="IsGreaterThanZero" />
-            </Requires>            
+            </Requires>    
+            <ParameterDefinitions>
+                <CurrentAcumulatorCharge name="pow_accumulator_charge" />
+                <CurrentAcumulatorChargeIndex name="pow_accumulator_index" />
+                <IsRunning name="pow_is_running" />
+                <Efficiency name="pow_efficiency" />
+                <OutputNeeded name="pow_out_needed" />
+            </ParameterDefinitions>
         </Component>        
 
         <GetProgressInfo functionName="PowerGenerator_FuelInfo" />
@@ -589,9 +599,7 @@
         <JobWorkSpotOffset X="1" Y="0" />
 
         <Component type="PowerConnection">
-            <Requires rate="2" canFluctuate="true">
-                <Param name="cur_processed_inv" condition="IsGreaterThanZero" />
-            </Requires>
+            <Requires rate="2" canFluctuate="true" />
         </Component>
 
         <Component type="GasConnection">
@@ -736,10 +744,11 @@
                     <Item objectType="power_cell" amount="1" slotPosX="2" slotPosY="1" />
                 </Output>
             </ProductionChain>
+            <Efficiency fromParameter="pow_efficiency" />
         </Component>
 
         <Component type="PowerConnection">
-            <Requires rate="1" />
+            <Requires rate="2" canFluctuate="true" />
         </Component>
         
         <GetProgressInfo functionName="PowerCellPress_StatusInfo" />

--- a/Assets/StreamingAssets/Images/Furniture/Heater.xml
+++ b/Assets/StreamingAssets/Images/Furniture/Heater.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Sprites>
+	<Sprite name="heater"     x="0" y="0" w="1" h="1" pixelPerUnit="64" />
+</Sprites>

--- a/Assets/StreamingAssets/Images/Furniture/Heater.xml.meta
+++ b/Assets/StreamingAssets/Images/Furniture/Heater.xml.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1289e9350951a6941b9e260d9ba45bae
+timeCreated: 1491147733
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/StreamingAssets/LUA/Furniture.lua
+++ b/Assets/StreamingAssets/LUA/Furniture.lua
@@ -409,9 +409,10 @@ end
 function PowerGenerator_FuelInfo(furniture)
     local curBurn = furniture.Parameters["cur_processing_time"].ToFloat()
 	local maxBurn = furniture.Parameters["max_processing_time"].ToFloat()
+	local invProc = furniture.Parameters["cur_processed_inv"].ToInt()
 
 	local perc = 0
-	if (maxBurn != 0) then
+	if (maxBurn != 0 and invProc > 0) then
 		perc = 100 - (curBurn * 100 / maxBurn)
 		if (perc <= 0) then
 			perc = 0


### PR DESCRIPTION
This allows to define furniture with fluctuating power input - meaning, if there is power shortage, instead of whole grid going down for these machines, machines will work at decreased efficiency (depending on available power)
E.g. here 2 smelters with power requirement of 2 (needed power = 4) being hooked on grid that provides 2 power. Efficiency varies from 50 to 60%. 
![image](https://cloud.githubusercontent.com/assets/12616499/22308848/008985fe-e349-11e6-8fe2-c4ef9f67ad31.png)

CanFluctuate flags are currently applied only on Oxygen Generator and Smelter.1

- [x] Fix showing efficiency/electricity description when offline (now showing 100%)
- [x] Do not consume power when not working
- [x] Do not consume inventory when not needed

Changes:
- Requires with params is now RunConditions in components
- Power grid info now shows whether it's connected to grid with at least one producer (as Online/Offline is kind of confusing now with machines that have means to run but are not required)
- IPluggable now has more flags to support 'on demand' producers (fission reactor)

Testcases:
Power on demand
- RTGs are providing power to oxygen generators and pumps
- spawn power cell
 => power cell goes into stockpile (there is enough power in grid)
- remove wires from RTGs that are next to fission reactor (disconnect power from RTGs to grid where reactor is in)
 => power goes offline in pumps and generator
 => power cell is hauled to fission reactor and reactor is producing power
- add power cables back to RTGs (so they are connected again)
 => fission reactor should be idle again, (power is provided from RTGs)
- remove cables from RTGs again
 => fission reactor continues to spend fuel and provide power
 
Grid efficiency
- create RTG, create another smelter
- connect both smelters to one RTG, assign iron smelting, spawn raw_iron
 => see power efficiency fluctuate when smelters are smelting