### PR TITLE
Disable currency UI in main menu

### DIFF
--- a/Assets/Scripts/Controllers/MainMenuController.cs
+++ b/Assets/Scripts/Controllers/MainMenuController.cs
@@ -1,4 +1,4 @@
-#region License
+﻿#region License
 // ====================================================
 // Project Porcupine Copyright(C) 2016 Team Porcupine
 // This program comes with ABSOLUTELY NO WARRANTY; This is free software, 

--- a/Assets/Scripts/Controllers/MainMenuController.cs
+++ b/Assets/Scripts/Controllers/MainMenuController.cs
@@ -1,4 +1,4 @@
-﻿#region License
+#region License
 // ====================================================
 // Project Porcupine Copyright(C) 2016 Team Porcupine
 // This program comes with ABSOLUTELY NO WARRANTY; This is free software, 

--- a/Assets/Scripts/UI/InGameUI/MenuTop/CurrencyDisplay.cs
+++ b/Assets/Scripts/UI/InGameUI/MenuTop/CurrencyDisplay.cs
@@ -1,4 +1,4 @@
-﻿#region License
+#region License
 // ====================================================
 // Project Porcupine Copyright(C) 2016 Team Porcupine
 // This program comes with ABSOLUTELY NO WARRANTY; This is free software, 
@@ -8,6 +8,7 @@
 #endregion
 using System.Text;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 using UnityEngine.UI;
 
 public class CurrencyDisplay : MonoBehaviour
@@ -17,6 +18,12 @@ public class CurrencyDisplay : MonoBehaviour
 
     private void Start()
     {
+        if (SceneManager.GetActiveScene().name != "_World")
+        {
+            gameObject.SetActive(false);
+            return;
+        }
+
         currencies = World.Current.Wallet.GetCurrencyNames();
     }
 


### PR DESCRIPTION
Atemporary fix for an issue from #1722 where the currency UI would be active in main menu and cause null refrence errors. This is not a permanent fix, and should be noted/fixed when the UI is fixed by @BraedonWooding.