### PR TITLE
[Small] Make Settings accessible to lua

### DIFF
--- a/Assets/Scripts/Models/Functions/LuaFunctions.cs
+++ b/Assets/Scripts/Models/Functions/LuaFunctions.cs
@@ -43,6 +43,7 @@ public class LuaFunctions : IFunctions
         RegisterGlobal(typeof(Scheduler.ScheduledEvent));
         RegisterGlobal(typeof(ProjectPorcupine.Jobs.RequestedItem));
         RegisterGlobal(typeof(DeveloperConsole.DevConsole));
+        RegisterGlobal(typeof(Settings));
     }
 
     public bool HasFunction(string name)

--- a/Assets/Scripts/Models/Settings/Settings.cs
+++ b/Assets/Scripts/Models/Settings/Settings.cs
@@ -110,6 +110,24 @@ public static class Settings
         return false;
     }
 
+    public static string GetSetting(string key)
+    {
+        if (settingsDict == null)
+        {
+            UnityDebugger.Debugger.LogError("Settings", "Settings Dictionary was not loaded!");
+            return null;
+        }
+
+        string value;
+        if (settingsDict.TryGetValue(key, out value))
+        {
+            return value;
+        }
+
+        UnityDebugger.Debugger.LogError("Settings", "Attempted to access a setting that was not loaded from either the SettingsFile or the Template:\t" + key);
+        return null;
+    }
+
     public static void SaveSettings()
     {
         UnityDebugger.Debugger.Log("Settings", "Settings have changed, so there are settings to save!");

--- a/Assets/Scripts/Models/Settings/Settings.cs
+++ b/Assets/Scripts/Models/Settings/Settings.cs
@@ -10,9 +10,11 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using MoonSharp.Interpreter;
 using Newtonsoft.Json;
 using UnityEngine;
 
+[MoonSharpUserData]
 public static class Settings
 {
     private static readonly string DefaultSettingsFilePath = System.IO.Path.Combine(


### PR DESCRIPTION
Previously Settings was inaccessible to Lua, and after being made accessible the standard GetSetting could not be used (some combination of generic function and an `out` parameter did not play well with Lua).

So this makes Settings accessible to Lua, and adds a simple GetSetting that just returns the base string, which lua can handle just fine as a number if that's what it is, and should be able to handle as a boolean (though I haven't tested that side heavily). Though simple this should work quite well for Lua.