### PR TITLE
Remove Expired Domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Make sure that you are using Unity 5.4.2 [Windows](https://unity3d.com/get-unity
 
 ## Community
 
-* [Unoffical Discord Channel ](https://discord.gg/68hkpSA)<discord.projectporcupine.com>
+* [Unoffical Discord Channel ](https://discord.gg/68hkpSA)
 * [Unoffical Subreddit](https://reddit.com/r/ProjectPorcupine)
 
 ## Contact


### PR DESCRIPTION
I Registered the `projectporcupine.com` domain when there was talk for creating a dev blog, it has since expired so this reference to it should be removed.
